### PR TITLE
Fix reference to Xcode in Android Studio chapter

### DIFF
--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -97,7 +97,7 @@ http://docs.couchbase.com/mobile/2.1/couchbase-lite-java[Java SDK API References
 === Android Studio
 
 The API has changed in Couchbase Lite 2.0 and will require porting an application that is using Couchbase Lite 1.x API to the Couchbase Lite 2.0 API.
-To update an Xcode project built with Couchbase Lite 1.x:
+To update an Android project built with Couchbase Lite 1.x:
 
 * Remove the existing Couchbase Lite dependency from the Android Studio project.
 * Install the Couchbase Lite 2.0 framework in your project (see the <<getting-started, Getting Started>> section).


### PR DESCRIPTION
Change to Android to match the context. Being cblite compatible with android framework only, reference to Android might be more suitable and not misleading than referring to Java