### PR TITLE
use tiles layout for samples page

### DIFF
--- a/modules/ROOT/pages/samples.adoc
+++ b/modules/ROOT/pages/samples.adoc
@@ -1,42 +1,44 @@
-== Samples
+= Samples
+:page-role: tiles
+:!sectids:
 
-=== Travel Sample
+== Travel Sample
 
 This application synchronizes documents with Sync Gateway 1.5 and Couchbase Server 5.0. Shared bucket access is enabled to allow web and mobile clients to perform the same operations on the bucket.
 
 http://docs.couchbase.com/tutorials/travel-sample/[Learn more >]
 
-=== ToDo Sample
+== ToDo Sample
 
 ToDo List application built with Couchbase Lite 2.0. Users can authenticate, create lists with tasks. Each task can have optional blob attached to it. Lists can be shared with multiple users.
 
 https://github.com/couchbaselabs/mobile-training-todo/tree/feature/2.0[Learn more >]
 
-=== Swift Playground
+== Swift Playground
 
 This Xcode playground demonstrates many features of the Couchbase Lite 2.0 API. And with the features of Xcode playgrounds, you can run the code sequentially and see results instantly within Xcode.
 
 https://github.com/couchbaselabs/couchbase-lite-ios-api-playground[Learn more >]
 
-=== User Profile Sample: Fundamentals
+== User Profile Sample: Fundamentals
 
 This tutorial will walk you through a very basic example of how you can use Couchbase Lite 2.0 as a standalone, embedded data store within your iOS App. You will learn the fundamentals of Database Operations and Document CRUD Operations.
 
 https://developer.couchbase.com/documentation/mobile/2.0/userprofile_basic.html[Learn more >]
 
-=== User Profile Sample: Prebuilt Database & Query Introduction
+== User Profile Sample: Prebuilt Database & Query Introduction
 
 This tutorial will walk you through a simple app that will demonstrate how to use a pre-built Couchbase Lite database . In addition, we will look at a sample Query using the new Query API to retrieve records from the local database.
 
 https://developer.couchbase.com/documentation/mobile/2.0/userprofile_query.html[Learn more >]
 
-=== User Profile Sample: Data Sync Fundamentals
+== User Profile Sample: Data Sync Fundamentals
 
 This tutorial will introduce you to data sync/replication across Couchbase Lite apps using the Sync Gateway. We will walk through Sync Gateway configuration and the core Sync Function API.
 
 https://developer.couchbase.com/documentation/mobile/2.0/userprofile_sync.html[Learn more >]
 
-=== University Lister – Using Couchbase Lite with Recycler Views
+== University Lister – Using Couchbase Lite with Recycler Views
 
 This tutorial will walk you through a simple example of how you can use Couchbase Lite 2.0 as a standalone, embedded data store within your Android App. Specifically, you will learn the basics of Database CRUD and Query API and specifically how to use Couchbase Lite as a data source for your Recycler Views.
 


### PR DESCRIPTION
- shift all heading levels up by one
- set the page role to tiles, which activates the tiles content layout
- disable sectids to skip toc creation