### PR TITLE
simplify xref syntax

### DIFF
--- a/modules/ROOT/pages/csharp.adoc
+++ b/modules/ROOT/pages/csharp.adoc
@@ -81,7 +81,7 @@ resources to test all of them. They are tested on Ubuntu 16.04, but have
 been shown to work on CentOS, and in theory work on any distro supported
 by .NET Core.
 
-Comparing this to the xref:1.4@couchbase-lite:ROOT:csharp.adoc#supported-versions[supported versions] in 1.x you can see we've traded some lower obsolete versions for new platform support.
+Comparing this to the xref:1.4@couchbase-lite::csharp.adoc#supported-versions[supported versions] in 1.x you can see we've traded some lower obsolete versions for new platform support.
 
 == API References
 
@@ -1038,11 +1038,11 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 === 2.0.3
 
-* Support for Log redaction of sensitive information when xref:#logging[logging is enabled].
+* Support for Log redaction of sensitive information when <<Logging,logging is enabled>>.
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when xref:#logging[logging is enabled].
+* Support for Log redaction of sensitive information when <<Logging,logging is enabled>>.
 
 === 2.0
 

--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -1025,7 +1025,7 @@ The Couchbase Lite API is thread safe except for calls to mutable objects:
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when xref:#logging[logging is enabled].
+* Support for Log redaction of sensitive information when <<Logging,logging is enabled>>.
 
 === 2.0.0
 

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -1094,7 +1094,7 @@ The Couchbase Lite API is thread safe except for calls to mutable objects:
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when xref:#logging[logging is enabled].
+* Support for Log redaction of sensitive information when <<Logging,logging is enabled>>.
 
 === 2.0.0
 

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -1085,7 +1085,7 @@ The Couchbase Lite API is thread safe except for calls to mutable objects:
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when xref:#logging[logging is enabled].
+* Support for Log redaction of sensitive information when <<Logging,logging is enabled>>.
 
 === 2.0.0
 


### PR DESCRIPTION
- drop ROOT module when referring to another component (it's implied)
- use xref shorthand syntax to link within page

When referring to an anchor in the same page, the syntax `<<id,text>>` is preferred. That way, it's easy to spot an internal reference vs a local reference.