### PR TITLE
DOC-5185 - merge conflict resolver

### DIFF
--- a/modules/ROOT/examples/swift/code-snippets/SampleCodeTest.swift
+++ b/modules/ROOT/examples/swift/code-snippets/SampleCodeTest.swift
@@ -995,9 +995,9 @@ class RemoteWinConflictResolver: ConflictResolver {
 class MergeConflictResolver: ConflictResolver {
     func resolve(conflict: Conflict) -> Document? {
         let localDict = conflict.localDocument!.toDictionary()
-        let remoteDict = conflict.localDocument!.toDictionary()
-        let result = localDict.merging(remoteDict) { (local, remote) -> Any in
-            return local
+        let remoteDict = conflict.remoteDocument!.toDictionary()
+        let result = localDict.merging(remoteDict) { (current, new) -> Any in
+            return current // return current value in case of duplicate keys
         }
         return MutableDocument(id: conflict.documentID, data: result)
     }

--- a/modules/ROOT/examples/swift/code-snippets/SampleCodeTest.swift
+++ b/modules/ROOT/examples/swift/code-snippets/SampleCodeTest.swift
@@ -994,7 +994,12 @@ class RemoteWinConflictResolver: ConflictResolver {
 // tag::merge-conflict-resolver[]
 class MergeConflictResolver: ConflictResolver {
     func resolve(conflict: Conflict) -> Document? {
-        return self.merge(conflict.localDocument, conflict.remoteDocument)
+        let localDict = conflict.localDocument!.toDictionary()
+        let remoteDict = conflict.localDocument!.toDictionary()
+        let result = localDict.merging(remoteDict) { (local, remote) -> Any in
+            return local
+        }
+        return MutableDocument(id: conflict.documentID, data: result)
     }
 }
 // end::merge-conflict-resolver[]


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-5185

@Sandychuang8 has included an actual implementation of merge ([click Merge tab](https://docs-staging.couchbase.com/couchbase-lite/2.6/csharp.html#conflict-resolver))

where as the swift version was only doing `self.merge(conflict.localDocument, conflict.remoteDocument)` (i.e implied to be an app method).

I think that's a good idea and was thinking to do the same for swift etc. @rajagp Need a review here please. Will then update other langs once this PR is merged.