### PR TITLE
escape literal ++ in string

### DIFF
--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -3,6 +3,7 @@
 :idprefix:
 :idseparator: -
 :source-language: java
+:pp: {plus}{plus}
 
 == Getting Started
 
@@ -910,8 +911,8 @@ The ForestDB engine isn't built into the iOS and tvOS platforms, to save space.
 To use ForestDB on those platforms you'll need to link it into your app as an extra static library.
 
 . Add the library `libCBLForestDBStorage.a` to your project and add it to your iOS app target's "Link Binary With Libraries" build phase.
-. Link the system library `+libc++.dylib+`.
-To do that, in the target's Build Phases editor, press the "+" button below the "Link Binary With Libraries" and add `+libc++.dylib+`
+. Link the system library `libc{pp}.dylib`.
+To do that, in the target's Build Phases editor, press the "+" button below the "Link Binary With Libraries" and add `libc{pp}.dylib`
 . Make sure `-ObjC` is set in `Other Linker Flags` in `Build Settings`
 
 NOTE: These steps aren't necessary for Mac OS because that version of the Couchbase Lite framework already has ForestDB built into it.

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -3,6 +3,7 @@
 :idprefix:
 :idseparator: -
 :source-language: objectivec
+:pp: {plus}{plus}
 
 == API References
 
@@ -749,8 +750,8 @@ The ForestDB engine isn't built into the iOS and tvOS platforms, to save space.
 To use ForestDB on those platforms you'll need to link it into your app as an extra static library.
 
 . Add the library `libCBLForestDBStorage.a` to your project and add it to your iOS app target's "Link Binary With Libraries" build phase.
-. Link the system library `+libc++.dylib+`.
-To do that, in the target's Build Phases editor, press the "+" button below the "Link Binary With Libraries" and add `+libc++.dylib+`
+. Link the system library `libc{pp}.dylib`.
+To do that, in the target's Build Phases editor, press the "+" button below the "Link Binary With Libraries" and add `libc{pp}.dylib`
 . Make sure `-ObjC` is set in `Other Linker Flags` in `Build Settings`
 
 NOTE: These steps aren't necessary for Mac OS because that version of the Couchbase Lite framework already has ForestDB built into it.

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -3,6 +3,7 @@
 :idprefix:
 :idseparator: -
 :source-language: swift
+:pp: {plus}{plus}
 
 == Getting Started
 
@@ -579,8 +580,8 @@ The ForestDB engine isn't built into the iOS and tvOS platforms, to save space.
 To use ForestDB on those platforms you'll need to link it into your app as an extra static library.
 
 . Add the library `libCBLForestDBStorage.a` to your project and add it to your iOS app target's "Link Binary With Libraries" build phase.
-. Link the system library `+libc++.dylib+`.
-To do that, in the target's Build Phases editor, press the "+" button below the "Link Binary With Libraries" and add `+libc++.dylib+`
+. Link the system library `libc{pp}.dylib`.
+To do that, in the target's Build Phases editor, press the "+" button below the "Link Binary With Libraries" and add `libc{pp}.dylib`
 . Make sure `-ObjC` is set in `Other Linker Flags` in `Build Settings`
 
 NOTE: These steps aren't necessary for Mac OS because that version of the Couchbase Lite framework already has ForestDB built into it.


### PR DESCRIPTION
The character sequence ++ has very strong meaning in AsciiDoc. If it occurs more than once on a line, it pairs up to create a passthrough. There are two ways to escape it.

* Define the `pp` attribute and use it in place of the literal text `++` (the `pp` attribute will eventually be a built-in, but for now we have to define it)
* Place it inside an inline pass macro (e.g., `pass:[libc++]`)

I opted to go with the first solution in this PR.