### PR TITLE
use incremental subs instead of explicit subs

### DIFF
--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -18,7 +18,7 @@ Create or open an existing Android Studio project and install Couchbase Lite usi
 * Add the following in the `dependencies` section of the
 application's *build.gradle* (the one in the *app* folder).
 +
-[source,groovy,subs="attributes"]
+[source,groovy,subs=attributes+]
 ----
 dependencies {
     implementation 'com.couchbase.lite:couchbase-lite-android:{version}'
@@ -45,7 +45,7 @@ allprojects {
 * Next, add the following in the `dependencies` section of the
 application's *build.gradle* (the one in the *app* folder).
 +
-[source,groovy,subs="attributes"]
+[source,groovy,subs=attributes+]
 ----
 dependencies {
     implementation 'com.couchbase.lite:couchbase-lite-android-ee:{version}'

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -33,14 +33,14 @@ navigator.
 +
 *Couchbase Lite Community Edition*
 +
-[source,ruby,subs="attributes"]
+[source,ruby,subs=attributes+]
 ----
 binary "https://s3.amazonaws.com/cbmobile-carthage/CouchbaseLite-Community.json" ~> {version}
 ----
 +
 *Couchbase Lite Enterprise Edition*
 +
-[source,ruby,subs="attributes"]
+[source,ruby,subs=attributes+]
 ----
 binary "https://s3.amazonaws.com/cbmobile-carthage/CouchbaseLite-Enterprise.json" ~> {version}
 ----
@@ -57,7 +57,7 @@ Cocoapods]
 +
 *Couchbase Lite Community Edition*
 +
-[source,ruby,subs="attributes"]
+[source,ruby,subs=attributes+]
 ----
 target '<your target name>' do
   use_frameworks!
@@ -67,7 +67,7 @@ end
 +
 *Couchbase Lite Enterprise Edition*
 +
-[source,ruby,subs="attributes"]
+[source,ruby,subs=attributes+]
 ----
 target '<your target name>' do
   use_frameworks!


### PR DESCRIPTION
By specifying the attributes substitution, you loose the special characters substitutions, which is crucial for not creating broken HTML.

You almost never want to specify subs explicitly unless you are going to specify all of them. Always start with incremental subs and then get more explicit if necessary.

See https://asciidoctor.org/docs/user-manual/#incremental-substitutions for details.