### PR TITLE
refactor source listings (master)

### DIFF
--- a/modules/ROOT/pages/_partials/database-encryption.adoc
+++ b/modules/ROOT/pages/_partials/database-encryption.adoc
@@ -7,16 +7,16 @@ The Couchbase Lite 2.1 release includes the ability to encrypt Couchbase Lite da
 
 To enable encryption, you must set the `DatabaseConfiguration.encryptionKey` property with the encryption key of your choice. The encryption key is then required every time the database is opened.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=database-encryption]
+include::{snippet}[tag=database-encryption]
 ----
 
 Couchbase Lite does not persist the key. It is the application's responsibility to manage the key and store it in a platform specific secure store.
 
 If you're migrating an application from Couchbase Lite 1.x to 2.x, note that the <<database-upgrade,automatic database upgrade>> functionality is *not supported* for encrypted databases. Thus, to upgrade an encrypted 1.x database, you can:
 
-. Disable encryption using the Couchbase Lite 1.x SDK (see xref:1.4@{lang}.adoc#database-encryption[1.x encryption guide])
+. Disable encryption using the Couchbase Lite 1.x SDK (see xref:1.4@{source-language}.adoc#database-encryption[1.x encryption guide])
 . Open the database file with encryption enabled using the Couchbase Lite 2.x SDK (see example above)
 
 An encrypted database can only be opened with the same language SDK that was used to encrypt it in the first place (Swift, C#, Java or Objective-C). For example, if a database is encrypted with the Swift SDK and then exported, it will only be readable with the Swift SDK.

--- a/modules/ROOT/pages/_partials/p2p-connection-teardown.adoc
+++ b/modules/ROOT/pages/_partials/p2p-connection-teardown.adoc
@@ -8,32 +8,32 @@ image::dis-active.png[]
 
 When an active peer disconnects, it must call the `ReplicatorConnection.close` method.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=active-replicator-close]
+include::{snippet}[tag=active-replicator-close]
 ----
 
 Then, Couchbase Lite will call back your code through the `MessageEndpointConnection.close` to give the application a chance to disconnect with the Communication Framework.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=active-peer-close]
+include::{snippet}[tag=active-peer-close]
 ----
 
 ===== Passive Peer
 
 When the passive peer receives the corresponding disconnect notification from the Communication Framework, it must call the `ReplicatorConnection.close` method.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=passive-replicator-close]
+include::{snippet}[tag=passive-replicator-close]
 ----
 
 Then, Couchbase Lite will call back your code through the `MessageEndpointConnection.close` to give the application a chance to disconnect with the Communication Framework.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=passive-peer-close]
+include::{snippet}[tag=passive-peer-close]
 ----
 
 ==== Initiated by Passive Peer
@@ -44,30 +44,30 @@ image::dis-passive.png[]
 
 When the passive disconnects, it must class the `MessageEndpointListener.closeAll` method.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=passive-stop-listener]
+include::{snippet}[tag=passive-stop-listener]
 ----
 
 Then, Couchbase Lite will call back your code through the `MessageEndpointConnection.close` to give the application a chance to disconnect with the Communication Framework.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=passive-peer-close]
+include::{snippet}[tag=passive-peer-close]
 ----
 
 ===== Active Peer
 
 When the active peer receives the corresponding disconnect notification from the Communication Framework, it must call the `ReplicatorConnection.close` method.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=active-replicator-close]
+include::{snippet}[tag=active-replicator-close]
 ----
 
 Then, Couchbase Lite will call back your code through the `MessageEndpointConnection.close` to give the application a chance to disconnect with the Communication Framework.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=active-peer-close]
+include::{snippet}[tag=active-peer-close]
 ----

--- a/modules/ROOT/pages/_partials/p2p-peer-discovery.adoc
+++ b/modules/ROOT/pages/_partials/p2p-peer-discovery.adoc
@@ -10,7 +10,7 @@ As shown on the diagram above, the first step is to initialize the Couchbase Lit
 
 In addition to initializing the database, the passive peer must initialize the `MessageEndpointListener`. The `MessageEndpointListener` acts as as a listener for incoming connections.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=listener]
+include::{snippet}[tag=listener]
 ----

--- a/modules/ROOT/pages/_partials/p2p-push-pull-repl.adoc
+++ b/modules/ROOT/pages/_partials/p2p-push-pull-repl.adoc
@@ -14,9 +14,9 @@ The replication lifecycle is handled through the `MessageEndpointConnection`.
 
 When Couchbase Lite calls back the application code through the `MessageEndpointConnection.send` method, you should send that data to the other peer using the communication framework.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=active-peer-send]
+include::{snippet}[tag=active-peer-send]
 ----
 
 Once the data is sent, call the completion block to acknowledge the completion. You can use the `MessageError` in the completion block to specify if the error is recoverable or not. If it is a recoverable error, the replicator will kick off a retry process which will result to creating a new `MessageEndpointConnection`.
@@ -24,9 +24,9 @@ Once the data is sent, call the completion block to acknowledge the completion. 
 
 When data is received from the passive peer via the Communication Framework, you call the `ReplicatorConnection.receive` method.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=active-peer-receive]
+include::{snippet}[tag=active-peer-receive]
 ----
 
 The replication connection's `receive` method is called which then processes the data in order to persist it to the local database.
@@ -35,16 +35,16 @@ The replication connection's `receive` method is called which then processes the
 
 As in the case of the active peer, the passive peer must implement the `MessageEndpointConnection.send` method to send data to the other peer.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=passive-peer-send]
+include::{snippet}[tag=passive-peer-send]
 ----
 
 Once the data is sent, call the completion block to acknowledge the completion. You can use the `MessageError` in the completion block to specify if the error is recoverable or not. If it is a recoverable error, the replicator will kick off a retry process which will result to creating a new `MessageEndpointConnection`.
 
 When data is received from the active peer via the Communication Framework, you call the `ReplicatorConnection.receive` method.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=passive-peer-receive]
+include::{snippet}[tag=passive-peer-receive]
 ----

--- a/modules/ROOT/pages/_partials/p2p-replication-setup.adoc
+++ b/modules/ROOT/pages/_partials/p2p-replication-setup.adoc
@@ -4,9 +4,9 @@ image::connection.png[]
 
 When the connection is established, the active peer must instantiate a `MessageEndpoint` object corresponding to the remote peer.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=message-endpoint]
+include::{snippet}[tag=message-endpoint]
 ----
 
 The `MessageEndpoint` initializer takes the following arguments.
@@ -22,23 +22,23 @@ Typically, the Communication Framework will handle message assembly and disassem
 
 Then, a `Replicator` is instantiated with the initialized `MessageEndpoint` as the target.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=message-endpoint-replicator]
+include::{snippet}[tag=message-endpoint-replicator]
 ----
 
 Next, Couchbase Lite will call back the application code through the `MessageEndpointDelegate.createConnection` interface method. When the application receives the callback, it must create an instance of `MessageEndpointConnection` and return it.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=create-connection]
+include::{snippet}[tag=create-connection]
 ----
 
 Next, Couchbase Lite will call back the application code through the `MessageEndpointConnection.open` method.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=active-peer-open]
+include::{snippet}[tag=active-peer-open]
 ----
 
 The connection argument is then set on an instance variable. The application code must keep track of every `ReplicatorConnection` associated with every `MessageEndpointConnection`.
@@ -49,18 +49,18 @@ The `MessageError` argument in the completion block is used to specify if the er
 
 The first step after connection establishment on the passive peer is to initialize a new `MessageEndpointConnection` and pass it to the listener. This tells the listener to accept incoming data from that peer.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=advertizer-accept]
+include::{snippet}[tag=advertizer-accept]
 ----
 
 `messageEndpointListener` is the instance of the `MessageEndpointListener` that was created in the first step (xref:#peer-discovery[Peer Discovery])
 
 Couchbase Lite will then call back the application code through the `MessageEndpointConnection.open` method.
 
-[source,{lang}]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=passive-peer-open]
+include::{snippet}[tag=passive-peer-open]
 ----
 
 The `connection` argument is then set on an instance variable. The application code must keep track of every `ReplicatorConnection` associated with every `MessageEndpointConnection`.

--- a/modules/ROOT/pages/csharp.adoc
+++ b/modules/ROOT/pages/csharp.adoc
@@ -1,7 +1,7 @@
 = C#
 :idprefix:
 :idseparator: -
-:snippetsdir: csharp/Program.cs
+:snippet: {examplesdir}/csharp/Program.cs
 :source-language: csharp
 
 == Getting Started
@@ -35,9 +35,9 @@ No more "mono-stdout" at always info level).
 Open *Main.cs* in Visual Studio and copy the following code in the `main` method.
 This snippet demonstrates how to run basic CRUD operations, a simple Query and running bi-directional replications with Sync Gateway.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=getting-started]
+include::{snippet}[tag=getting-started]
 ----
 
 Build and run.
@@ -140,9 +140,9 @@ In 1.x they were stored under the `_attachments` field and in Couchbase Lite 2.0
 The automatic upgrade functionality will not update the internal schema for attachments, so they will still be accessible under the `_attachments` field.
 The following example shows how to retrieve an attachment that was created in a 1.x database with the 2.0 API.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=1x-attachment]
+include::{snippet}[tag=1x-attachment]
 ----
 
 === Replication Compatibility
@@ -161,9 +161,9 @@ This allows for a smoother transition to get all your user base onto a version o
 As the top-level entity in the API, new databases can be created using the `Database` class by passing in a name, configuration, or both.
 The following example creates a database using the `Database(string name)` method.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=new-database]
+include::{snippet}[tag=new-database]
 ----
 
 Just as before, the database will be created in a default location.
@@ -190,9 +190,9 @@ Note that this sandbox gets deleted sometimes when debugging from inside Visual 
 The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
 The following example enables `Verbose` logging for the `Replicator` and `Query` domains.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=logging]
+include::{snippet}[tag=logging]
 ----
 
 === Loading a pre-built database
@@ -204,9 +204,9 @@ To use a prebuilt database, you need to set up the database, build the database 
 After your app launches, it needs to check whether the database exists.
 If the database does not exist, the app should copy it from the app bundle using the http://docs.couchbase.com/mobile/2.0/couchbase-lite-net/db022/html/M_Couchbase_Lite_Database_Copy.htm[`Database.Copy(string, DatabaseConfiguration)`] method as shown below.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=prebuilt-database]
+include::{snippet}[tag=prebuilt-database]
 ----
 
 == Document
@@ -226,9 +226,9 @@ This method can be used to check if a document with a given ID already exists in
 
 The following code example creates a document and persists it to the database.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=initializer]
+include::{snippet}[tag=initializer]
 ----
 
 === Mutability
@@ -236,9 +236,9 @@ include::{examplesdir}/{snippetsdir}[tags=initializer]
 By default, when a document is read from the database it is immutable.
 The `document.toMutable()` method should be used to create an instance of the document which can be updated.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=update-document]
+include::{snippet}[tag=update-document]
 ----
 
 Changes to the document are persisted to the database when the `saveDocument` method is called.
@@ -252,9 +252,9 @@ In addition, as a convenience we offer `DateTimeOffset` accessors.
 Dates are a common data type, but JSON doesn't natively support them, so the convention is to store them as strings in ISO-8601 format.
 The following example sets the date on the `createdAt` property and reads it back using the `document.GetDate(string key)` accessor method.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=date-getter]
+include::{snippet}[tag=date-getter]
 ----
 
 If the property doesn't exist in the document it will return the default value for that getter method (0 for `getInt`, 0.0 for `getFloat` etc.).
@@ -265,9 +265,9 @@ To check whether a given property exists in the document, you should use the htt
 If you're making multiple changes to a database at once, it's faster to group them together.
 The following example persists a few documents in batch.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=batch]
+include::{snippet}[tag=batch]
 ----
 
 At the *local* level this operation is still transactional: no other `Database` instances, including ones managed by the replicator can make changes during the execution of the block, and other instances will not see partial changes.
@@ -280,9 +280,9 @@ The new behavior should be clearer too: a `Blob` is now a normal object that can
 In other words, you just instantiate a `Blob` and set it as the value of a property, and then later you can get the property value, which will be a `Blob` object.
 The following code example adds a blob to the document under the `avatar` property.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=blob]
+include::{snippet}[tag=blob]
 ----
 
 The `Blob` API lets you access the contents as in-memory data (a `Data` object) or as a `InputStream`.
@@ -332,9 +332,9 @@ The following example creates a new index for the `type` and `name` properties.
 }
 ----
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-index]
+include::{snippet}[tag=query-index]
 ----
 
 If there are multiple expressions, the first one will be the primary key, the second the secondary key, etc.
@@ -361,18 +361,18 @@ In the query result, we print the `_id` and `name` properties of each row using 
 }
 ----
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-select-meta]
+include::{snippet}[tag=query-select-meta]
 ----
 
 The `SelectResult.all()` method can be used to query all the properties of a document.
 In this case, the document in the result is embedded in a dictionary where the key is the database name.
 The following snippet shows the same query using `SelectResult.all()` and the result in JSON.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-select-all]
+include::{snippet}[tag=query-select-all]
 ----
 
 [source,json]
@@ -423,9 +423,9 @@ In the example below, we use the `equalTo` operator to query documents where the
 }
 ----
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-where]
+include::{snippet}[tag=query-where]
 ----
 
 ==== Collection Operators
@@ -445,9 +445,9 @@ The following example uses the `Function.arrayContains` to find documents whose 
 }
 ----
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-contains]
+include::{snippet}[tag=query-collection-operator-contains]
 ----
 
 ===== IN Operator
@@ -455,9 +455,9 @@ include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-contains]
 The `IN` operator is useful when you need to explicitly list out the values to test against.
 The following example looks for documents whose `first`, `last` or `username` property value equals "Armani".
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-in]
+include::{snippet}[tag=query-collection-operator-in]
 ----
 
 ==== Like Operator
@@ -468,9 +468,9 @@ It is recommended to use the `like` operator for case insensitive matches and th
 In the example below, we are looking for documents of type `landmark` where the name property exactly matches the string "Royal engineers museum".
 Note that since `like` does a case insensitive match, the following query will return "landmark" type documents with name matching "Royal Engineers Museum", "royal engineers museum", "ROYAL ENGINEERS MUSEUM" and so on.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator]
+include::{snippet}[tag=query-like-operator]
 ----
 
 ==== Wildcard Match
@@ -482,9 +482,9 @@ In the example below, we are looking for documents of `type` "landmark" where th
 The following query will return "landmark" type documents with name matching "Engineers", "engine", "english egg" , "England Eagle" and so on.
 Notice that the matches may span word boundaries.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator-wildcard-match]
+include::{snippet}[tag=query-like-operator-wildcard-match]
 ----
 
 ==== Wildcard Character Match
@@ -494,9 +494,9 @@ We can use `_` sign within a like expression to do a wildcard match against a si
 In the example below, we are looking for documents of type "landmark" where the `name` property matches any string that begins with "eng" followed by exactly 4 wildcard characters and ending in the letter "r".
 The following query will return "landmark" `type` documents with the `name` matching "Engineer", "engineer" and so on.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator-wildcard-character-match]
+include::{snippet}[tag=query-like-operator-wildcard-character-match]
 ----
 
 ==== Regex Operator
@@ -508,9 +508,9 @@ In the example below, we are looking for documents of `type` "landmark" where th
 The following query will return "landmark" type documents with name matching "Engine", "engine" and so on.
 Note that the `\b` specifies that the match must occur on word boundaries.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-regex-operator]
+include::{snippet}[tag=query-regex-operator]
 ----
 
 === JOIN statement
@@ -520,9 +520,9 @@ The JOIN clause enables you to create new input objects by combining two or more
 The following example uses a JOIN clause to find the airline details which have routes that start from RIX.
 This example JOINS the document of type "route" with documents of type "airline" using the document ID (`_id`) on the "airline" document and `airlineid` on the "route" document.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-join]
+include::{snippet}[tag=query-join]
 ----
 
 === GROUP BY statement
@@ -541,9 +541,9 @@ The following example looks for the number of airports at an altitude of 300 ft 
 }
 ----
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-groupby]
+include::{snippet}[tag=query-groupby]
 ----
 
 [source,text]
@@ -560,9 +560,9 @@ There are 123 airports on the America/Denver timezone located in United States a
 It is possible to sort the results of a query based on a given expression result.
 The example below returns documents of type equal to "hotel" sorted in ascending order by the value of the title property.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-orderby]
+include::{snippet}[tag=query-orderby]
 ----
 
 [source,text]
@@ -583,9 +583,9 @@ To run a full-text search (FTS) query, you must have created a full-text index o
 Unlike regular queries, the index is not optional.
 The following example inserts documents and creates an FTS index on the `name` property.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=fts-index]
+include::{snippet}[tag=fts-index]
 ----
 
 Multiple properties to index can be specified in the `IndexBuilder.FullTextIndex(params FullTextIndexItem[] items)` method.
@@ -594,9 +594,9 @@ With the index created, an FTS query on the property that is being indexed can b
 The full-text search criteria is defined as a `FullTextExpression`.
 The left-hand side is the full-text index to use and the right-hand side is the pattern to match.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=fts-query]
+include::{snippet}[tag=fts-query]
 ----
 
 In the example above, the pattern to match is a word, the full-text search query matches all documents that contain the word 'buy' in the value of the `doc.name` property.
@@ -701,7 +701,7 @@ The replication's parameters can be specified through the http://docs.couchbase.
 
 The following example creates a `pull` replication with Sync Gateway.
 
-[source,csharp]
+[source]
 ----
 public class MyClass
 {
@@ -745,9 +745,9 @@ So we don't recommend to rely on that when using the replication or database cha
 As always, when there is a problem with replication, logging is your friend.
 The following example increases the log output for activity related to replication with Sync Gateway.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-logging]
+include::{snippet}[tag=replication-logging]
 ----
 
 === Replication Status
@@ -755,9 +755,9 @@ include::{examplesdir}/{snippetsdir}[tags=replication-logging]
 The `replication.Status.Activity` property can be used to check the status of a replication.
 For example, when the replication is actively transferring data and when it has stopped.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-status]
+include::{snippet}[tag=replication-status]
 ----
 
 The following table lists the different activity levels in the API and the meaning of each one.
@@ -787,9 +787,9 @@ The `IDLE` state is only used in continuous replications.
 If an error occurs, the replication status will be updated with an `Error` which follows the standard HTTP error codes.
 The following example monitors the replication for errors and logs the error code to the console.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-error-handling]
+include::{snippet}[tag=replication-error-handling]
 ----
 
 When a permanent error occurs (i.e `404`: not found, `401`: unauthorized), the replicator (continuous or one-shot) will stop permanently.
@@ -808,18 +808,18 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 include::{partialsdir}/replication-custom-header.adoc[]
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-custom-header]
+include::{snippet}[tag=replication-custom-header]
 ----
 
 === Replication Checkpoint Reset
 
 include::{partialsdir}/replication-checkpoint.adoc[]
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-reset-checkpoint]
+include::{snippet}[tag=replication-reset-checkpoint]
 ----
 
 == Handling Conflicts
@@ -864,9 +864,9 @@ The `cert.pem` and `key.pem` can be used in the Sync Gateway configuration (see 
 
 On the Couchbase Lite side, the replication must be configured with the `cert.cer` file.
 
-[source,csharp]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=certificate-pinning]
+include::{snippet}[tag=certificate-pinning]
 ----
 
 This example loads the certificate from the application sandbox, then converts it to the appropriate type to configure the replication object.

--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -1,7 +1,7 @@
 = Java
 :idprefix:
 :idseparator: -
-:snippetsdir: java/code-snippets/app/src/main/java/com/couchbase/code_snippets/MainActivity.java
+:snippet: {examplesdir}/java/code-snippets/app/src/main/java/com/couchbase/code_snippets/MainActivity.java
 :source-language: java
 :version: 2.1.0-DB001
 
@@ -55,9 +55,9 @@ dependencies {
 Open *MainActivity.java* in Android Studio and copy the following code in the `didStart` method.
 This snippet demonstrates how to run basic CRUD operations, a simple Query and running bi-directional replications with Sync Gateway.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=getting-started]
+include::{snippet}[tag=getting-started]
 ----
 
 Build and run.
@@ -123,9 +123,9 @@ In 1.x they were stored under the `_attachments` field and in Couchbase Lite 2.0
 The automatic upgrade functionality will not update the internal schema for attachments, so they will still be accessible under the `_attachments` field.
 The following example shows how to retrieve an attachment that was created in a 1.x database with the 2.0 API.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=1x-attachment]
+include::{snippet}[tag=1x-attachment]
 ----
 
 === Replication Compatibility
@@ -144,9 +144,9 @@ This allows for a smoother transition to get all your user base onto a version o
 As the top-level entity in the API, new databases can be created using the `Database` class by passing in a name, configuration, or both.
 The following example creates a database using the `Database(String name, DatabaseConfiguration config)` method.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=new-database]
+include::{snippet}[tag=new-database]
 ----
 
 Just as before, the database will be created in a default location.
@@ -182,9 +182,9 @@ $ adb pull /data/data/{APPLICATION_ID}/files/{DATABASE_NAME}.cblite2 .
 The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
 The following example enables `verbose` logging for the `replicator` and `query` domains.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=logging]
+include::{snippet}[tag=logging]
 ----
 
 === Loading a pre-built database
@@ -196,9 +196,9 @@ To use a prebuilt database, you need to set up the database, build the database 
 After your app launches, it needs to check whether the database exists.
 If the database does not exist, the app should copy it from the app bundle using the http://docs.couchbase.com/mobile/2.0/couchbase-lite-java/db022/com/couchbase/lite/Database.html#copy-java.io.File-java.lang.String-com.couchbase.lite.DatabaseConfiguration-[`Database.copy(File path, String name, DatabaseConfiguration config)`] method as shown below.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=prebuilt-database]
+include::{snippet}[tag=prebuilt-database]
 ----
 
 == Document
@@ -218,9 +218,9 @@ This method can be used to check if a document with a given ID already exists in
 
 The following code example creates a document and persists it to the database.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=initializer]
+include::{snippet}[tag=initializer]
 ----
 
 === Mutability
@@ -228,9 +228,9 @@ include::{examplesdir}/{snippetsdir}[tags=initializer]
 By default, when a document is read from the database it is immutable.
 The `document.toMutable()` method should be used to create an instance of the document which can be updated.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=update-document]
+include::{snippet}[tag=update-document]
 ----
 
 Changes to the document are persisted to the database when the `save` method is called.
@@ -244,9 +244,9 @@ In addition, as a convenience we offer `Date` accessors.
 Dates are a common data type, but JSON doesn't natively support them, so the convention is to store them as strings in ISO-8601 format.
 The following example sets the date on the `createdAt` property and reads it back using the `document.getDate(String key)` accessor method.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=date-getter]
+include::{snippet}[tag=date-getter]
 ----
 
 If the property doesn't exist in the document it will return the default value for that getter method (0 for `getInt`, 0.0 for `getFloat` etc.).
@@ -257,9 +257,9 @@ To check whether a given property exists in the document, you should use the htt
 If you're making multiple changes to a database at once, it's faster to group them together.
 The following example persists a few documents in batch.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=batch]
+include::{snippet}[tag=batch]
 ----
 
 At the *local* level this operation is still transactional: no other `Database` instances, including ones managed by the replicator can make changes during the execution of the block, and other instances will not see partial changes.
@@ -272,9 +272,9 @@ The new behavior should be clearer too: a `Blob` is now a normal object that can
 In other words, you just instantiate a `Blob` and set it as the value of a property, and then later you can get the property value, which will be a `Blob` object.
 The following code example adds a blob to the document under the `avatar` property.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=blob]
+include::{snippet}[tag=blob]
 ----
 
 The `Blob` API lets you access the contents as in-memory data (a `Data` object) or as a `InputStream`.
@@ -327,18 +327,18 @@ In the query result, we print the `_id` and `name` properties of each row using 
 }
 ----
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-select-meta]
+include::{snippet}[tag=query-select-meta]
 ----
 
 The `SelectResult.all()` method can be used to query all the properties of a document.
 In this case, the document in the result is embedded in a dictionary where the key is the database name.
 The following snippet shows the same query using `SelectResult.all()` and the result in JSON.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-select-all]
+include::{snippet}[tag=query-select-all]
 ----
 
 [source,json]
@@ -389,9 +389,9 @@ In the example below, we use the `equalTo` operator to query documents where the
 }
 ----
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-where]
+include::{snippet}[tag=query-where]
 ----
 
 ==== Collection Operators
@@ -411,9 +411,9 @@ The following example uses the `Function.arrayContains` to find documents whose 
 }
 ----
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-contains]
+include::{snippet}[tag=query-collection-operator-contains]
 ----
 
 ===== IN Operator
@@ -421,9 +421,9 @@ include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-contains]
 The `IN` operator is useful when you need to explicitly list out the values to test against.
 The following example looks for documents whose `first`, `last` or `username` property value equals "Armani".
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-in]
+include::{snippet}[tag=query-collection-operator-in]
 ----
 
 ==== Like Operator
@@ -434,9 +434,9 @@ It is recommended to use the `like` operator for case insensitive matches and th
 In the example below, we are looking for documents of type `landmark` where the name property exactly matches the string "Royal engineers museum".
 Note that since `like` does a case insensitive match, the following query will return "landmark" type documents with name matching "Royal Engineers Museum", "royal engineers museum", "ROYAL ENGINEERS MUSEUM" and so on.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator]
+include::{snippet}[tag=query-like-operator]
 ----
 
 ==== Wildcard Match
@@ -448,9 +448,9 @@ In the example below, we are looking for documents of `type` "landmark" where th
 The following query will return "landmark" type documents with name matching "Engineers", "engine", "english egg" , "England Eagle" and so on.
 Notice that the matches may span word boundaries.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator-wildcard-match]
+include::{snippet}[tag=query-like-operator-wildcard-match]
 ----
 
 ==== Wildcard Character Match
@@ -460,9 +460,9 @@ We can use `_` sign within a like expression to do a wildcard match against a si
 In the example below, we are looking for documents of type "landmark" where the `name` property matches any string that begins with "eng" followed by exactly 4 wildcard characters and ending in the letter "r".
 The following query will return "landmark" `type` documents with the `name` matching "Engineer", "engineer" and so on.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator-wildcard-character-match]
+include::{snippet}[tag=query-like-operator-wildcard-character-match]
 ----
 
 ==== Regex Operator
@@ -474,9 +474,9 @@ In the example below, we are looking for documents of `type` "landmark" where th
 The following query will return "landmark" type documents with name matching "Engine", "engine" and so on.
 Note that the `\b` specifies that the match must occur on word boundaries.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-regex-operator]
+include::{snippet}[tag=query-regex-operator]
 ----
 
 === JOIN statement
@@ -486,9 +486,9 @@ The JOIN clause enables you to create new input objects by combining two or more
 The following example uses a JOIN clause to find the airline details which have routes that start from RIX.
 This example JOINS the document of type "route" with documents of type "airline" using the document ID (`_id`) on the "airline" document and `airlineid` on the "route" document.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-join]
+include::{snippet}[tag=query-join]
 ----
 
 === GROUP BY statement
@@ -507,9 +507,9 @@ The following example looks for the number of airports at an altitude of 300 ft 
 }
 ----
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-groupby]
+include::{snippet}[tag=query-groupby]
 ----
 
 [source,text]
@@ -526,9 +526,9 @@ There are 123 airports on the America/Denver timezone located in United States a
 It is possible to sort the results of a query based on a given expression result.
 The example below returns documents of type equal to "hotel" sorted in ascending order by the value of the title property.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-orderby]
+include::{snippet}[tag=query-orderby]
 ----
 
 [source,text]
@@ -560,9 +560,9 @@ The following example creates a new index for the `type` and `name` properties.
 }
 ----
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-index]
+include::{snippet}[tag=query-index]
 ----
 
 If there are multiple expressions, the first one will be the primary key, the second the secondary key, etc.
@@ -576,9 +576,9 @@ To run a full-text search (FTS) query, you must have created a full-text index o
 Unlike regular queries, the index is not optional.
 The following example inserts documents and creates an FTS index on the `name` property.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=fts-index]
+include::{snippet}[tag=fts-index]
 ----
 
 Multiple properties to index can be specified in the index creation method.
@@ -587,9 +587,9 @@ With the index created, an FTS query on the property that is being indexed can b
 The full-text search criteria is defined as a `FullTextExpression`.
 The left-hand side is the full-text index to use and the right-hand side is the pattern to match.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=fts-query]
+include::{snippet}[tag=fts-query]
 ----
 
 In the example above, the pattern to match is a word, the full-text search query matches all documents that contain the word 'buy' in the value of the `doc.name` property.
@@ -694,7 +694,7 @@ The replication's parameters can be specified through the http://docs.couchbase.
 
 The following example creates a `pull` replication with Sync Gateway.
 
-[source,java]
+[source]
 ----
 class MyClass {
     Database database;
@@ -740,9 +740,9 @@ So we don't recommend to rely on that when using the replication or database cha
 As always, when there is a problem with replication, logging is your friend.
 The following example increases the log output for activity related to replication with Sync Gateway.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-logging]
+include::{snippet}[tag=replication-logging]
 ----
 
 === Replication Status
@@ -750,9 +750,9 @@ include::{examplesdir}/{snippetsdir}[tags=replication-logging]
 The `replication.Status.Activity` property can be used to check the status of a replication.
 For example, when the replication is actively transferring data and when it has stopped.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-status]
+include::{snippet}[tag=replication-status]
 ----
 
 The following table lists the different activity levels in the API and the meaning of each one.
@@ -782,9 +782,9 @@ The `IDLE` state is only used in continuous replications.
 If an error occurs, the replication status will be updated with an `Error` which follows the standard HTTP error codes.
 The following example monitors the replication for errors and logs the error code to the console.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-error-handling]
+include::{snippet}[tag=replication-error-handling]
 ----
 
 When a permanent error occurs (i.e `404`: not found, `401`: unauthorized), the replicator (continuous or one-shot) will stop permanently.
@@ -803,18 +803,18 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 include::{partialsdir}/replication-custom-header.adoc[]
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-custom-header]
+include::{snippet}[tag=replication-custom-header]
 ----
 
 === Replication Checkpoint Reset
 
 include::{partialsdir}/replication-checkpoint.adoc[]
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-reset-checkpoint]
+include::{snippet}[tag=replication-reset-checkpoint]
 ----
 
 == Handling Conflicts
@@ -860,9 +860,9 @@ The `cert.pem` and `key.pem` can be used in the Sync Gateway configuration (see 
 
 On the Couchbase Lite side, the replication must be configured with the `cert.cer` file.
 
-[source,java]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=certificate-pinning]
+include::{snippet}[tag=certificate-pinning]
 ----
 
 This example loads the certificate from the application sandbox, then converts it to the appropriate type to configure the replication object.

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -1,8 +1,8 @@
 = Objective-C
 :idprefix:
 :idseparator: -
-:snippetsdir: objc/SampleCodeTest.m
-:source-language: objc
+:snippet: {examplesdir}/objc/SampleCodeTest.m
+:source-language: objectivec
 :version: 2.1.0-DB001
 
 == Getting Started
@@ -18,7 +18,7 @@ Create or open an existing Xcode project and install Couchbase Lite using one of
 * Click on Project > General > Embedded Binary and add *CouchbaseLite.framework* to this section.
 * Import the framework and start using it in your project.
 +
-[source,objectivec]
+[source]
 ----
 #include <CouchbaseLite/CouchbaseLite.h>
 ...
@@ -84,9 +84,9 @@ pod install
 Open *ViewController.m* in Xcode and copy the following code in the `viewDidLoad` method.
 This snippet demonstrates how to run basic CRUD operations, a simple Query and running bi-directional replications with Sync Gateway.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=getting-started]
+include::{snippet}[tag=getting-started]
 ----
 
 Build and run.
@@ -164,9 +164,9 @@ In 1.x they were stored under the `_attachments` field and in Couchbase Lite 2.0
 The automatic upgrade functionality will not update the internal schema for attachments, so they will still be accessible under the `_attachments` field.
 The following example shows how to retrieve an attachment that was created in a 1.x database with the 2.0 API.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=1x-attachment]
+include::{snippet}[tag=1x-attachment]
 ----
 
 === Replication Compatibility
@@ -185,9 +185,9 @@ This allows for a smoother transition to get all your user base onto a version o
 As the top-level entity in the API, new databases can be created using the `Database` class by passing in a name, configuration, or both.
 The following example creates a database using the `Database(name: String)` method.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=new-database]
+include::{snippet}[tag=new-database]
 ----
 
 Just as before, the database will be created in a default location.
@@ -215,9 +215,9 @@ Instructions for various commands are available in *Tools/README.md*.
 The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
 The following example enables `verbose` logging for the `replicator` and `query` domains.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=logging]
+include::{snippet}[tag=logging]
 ----
 
 === Loading a pre-built database
@@ -229,9 +229,9 @@ To use a prebuilt database, you need to set up the database, build the database 
 After your app launches, it needs to check whether the database exists.
 If the database does not exist, the app should copy it from the app bundle using the http://docs.couchbase.com/mobile/2.0/couchbase-lite-objc/db022/Classes/CBLDatabase.html#/c:objc(cs)CBLDatabase(cm)copyFromPath:toDatabase:withConfig:error:[`[CBLDatabase copyFromPath:toDatabase:withConfig:error:]`] method as shown below.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=prebuilt-database]
+include::{snippet}[tag=prebuilt-database]
 ----
 
 == Document
@@ -251,9 +251,9 @@ This method can be used to check if a document with a given ID already exists in
 
 The following code example creates a document and persists it to the database.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=initializer]
+include::{snippet}[tag=initializer]
 ----
 
 === Mutability
@@ -261,9 +261,9 @@ include::{examplesdir}/{snippetsdir}[tags=initializer]
 By default, when a document is read from the database it is immutable.
 The `document.toMutable()` method should be used to create an instance of the document which can be updated.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=update-document]
+include::{snippet}[tag=update-document]
 ----
 
 Changes to the document are persisted to the database when the `saveDocument` method is called.
@@ -277,9 +277,9 @@ In addition, as a convenience we offer `Date` accessors.
 Dates are a common data type, but JSON doesn't natively support them, so the convention is to store them as strings in ISO-8601 format.
 The following example sets the date on the `createdAt` property and reads it back using the `document.date(forKey: String)` accessor method.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=date-getter]
+include::{snippet}[tag=date-getter]
 ----
 
 If the property doesn't exist in the document it will return the default value for that  getter method (0 for `getInt`, 0.0 for `getFloat` etc.).
@@ -291,9 +291,9 @@ If you need to determine whether a given property exists in the document, you sh
 If you're making multiple changes to a database at once, it's faster to group them together.
 The following example persists a few documents in batch.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=batch]
+include::{snippet}[tag=batch]
 ----
 
 At the *local* level this operation is still transactional: no other `Database` instances, including ones managed by the replicator can make changes during the execution of the block, and other instances will not see partial changes.
@@ -306,9 +306,9 @@ The new behavior should be clearer too: a `Blob` is now a normal object that can
 In other words, you just instantiate a `Blob` and set it as the value of a property, and then later you can get the property value, which will be a `Blob` object.
 The following code example adds a blob to the document under the `avatar` property.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=blob]
+include::{snippet}[tag=blob]
 ----
 
 The `Blob` API lets you access the contents as in-memory data (a `Data` object) or as a `InputStream`.
@@ -365,18 +365,18 @@ In the query result, we print the `_id` and `name` properties of each row using 
 }
 ----
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-select-meta]
+include::{snippet}[tag=query-select-meta]
 ----
 
 The `SelectResult.all()` method can be used to query all the properties of a document.
 In this case, the document in the result is embedded in a dictionary where the key is the database name.
 The following snippet shows the same query using `SelectResult.all()` and the result in JSON.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-select-all]
+include::{snippet}[tag=query-select-all]
 ----
 
 [source,json]
@@ -427,9 +427,9 @@ In the example below, we use the `equalTo` operator to query documents where the
 }
 ----
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-where]
+include::{snippet}[tag=query-where]
 ----
 
 ==== Collection Operators
@@ -449,9 +449,9 @@ The following example uses the `Function.arrayContains` to find documents whose 
 }
 ----
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-contains]
+include::{snippet}[tag=query-collection-operator-contains]
 ----
 
 ===== IN Operator
@@ -459,9 +459,9 @@ include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-contains]
 The `IN` operator is useful when you need to explicitly list out the values to test against.
 The following example looks for documents whose `first`, `last` or `username` property value equals "Armani".
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-in]
+include::{snippet}[tag=query-collection-operator-in]
 ----
 
 ==== Like Operator
@@ -472,9 +472,9 @@ It is recommended to use the `like` operator for case insensitive matches and th
 In the example below, we are looking for documents of type `landmark` where the name property exactly matches the string "Royal engineers museum".
 Note that since `like` does a case insensitive match, the following query will return "landmark" type documents with name matching "Royal Engineers Museum", "royal engineers museum", "ROYAL ENGINEERS MUSEUM" and so on.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator]
+include::{snippet}[tag=query-like-operator]
 ----
 
 ==== Wildcard Match
@@ -486,9 +486,9 @@ In the example below, we are looking for documents of `type` "landmark" where th
 The following query will return "landmark" type documents with name matching "Engineers", "engine", "english egg" , "England Eagle" and so on.
 Notice that the matches may span word boundaries.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator-wildcard-match]
+include::{snippet}[tag=query-like-operator-wildcard-match]
 ----
 
 ==== Wildcard Character Match
@@ -498,9 +498,9 @@ We can use `_` sign within a like expression to do a wildcard match against a si
 In the example below, we are looking for documents of type "landmark" where the `name` property matches any string that begins with "eng" followed by exactly 4 wildcard characters and ending in the letter "r".
 The following query will return "landmark" `type` documents with the `name` matching "Engineer", "engineer" and so on.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator-wildcard-character-match]
+include::{snippet}[tag=query-like-operator-wildcard-character-match]
 ----
 
 ==== Regex Operator
@@ -512,9 +512,9 @@ In the example below, we are looking for documents of `type` "landmark" where th
 The following query will return "landmark" type documents with name matching "Engine", "engine" and so on.
 Note that the `\b` specifies that the match must occur on word boundaries.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-regex-operator]
+include::{snippet}[tag=query-regex-operator]
 ----
 
 === JOIN statement
@@ -524,9 +524,9 @@ The JOIN clause enables you to create new input objects by combining two or more
 The following example uses a JOIN clause to find the airline details which have routes that start from RIX.
 This example JOINS the document of type "route" with documents of type "airline" using the document ID (`_id`) on the "airline" document and `airlineid` on the "route" document.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-join]
+include::{snippet}[tag=query-join]
 ----
 
 === GROUP BY statement
@@ -545,9 +545,9 @@ The following example looks for the number of airports at an altitude of 300 ft 
 }
 ----
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-groupby]
+include::{snippet}[tag=query-groupby]
 ----
 
 [source,text]
@@ -564,9 +564,9 @@ There are 123 airports on the America/Denver timezone located in United States a
 It is possible to sort the results of a query based on a given expression result.
 The example below returns documents of type equal to "hotel" sorted in ascending order by the value of the title property.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-orderby]
+include::{snippet}[tag=query-orderby]
 ----
 
 [source,text]
@@ -597,9 +597,9 @@ The following example creates a new index for the `type` and `name` properties.
 }
 ----
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-index]
+include::{snippet}[tag=query-index]
 ----
 
 If there are multiple expressions, the first one will be the primary key, the second the secondary key, etc.
@@ -615,18 +615,18 @@ A live query is a great way to build reactive user interfaces, especially table/
 For example, as the replicator runs and pulls new data from the server, a live query-driven UI will automatically update to show the data without the user having to manually refresh.
 This helps your app feel quick and responsive.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=live-query]
+include::{snippet}[tag=live-query]
 ----
 
 The live query starts immediately and changes are posted asynchronously.
 
 The following example stops the live query with the token from the previous example.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=stop-live-query]
+include::{snippet}[tag=stop-live-query]
 ----
 
 == Full-Text Search
@@ -635,9 +635,9 @@ To run a full-text search (FTS) query, you must have created a full-text index o
 Unlike regular queries, the index is not optional.
 The following example inserts documents and creates an FTS index on the `name` property.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=fts-index]
+include::{snippet}[tag=fts-index]
 ----
 
 Multiple properties to index can be specified in the `Index.fullTextIndex(withItems: [FullTextIndexItem])` method.
@@ -646,9 +646,9 @@ With the index created, an FTS query on the property that is being indexed can b
 The full-text search criteria is defined as a `FullTextExpression`.
 The left-hand side is the full-text index to use and the right-hand side is the pattern to match.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=fts-query]
+include::{snippet}[tag=fts-query]
 ----
 
 In the example above, the pattern to match is a word, the full-text search query matches all documents that contain the word 'buy' in the value of the `doc.name` property.
@@ -753,7 +753,7 @@ The replication's parameters can be specified through the http://docs.couchbase.
 
 The following example creates a `pull` replication with Sync Gateway.
 
-[source,objectivec]
+[source]
 ----
 @interface MyClass : NSObject
 @property (nonatomic) CBLDatabase *database;
@@ -798,9 +798,9 @@ So we don't recommend to rely on that when using the replication or database cha
 As always, when there is a problem with replication, logging is your friend.
 The following example increases the log output for activity related to replication with Sync Gateway.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-logging]
+include::{snippet}[tag=replication-logging]
 ----
 
 === Replication Status
@@ -808,9 +808,9 @@ include::{examplesdir}/{snippetsdir}[tags=replication-logging]
 The `replication.status.activity` property can be used to check the status of a replication.
 For example, when the replication is actively transferring data and when it has stopped.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-status]
+include::{snippet}[tag=replication-status]
 ----
 
 The following table lists the different activity levels in the API and the meaning of each one.
@@ -840,9 +840,9 @@ The `IDLE` state is only used in continuous replications.
 If an error occurs, the replication status will be updated with an `Error` which follows the standard HTTP error codes.
 The following example monitors the replication for errors and logs the error code to the console.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-error-handling]
+include::{snippet}[tag=replication-error-handling]
 ----
 
 When a permanent error occurs (i.e `404`: not found, `401`: unauthorized), the replicator (continuous or one-shot) will stop permanently.
@@ -861,18 +861,18 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 include::{partialsdir}/replication-custom-header.adoc[]
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-custom-header]
+include::{snippet}[tag=replication-custom-header]
 ----
 
 === Replication Checkpoint Reset
 
 include::{partialsdir}/replication-checkpoint.adoc[]
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-reset-checkpoint]
+include::{snippet}[tag=replication-reset-checkpoint]
 ----
 
 == Handling Conflicts
@@ -904,9 +904,9 @@ It allows a Couchbase Lite replicator to store data on secondary storage.
 It would be especially useful in scenarios where a user's device is damaged and the data needs to be moved to a different device.
 Note that the code below won't compile if you're running the *Community Edition* of Couchbase Lite.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=database-replica]
+include::{snippet}[tag=database-replica]
 ----
 
 == Certificate Pinning
@@ -923,9 +923,9 @@ The `cert.pem` and `key.pem` can be used in the Sync Gateway configuration (see 
 
 On the Couchbase Lite side, the replication must be configured with the `cert.cer` file.
 
-[source,objectivec]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=certificate-pinning]
+include::{snippet}[tag=certificate-pinning]
 ----
 
 This example loads the certificate from the application sandbox, then converts it to the appropriate type to configure the replication object.

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -1,7 +1,7 @@
 = Swift
 :idprefix:
 :idseparator: -
-:snippetsdir: swift/SampleCodeTest.swift
+:snippet: {examplesdir}/swift/SampleCodeTest.swift
 :source-language: swift
 :version: 2.1.0-DB001
 
@@ -18,7 +18,7 @@ Create or open an existing Xcode project and install Couchbase Lite using one of
 * Click on *Project > General > Embedded Binary* and add *CouchbaseLiteSwift.framework* to this section.
 * Import the framework and start using it in your project.
 +
-[source,swift]
+[source]
 ----
 import CouchbaseLiteSwift
 ...
@@ -31,14 +31,14 @@ import CouchbaseLiteSwift
 +
 *Couchbase Lite Community Edition*
 +
-[source,ruby,subs="attributes"]
+[source,ruby,subs=attributes+]
 ----
 binary "https://s3.amazonaws.com/cbmobile-carthage/CouchbaseLite-Community.json" ~> {version}
 ----
 +
 *Couchbase Lite Enterprise Edition*
 +
-[source,ruby,subs="attributes"]
+[source,ruby,subs=attributes+]
 ----
 binary "https://s3.amazonaws.com/cbmobile-carthage/CouchbaseLite-Enterprise.json" ~> {version}
 ----
@@ -55,7 +55,7 @@ Cocoapods]
 +
 *Couchbase Lite Community Edition*
 +
-[source,ruby,subs="attributes"]
+[source,ruby,subs=attributes+]
 ----
 target 'Example' do
   use_frameworks!
@@ -65,7 +65,7 @@ end
 +
 *Couchbase Lite Enterprise Edition*
 +
-[source,ruby,subs="attributes"]
+[source,ruby,subs=attributes+]
 ----
 target 'Example' do
   use_frameworks!
@@ -86,9 +86,9 @@ pod install
 Open *ViewController.swift* in Xcode and copy the following code in the `viewDidLoad` method.
 This snippet demonstrates how to run basic CRUD operations, a simple Query and running bi-directional replications with Sync Gateway.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=getting-started]
+include::{snippet}[tag=getting-started]
 ----
 
 Build and run.
@@ -169,9 +169,9 @@ In 1.x they were stored under the `_attachments` field and in Couchbase Lite 2.0
 The automatic upgrade functionality will not update the internal schema for attachments, so they will still be accessible under the `_attachments` field.
 The following example shows how to retrieve an attachment that was created in a 1.x database with the 2.0 API.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=1x-attachment]
+include::{snippet}[tag=1x-attachment]
 ----
 
 === Replication Compatibility
@@ -190,9 +190,9 @@ This allows for a smoother transition to get all your user base onto a version o
 As the top-level entity in the API, new databases can be created using the `Database` class by passing in a name, configuration, or both.
 The following example creates a database using the `Database(name: String)` method.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=new-database]
+include::{snippet}[tag=new-database]
 ----
 
 Just as before, the database will be created in a default location.
@@ -220,9 +220,9 @@ Instructions for various commands are available in *Tools/README.md*.
 The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
 The following example enables `verbose` logging for the `replicator` and `query` domains.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=logging]
+include::{snippet}[tag=logging]
 ----
 
 === Loading a pre-built database
@@ -234,9 +234,9 @@ To use a prebuilt database, you need to set up the database, build the database 
 After your app launches, it needs to check whether the database exists.
 If the database does not exist, the app should copy it from the app bundle using the http://docs.couchbase.com/mobile/2.0/couchbase-lite-swift/db022/Classes/Database.html#/s:18CouchbaseLiteSwift8DatabaseC4copyySS8fromPath_SS02toD0AA0D13ConfigurationVSg10withConfigtKFZ[`Database.copy(fromPath:toDatabase:withConfig:)`] method as shown below.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=prebuilt-database]
+include::{snippet}[tag=prebuilt-database]
 ----
 
 == Document
@@ -256,9 +256,9 @@ This method can be used to check if a document with a given ID already exists in
 
 The following code example creates a document and persists it to the database.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=initializer]
+include::{snippet}[tag=initializer]
 ----
 
 === Mutability
@@ -266,9 +266,9 @@ include::{examplesdir}/{snippetsdir}[tags=initializer]
 By default, when a document is read from the database it is immutable.
 The `document.toMutable()` method should be used to create an instance of the document which can be updated.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=update-document]
+include::{snippet}[tag=update-document]
 ----
 
 Changes to the document are persisted to the database when the `saveDocument` method is called.
@@ -282,9 +282,9 @@ In addition, as a convenience we offer `Date` accessors.
 Dates are a common data type, but JSON doesn't natively support them, so the convention is to store them as strings in ISO-8601 format.
 The following example sets the date on the `createdAt` property and reads it back using the `document.date(forKey: String)` accessor method.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=date-getter]
+include::{snippet}[tag=date-getter]
 ----
 
 If the property doesn't exist in the document it will return the default value for that  getter method (0 for `getInt`, 0.0 for `getFloat` etc.).
@@ -294,9 +294,9 @@ If you need to determine whether a given property exists in the document, you sh
 A `Document` can be converted to a plain dictionary type.
 That's often useful to pass the document contents as a plain object to another method.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=to-dictionary]
+include::{snippet}[tag=to-dictionary]
 ----
 
 === Batch operations
@@ -304,9 +304,9 @@ include::{examplesdir}/{snippetsdir}[tags=to-dictionary]
 If you're making multiple changes to a database at once, it's faster to group them together.
 The following example persists a few documents in batch.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=batch]
+include::{snippet}[tag=batch]
 ----
 
 At the *local* level this operation is still transactional: no other `Database` instances, including ones managed by the replicator can make changes during the execution of the block, and other instances will not see partial changes.
@@ -317,9 +317,9 @@ But Couchbase Mobile is a distributed system, and due to the way replication wor
 It's also possible to register for document changes.
 The following example registers for changes to the document with ID `user.john` and prints the `verified_account` property.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=document-listener]
+include::{snippet}[tag=document-listener]
 ----
 
 == Blobs
@@ -329,9 +329,9 @@ The new behavior should be clearer too: a `Blob` is now a normal object that can
 In other words, you just instantiate a `Blob` and set it as the value of a property, and then later you can get the property value, which will be a `Blob` object.
 The following code example adds a blob to the document under the `avatar` property.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=blob]
+include::{snippet}[tag=blob]
 ----
 
 The `Blob` API lets you access the contents as in-memory data (a `Data` object) or as a `InputStream`.
@@ -388,18 +388,18 @@ In the query result, we print the `_id` and `name` properties of each row using 
 }
 ----
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-select-meta]
+include::{snippet}[tag=query-select-meta]
 ----
 
 The `SelectResult.all()` method can be used to query all the properties of a document.
 In this case, the document in the result is embedded in a dictionary where the key is the database name.
 The following snippet shows the same query using `SelectResult.all()` and the result in JSON.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-select-all]
+include::{snippet}[tag=query-select-all]
 ----
 
 [source,json]
@@ -450,9 +450,9 @@ In the example below, we use the `equalTo` operator to query documents where the
 }
 ----
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-where]
+include::{snippet}[tag=query-where]
 ----
 
 ==== Collection Operators
@@ -472,9 +472,9 @@ The following example uses the `Function.arrayContains` to find documents whose 
 }
 ----
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-contains]
+include::{snippet}[tag=query-collection-operator-contains]
 ----
 
 ===== IN Operator
@@ -482,9 +482,9 @@ include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-contains]
 The `IN` operator is useful when you need to explicitly list out the values to test against.
 The following example looks for documents whose `first`, `last` or `username` property value equals "Armani".
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-collection-operator-in]
+include::{snippet}[tag=query-collection-operator-in]
 ----
 
 ==== Like Operator
@@ -495,9 +495,9 @@ Use the `like` operator for case insensitive matches and the `regex` operator (s
 In the example below, we are looking for documents of type `landmark` where the name property exactly matches the string "Royal engineers museum".
 Note that since `like` does a case insensitive match, the following query will return "landmark" type documents with name matching "Royal Engineers Museum", "royal engineers museum", "ROYAL ENGINEERS MUSEUM" and so on.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator]
+include::{snippet}[tag=query-like-operator]
 ----
 
 ==== Wildcard Match
@@ -509,9 +509,9 @@ In the example below, we are looking for documents of `type` "landmark" where th
 The following query will return "landmark" type documents with name matching "Engineers", "engine", "english egg" , "England Eagle" and so on.
 Notice that the matches may span word boundaries.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator-wildcard-match]
+include::{snippet}[tag=query-like-operator-wildcard-match]
 ----
 
 ==== Wildcard Character Match
@@ -521,9 +521,9 @@ We can use `_` sign within a like expression to do a wildcard match against a si
 In the example below, we are looking for documents of type "landmark" where the `name` property matches any string that begins with "eng" followed by exactly 4 wildcard characters and ending in the letter "r".
 The following query will return "landmark" `type` documents with the `name` matching "Engineer", "engineer" and so on.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-like-operator-wildcard-character-match]
+include::{snippet}[tag=query-like-operator-wildcard-character-match]
 ----
 
 ==== Regex Operator
@@ -535,9 +535,9 @@ In the example below, we are looking for documents of `type` "landmark" where th
 The following query will return "landmark" type documents with name matching "Engine", "engine" and so on.
 Note that the `\b` specifies that the match must occur on word boundaries.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-regex-operator]
+include::{snippet}[tag=query-regex-operator]
 ----
 
 === JOIN statement
@@ -547,9 +547,9 @@ The JOIN clause enables you to create new input objects by combining two or more
 The following example uses a JOIN clause to find the airline details which have routes that start from RIX.
 This example JOINS the document of type "route" with documents of type "airline" using the document ID (`_id`) on the "airline" document and `airlineid` on the "route" document.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-join]
+include::{snippet}[tag=query-join]
 ----
 
 === GROUP BY statement
@@ -568,9 +568,9 @@ The following example looks for the number of airports at an altitude of 300 ft 
 }
 ----
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-groupby]
+include::{snippet}[tag=query-groupby]
 ----
 
 [source,text]
@@ -587,9 +587,9 @@ There are 123 airports on the America/Denver timezone located in United States a
 It is possible to sort the results of a query based on a given expression result.
 The example below returns documents of type equal to "hotel" sorted in ascending order by the value of the title property.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-orderby]
+include::{snippet}[tag=query-orderby]
 ----
 
 [source,text]
@@ -621,9 +621,9 @@ The following example creates a new index for the `type` and `name` properties.
 }
 ----
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=query-index]
+include::{snippet}[tag=query-index]
 ----
 
 If there are multiple expressions, the first one will be the primary key, the second the secondary key, etc.
@@ -639,17 +639,17 @@ A live query is a great way to build reactive user interfaces, especially table/
 For example, as the replicator runs and pulls new data from the server, a live query-driven UI will automatically update to show the data without the user having to manually refresh.
 This helps your app feel quick and responsive.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=live-query]
+include::{snippet}[tag=live-query]
 ----
 <1> The live query starts immediately and changes are posted asynchronously.
 
 The following example stops the live query with the token from the previous example.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=stop-live-query]
+include::{snippet}[tag=stop-live-query]
 ----
 
 == Full-Text Search
@@ -658,9 +658,9 @@ To run a full-text search (FTS) query, you must have created a full-text index o
 Unlike queries, the index is not optional.
 The following example inserts documents and creates an FTS index on the `name` property.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=fts-index]
+include::{snippet}[tag=fts-index]
 ----
 
 Multiple properties to index can be specified in the `Index.fullTextIndex(withItems: [FullTextIndexItem])` method.
@@ -669,9 +669,9 @@ With the index created, an FTS query on the property that is being indexed can b
 The full-text search criteria is defined as a `FullTextExpression`.
 The left-hand side is the full-text index to use and the right-hand side is the pattern to match.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=fts-query]
+include::{snippet}[tag=fts-query]
 ----
 
 In the example above, the pattern to match is a word, the full-text search query matches all documents that contain the word 'buy' in the value of the `doc.name` property.
@@ -782,7 +782,7 @@ The replication's parameters can be specified through the http://docs.couchbase.
 
 The following example creates a `pull` replication with Sync Gateway.
 
-[source,swift]
+[source]
 ----
 class MyClass {
     var database: Database?
@@ -822,9 +822,9 @@ So we don't recommend to rely on that when using the replication or database cha
 As always, when there is a problem with replication, logging is your friend.
 The following example increases the log output for activity related to replication with Sync Gateway.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-logging]
+include::{snippet}[tag=replication-logging]
 ----
 
 === Authentication
@@ -857,9 +857,9 @@ Under the hood, the replicator will send the credentials in the first request to
 This is the recommended way of using basic authentication.
 The following example initiates a one-shot replication as the user *john* with the password *pass*.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=basic-authentication]
+include::{snippet}[tag=basic-authentication]
 ----
 
 ==== Session Authentication
@@ -869,9 +869,9 @@ A user session must first be created through the link:../references/sync-gateway
 The HTTP response contains a session ID which can then be used to authenticate as the user it was created for.
 The following example initiates a one-shot replication with the session ID that is returned from the `POST /{db}/_session` endpoint.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=session-authentication]
+include::{snippet}[tag=session-authentication]
 ----
 
 === Replication Status
@@ -879,9 +879,9 @@ include::{examplesdir}/{snippetsdir}[tags=session-authentication]
 The `replication.status.activity` property can be used to check the status of a replication.
 For example, when the replication is actively transferring data and when it has stopped.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-status]
+include::{snippet}[tag=replication-status]
 ----
 
 The following table lists the different activity levels in the API and the meaning of each one.
@@ -911,9 +911,9 @@ The `IDLE` state is only used in continuous replications.
 If an error occurs, the replication status will be updated with an `Error` which follows the standard HTTP error codes.
 The following example monitors the replication for errors and logs the error code to the console.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-error-handling]
+include::{snippet}[tag=replication-error-handling]
 ----
 
 When a permanent error occurs (i.e `404`: not found, `401`: unauthorized), the replicator (continuous or one-shot) will stop permanently.
@@ -932,18 +932,18 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 include::{partialsdir}/replication-custom-header.adoc[]
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-custom-header]
+include::{snippet}[tag=replication-custom-header]
 ----
 
 === Replication Checkpoint Reset
 
 include::{partialsdir}/replication-checkpoint.adoc[]
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=replication-reset-checkpoint]
+include::{snippet}[tag=replication-reset-checkpoint]
 ----
 
 == Handling Conflicts
@@ -975,9 +975,9 @@ It allows a Couchbase Lite replicator to store data on secondary storage.
 It would be especially useful in scenarios where a user's device is damaged and the data needs to be moved to a different device.
 Note that the code below won't compile if you're running the *Community Edition* of Couchbase Lite.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=database-replica]
+include::{snippet}[tag=database-replica]
 ----
 
 == Certificate Pinning
@@ -994,9 +994,9 @@ The `cert.pem` and `key.pem` can be used in the Sync Gateway configuration (see 
 
 On the Couchbase Lite side, the replication must be configured with the `cert.cer` file.
 
-[source,swift]
+[source]
 ----
-include::{examplesdir}/{snippetsdir}[tags=certificate-pinning]
+include::{snippet}[tag=certificate-pinning]
 ----
 
 This example loads the certificate from the application sandbox, then converts it to the appropriate type to configure the replication object.


### PR DESCRIPTION
- consolidate include target to {snippet}
- drop redundant language declaration on source block
- rename tags attribute to tag
- use {source-language} instead of {lang}
- rename objc to objectivec