### PR TITLE
Update outdated reference

### DIFF
--- a/modules/ROOT/pages/csharp.adoc
+++ b/modules/ROOT/pages/csharp.adoc
@@ -8,7 +8,7 @@
 
 == Getting Started
 
-=== UWP project
+=== Visual Studio Project
 
 Create or open an existing Visual Studio project and install Couchbase Lite using the following method.
 


### PR DESCRIPTION
"UWP" is not the only supported platform so replace "UWP Project" with "Visual Studio Project"