### PR TITLE
Correct Windows commands for downloading cbl-log

### DIFF
--- a/modules/ROOT/pages/_partials/logging.adoc
+++ b/modules/ROOT/pages/_partials/logging.adoc
@@ -88,18 +88,18 @@ cbl-log logcat LOGFILE <OUTPUT_PATH>
 Windows::
 +
 --
-Download the *cbl-log* tool using `wget`.
+Download the *cbl-log* tool using PowerShell.
 
-[source,console]
+[source,powershell]
 ----
-wget https://packages.couchbase.com/releases/couchbase-lite-log/2.5.0/couchbase-lite-log-2.5.0-windows.zip
+Invoke-WebRequest https://packages.couchbase.com/releases/couchbase-lite-log/2.5.0/couchbase-lite-log-2.5.0-windows.zip -OutFile couchbase-lite-log-2.5.0-windows.zip
 ----
 
 Run the `cbl-log` executable.
 
-[source,bash]
+[source,powershell]
 ----
-$ ./cbl-log logcat LOGFILE <OUTPUT_PATH>
+$ .\cbl-log.exe logcat LOGFILE <OUTPUT_PATH>
 ----
 --
 ====


### PR DESCRIPTION
`wget` is not a system tool on Windows.  Users should use PowerShell.  Also backslask is correct for path separators (.\) not forward slash (./) and the binary extension is .exe.