### PR TITLE
Fix Swift P2P Sample

### DIFF
--- a/modules/ROOT/examples/swift/SampleCodeTest.swift
+++ b/modules/ROOT/examples/swift/SampleCodeTest.swift
@@ -712,10 +712,10 @@ class SampleCodeTest: CBLTestCase {
 }
 
 /* ----------------------------------------------------------- */
-/* ---------------------  ACTIVE SIDE  ---------------------- */
+/* ---------------------  ACTIVE SIDE  ----------------------- */
+/* ---------------  stubs for documentation  ----------------- */
 /* ----------------------------------------------------------- */
-// Class to configure replicator and initiate a connection with the remote peer.
-class BrowserSessionManager: MessageEndpointDelegate {
+class ActivePeer: MessageEndpointDelegate {
     
     init() throws {
         let id = ""
@@ -800,11 +800,16 @@ class ActivePeerConnection: MessageEndpointConnection {
 
 /* ----------------------------------------------------------- */
 /* ---------------------  PASSIVE SIDE  ---------------------- */
+/* ---------------  stubs for documentation  ----------------- */
 /* ----------------------------------------------------------- */
-
-class AdvertizingSessionManager: NSObject, MCSessionDelegate, MCNearbyServiceAdvertiserDelegate {
+class PassivePeerConnection: NSObject, MessageEndpointConnection {
     
     var messageEndpointListener: MessageEndpointListener?
+    var replicatorConnection: ReplicatorConnection?
+    
+    override init() {
+        super.init()
+    }
     
     func startListener() {
         // # tag::listener[]
@@ -820,41 +825,11 @@ class AdvertizingSessionManager: NSObject, MCSessionDelegate, MCNearbyServiceAdv
         // # end::passive-stop-listener[]
     }
     
-    func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
-        
-    }
-    
-    func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+    func acceptConnection() {
         // # tag::advertizer-accept[]
         let connection = PassivePeerConnection() /* implements MessageEndpointConnection */
         messageEndpointListener?.accept(connection: connection)
         // # end::advertizer-accept[]
-    }
-    
-    func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
-        
-    }
-    
-    func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {
-        
-    }
-    
-    func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {
-        
-    }
-    
-    func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {
-        
-    }
-    
-}
-
-class PassivePeerConnection: NSObject, MessageEndpointConnection {
-    
-    var replicatorConnection: ReplicatorConnection?
-    
-    override init() {
-        super.init()
     }
     
     func disconnect() {

--- a/modules/ROOT/examples/swift/SampleCodeTest.swift
+++ b/modules/ROOT/examples/swift/SampleCodeTest.swift
@@ -719,12 +719,12 @@ class BrowserSessionManager: MessageEndpointDelegate {
     
     init() throws {
         let id = ""
-        let delegate = try! BrowserSessionManager()
+
         // # tag::message-endpoint[]
         let database = try Database(name: "dbname")
         
         // The delegate must implement the `MessageEndpointDelegate` protocol.
-        let messageEndpointTarget = MessageEndpoint(uid: "UID:123", target: id, protocolType: .messageStream, delegate: delegate)
+        let messageEndpointTarget = MessageEndpoint(uid: "UID:123", target: id, protocolType: .messageStream, delegate: self)
         // # end::message-endpoint[]
         
         // # tag::message-endpoint-replicator[]
@@ -771,8 +771,7 @@ class ActivePeerConnection: MessageEndpointConnection {
     // # tag::active-peer-send[]
     /* implementation of MessageEndpointConnection */
     func send(message: Message, completion: @escaping (Bool, MessagingError?) -> Void) {
-        var data = Data()
-        data.append(message.toData())
+        var data = message.toData()
         /* send the data to the other peer */
         /* ... */
         /* call the completion handler once the message is sent */


### PR DESCRIPTION
- Used self as the delegate
- No needs to create a new Data object to append message’s data