### PR TITLE
refactor Antora nav (release/2.0)

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -3,4 +3,4 @@ title: Couchbase Lite
 version: '2.0'
 start_page: ROOT:index.adoc
 nav:
-- modules/nav.adoc
+- modules/ROOT/nav.adoc

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,0 +1,7 @@
+* xref:index.adoc[What's New]
+* xref:swift.adoc[Swift]
+* xref:java.adoc[Java]
+* xref:csharp.adoc[C#]
+* xref:objc.adoc[Objective-C]
+* xref:samples.adoc[Samples]
+* xref:compatibility-matrix.adoc[Compatibility Matrix]

--- a/modules/ROOT/pages/_attributes.adoc
+++ b/modules/ROOT/pages/_attributes.adoc
@@ -1,2 +1,0 @@
-:moduledir: ..
-include::{moduledir}/_attributes.adoc[]

--- a/modules/ROOT/pages/_partials/verify-replication.adoc
+++ b/modules/ROOT/pages/_partials/verify-replication.adoc
@@ -1,6 +1,6 @@
 To verify that documents have been replicated, you can:
 
-* Monitor the Sync Gateway sequence number returned by the database endpoint (xref:sync-gateway:ROOT:rest-api.adoc#/database/get\__db__[`GET /{db}/`]).
+* Monitor the Sync Gateway sequence number returned by the database endpoint (xref:sync-gateway::rest-api.adoc#/database/get\__db__[`GET /{db}/`]).
 The sequence number increments for every change that happens on the Sync Gateway database.
-* Query a document by ID on the Sync Gateway REST API (xref:sync-gateway:ROOT:rest-api.adoc#/document/get\__db___doc_[`GET /{db}/{id}`]).
+* Query a document by ID on the Sync Gateway REST API (xref:sync-gateway::rest-api.adoc#/document/get\__db___doc_[`GET /{db}/{id}`]).
 * Query a document from the Query Workbench on the Couchbase Server Console.

--- a/modules/ROOT/pages/csharp.adoc
+++ b/modules/ROOT/pages/csharp.adoc
@@ -77,7 +77,7 @@ The following runtimes are also compatible but have not received as much testing
 *{sp}There are many different variants of Linux, and we don't have the resources to test all of them.
 They are tested on Ubuntu 16.04, but have been shown to work on CentOS, and in theory work on any distro supported by .NET Core.
 
-Comparing this to the xref:1.4@couchbase-lite:ROOT:csharp.adoc#supported-versions[supported versions] in 1.x you can see we've traded some lower obsolete versions for new platform support.
+Comparing this to the xref:1.4@csharp.adoc#supported-versions[supported versions] in 1.x you can see we've traded some lower obsolete versions for new platform support.
 
 == API References
 

--- a/modules/nav.adoc
+++ b/modules/nav.adoc
@@ -1,7 +1,0 @@
-* xref:ROOT:index.adoc[What's New]
-* xref:ROOT:swift.adoc[Swift]
-* xref:ROOT:java.adoc[Java]
-* xref:ROOT:csharp.adoc[C#]
-* xref:ROOT:objc.adoc[Objective-C]
-* xref:ROOT:samples.adoc[Samples]
-* xref:ROOT:compatibility-matrix.adoc[Compatibility Matrix]


### PR DESCRIPTION
* move nav.adoc to ROOT module
* simplify xrefs
* drop _attributes.adoc files