### PR TITLE
groom internal refs (release/1.4)

### DIFF
--- a/modules/ROOT/pages/csharp.adoc
+++ b/modules/ROOT/pages/csharp.adoc
@@ -1804,7 +1804,7 @@ Some typical Listener use cases include:
 
 === Installing the Listener library
 
-Refer to the <<installation, Installation>> section to install the Listener component.
+Refer to the <<installation,Installation>> section to install the Listener component.
 The Couchbase Lite Listener is coupled to Couchbase Lite.
 Both frameworks should always have the same release version.
 
@@ -1886,7 +1886,7 @@ However, there are some good practice guidelines to follow in order to replicate
 
 ==== Filter functions
 
-It may be desirable to use <<filtered-replications, filtered replications>> to replicate only the documents of interest to another peer.
+It may be desirable to use <<filtered-replications,filtered replications>> to replicate only the documents of interest to another peer.
 Filter functions in a peer-to-peer context are executed when the start method on the replication object is called.
 This is a major difference with the Sync Function available on Sync Gateway that builds the access rules when documents are saved to the Sync Gateway database.
 

--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -1163,7 +1163,7 @@ they're buffered up for delivery after the transaction completes.
 
 === Database housekeeping
 
-Refer to the <<revision, Revision>> guide to learn about compaction and pruning to manage the database size.
+Refer to the <<revision,Revision>> guide to learn about compaction and pruning to manage the database size.
 
 === Deleting a database
 
@@ -4090,7 +4090,7 @@ Some typical Listener use cases include:
 
 === Installing the Listener library
 
-Refer to the <<installation, Installation>> section to install the Listener component.
+Refer to the <<installation,Installation>> section to install the Listener component.
 The Couchbase Lite Listener is coupled to Couchbase Lite.
 Both frameworks should always have the same release version.
 
@@ -4197,7 +4197,7 @@ However, there are some good practice guidelines to follow in order to replicate
 
 ==== Filter functions
 
-It may be desirable to use <<filtered-replications, filtered replications>> to replicate only the documents of interest to another peer.
+It may be desirable to use <<filtered-replications,filtered replications>> to replicate only the documents of interest to another peer.
 Filter functions in a peer-to-peer context are executed when the start method on the replication object is called.
 This is a major difference with the Sync Function available on Sync Gateway that builds the access rules when documents are saved to the Sync Gateway database.
 

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -1002,7 +1002,7 @@ they're buffered up for delivery after the transaction completes.
 
 === Database housekeeping
 
-Refer to the <<revision, Revision>> guide to learn about compaction and pruning to manage the database size.
+Refer to the <<revision,Revision>> guide to learn about compaction and pruning to manage the database size.
 
 === Deleting a database
 
@@ -4253,7 +4253,7 @@ Some typical Listener use cases include:
 
 === Installing the Listener library
 
-Refer to the <<installation, Installation>> section to install the Listener component.
+Refer to the <<installation,Installation>> section to install the Listener component.
 The Couchbase Lite Listener is coupled to Couchbase Lite.
 Both frameworks should always have the same release version.
 
@@ -4360,7 +4360,7 @@ However, there are some good practice guidelines to follow in order to replicate
 
 ==== Filter functions
 
-It may be desirable to use <<filtered-replications, filtered replications>> to replicate only the documents of interest to another peer.
+It may be desirable to use <<filtered-replications,filtered replications>> to replicate only the documents of interest to another peer.
 Filter functions in a peer-to-peer context are executed when the start method on the replication object is called.
 This is a major difference with the Sync Function available on Sync Gateway that builds the access rules when documents are saved to the Sync Gateway database.
 

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -689,7 +689,7 @@ they're buffered up for delivery after the transaction completes.
 
 === Database housekeeping
 
-Refer to the <<revision, Revision>> guide to learn about compaction and pruning to manage the database size.
+Refer to the <<revision,Revision>> guide to learn about compaction and pruning to manage the database size.
 
 === Deleting a database
 
@@ -2441,7 +2441,7 @@ Some typical Listener use cases include:
 
 === Installing the Listener library
 
-Refer to the <<Installation, installation>> section to install the Listener component.
+Refer to the <<installation,installation>> section to install the Listener component.
 The Couchbase Lite Listener is coupled to Couchbase Lite.
 Both frameworks should always have the same release version.
 
@@ -2523,7 +2523,7 @@ However, there are some good practice guidelines to follow in order to replicate
 
 ==== Filter functions
 
-It may be desirable to use <<filtered-replications, filtered replications>> to replicate only the documents of interest to another peer.
+It may be desirable to use <<filtered-replications,filtered replications>> to replicate only the documents of interest to another peer.
 Filter functions in a peer-to-peer context are executed when the start method on the replication object is called.
 This is a major difference with the Sync Function available on Sync Gateway that builds the access rules when documents are saved to the Sync Gateway database.
 


### PR DESCRIPTION
- remove space after comma
- fix one instance where arguments were inverted