### PR TITLE
use proper AsciiDoc admonitions (master)

### DIFF
--- a/modules/ROOT/pages/_partials/database-encryption.adoc
+++ b/modules/ROOT/pages/_partials/database-encryption.adoc
@@ -1,7 +1,5 @@
-[IMPORTANT, caption="ENTERPRISE EDITION"]
-====
-Database encryption is an link:https://www.couchbase.com/products/editions[Enterprise Edition] feature.
-====
+.Enterprise Edition only
+IMPORTANT: Database encryption is an link:https://www.couchbase.com/products/editions[Enterprise Edition] feature.
 
 The Couchbase Lite 2.1 release includes the ability to encrypt Couchbase Lite databases. This allows mobile applications to secure the data at rest, when it is being stored on the device. The algorithm used to encrypt the database is 256-bit AES.
 

--- a/modules/ROOT/pages/_partials/p2p-intro.adoc
+++ b/modules/ROOT/pages/_partials/p2p-intro.adoc
@@ -1,7 +1,5 @@
-[IMPORTANT, caption="ENTERPRISE EDITION"]
-====
-Peer-to-peer sync is an link:https://www.couchbase.com/products/editions[Enterprise Edition] feature.
-====
+.Enterprise Edition only
+IMPORTANT: Peer-to-peer sync is an link:https://www.couchbase.com/products/editions[Enterprise Edition] feature.
 
 Peer-to-peer sync allows devices running Couchbase Lite to directly sync data with each other. As part of this, Couchbase Lite is responsible for storing the data and keeping track of the data exchange, but isn't responsible for the data transfer itself. Sending and receiving data must be handled by the platform APIs or a third party framework. In this section, we will refer to these third party frameworks as communication frameworks.
 

--- a/modules/ROOT/pages/csharp.adoc
+++ b/modules/ROOT/pages/csharp.adoc
@@ -339,7 +339,7 @@ include::{examplesdir}/{snippetsdir}[tags=query-index]
 
 If there are multiple expressions, the first one will be the primary key, the second the secondary key, etc.
 
-*Note:* Every index has to be updated whenever a document is updated, so too many indexes can hurt performance.
+NOTE: Every index has to be updated whenever a document is updated, so too many indexes can hurt performance.
 Thus, good performance depends on designing and creating the _right_ indexes to go along with your queries.
 
 === SELECT statement
@@ -677,7 +677,7 @@ This protocol has been designed to be fast, efficient, easier to implement, and 
 
 === Compatibility
 
-⚠️ The new protocol is *incompatible* with CouchDB-based databases.
+WARNING: The new protocol is *incompatible* with CouchDB-based databases.
 And since Couchbase Lite 2 only supports the new protocol, you will need to run a version of Sync Gateway that link:../references/couchbase-lite/release-notes/index.html#compatibility-matrix[supports it].
 
 To use this protocol with Couchbase Lite 2.0, the replication URL should specify WebSockets as the URL scheme (see the "Starting a Replication" section below).

--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -5,7 +5,7 @@
 :source-language: java
 :version: 2.1.0-DB001
 
-⚠ Currently, Couchbase Lite 2.0 is available for Android only.
+WARNING: Currently, Couchbase Lite 2.0 is available for Android only.
 The SDK cannot be used in Java applications.
 
 == Getting Started
@@ -567,7 +567,7 @@ include::{examplesdir}/{snippetsdir}[tags=query-index]
 
 If there are multiple expressions, the first one will be the primary key, the second the secondary key, etc.
 
-*Note:* Every index has to be updated whenever a document is updated, so too many indexes can hurt performance.
+NOTE: Every index has to be updated whenever a document is updated, so too many indexes can hurt performance.
 Thus, good performance depends on designing and creating the _right_ indexes to go along with your queries.
 
 == Full-Text Search
@@ -669,7 +669,7 @@ Couchbase Mobile 2.0 uses a new replication protocol based on WebSockets.
 
 === Compatibility
 
-⚠️ The new protocol is *incompatible* with CouchDB-based databases.
+WARNING: The new protocol is *incompatible* with CouchDB-based databases.
 And since Couchbase Lite 2 only supports the new protocol, you will need to run a version of Sync Gateway that link:../references/couchbase-lite/release-notes/index.html#compatibility-matrix[supports it].
 
 To use this protocol with Couchbase Lite 2.0, the replication URL should specify WebSockets as the URL scheme (see the "Starting a Replication" section below).

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -604,7 +604,7 @@ include::{examplesdir}/{snippetsdir}[tags=query-index]
 
 If there are multiple expressions, the first one will be the primary key, the second the secondary key, etc.
 
-*Note:* Every index has to be updated whenever a document is updated, so too many indexes can hurt performance.
+NOTE: Every index has to be updated whenever a document is updated, so too many indexes can hurt performance.
 Thus, good performance depends on designing and creating the _right_ indexes to go along with your queries.
 
 === Change Events
@@ -728,7 +728,7 @@ Couchbase Mobile 2.0 uses a new replication protocol based on WebSockets.
 
 === Compatibility
 
-⚠️ The new protocol is *incompatible* with CouchDB-based databases.
+WARNING: The new protocol is *incompatible* with CouchDB-based databases.
 And since Couchbase Lite 2 only supports the new protocol, you will need to run a version of Sync Gateway that link:../references/couchbase-lite/release-notes/index.html#compatibility-matrix[supports it].
 
 To use this protocol with Couchbase Lite 2.0, the replication URL should specify WebSockets as the URL scheme (see the "Starting a Replication" section below).

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -628,7 +628,7 @@ include::{examplesdir}/{snippetsdir}[tags=query-index]
 
 If there are multiple expressions, the first one will be the primary key, the second the secondary key, etc.
 
-*Note:* Every index has to be updated whenever a document is updated, so too many indexes can hurt performance.
+NOTE: Every index has to be updated whenever a document is updated, so too many indexes can hurt performance.
 Thus, good performance depends on designing and creating the _right_ indexes to go along with your queries.
 
 === Change Events
@@ -757,7 +757,7 @@ The replicator is designed to send documents from a source to a target database.
 
 === Compatibility
 
-⚠️ The new protocol is *incompatible* with CouchDB-based databases.
+WARNING: The new protocol is *incompatible* with CouchDB-based databases.
 And since Couchbase Lite 2 only supports the new protocol, you will need to run a version of Sync Gateway that link:../references/couchbase-lite/release-notes/index.html#compatibility-matrix[supports it].
 
 To use this protocol with Couchbase Lite 2.0, the replication URL should specify WebSockets as the URL scheme (see the "Starting a Replication" section below).


### PR DESCRIPTION
Note that Antora doesn't currently support a custom caption on an admonition block. A block title should be used instead.