### PR TITLE
DOC-6170-update-cbl-log-decoder-tool-path

### DIFF
--- a/modules/ROOT/pages/_partials/logging.adoc
+++ b/modules/ROOT/pages/_partials/logging.adoc
@@ -56,7 +56,7 @@ Download the *cbl-log* tool using `wget`.
 
 [source,console]
 ----
-wget https://packages.couchbase.com/releases/couchbase-lite-log/2.6.0/couchbase-lite-log-2.6.0-macos.zip
+wget https://packages.couchbase.com/releases/couchbase-lite-log/2.7.0/couchbase-lite-log-2.7.0-macos.zip
 ----
 
 Navigate to the *bin* directory and run the `cbl-log` executable.
@@ -74,7 +74,7 @@ Download the *cbl-log* tool using `wget`.
 
 [source,console]
 ----
-wget https://packages.couchbase.com/releases/couchbase-lite-log/2.6.0/couchbase-lite-log-2.6.0-centos.zip
+wget https://packages.couchbase.com/releases/couchbase-lite-log/2.7.0/couchbase-lite-log-2.7.0-centos.zip
 ----
 
 Navigate to the *bin* directory and run the `cbl-log` executable.
@@ -92,7 +92,7 @@ Download the *cbl-log* tool using PowerShell.
 
 [source,powershell]
 ----
-Invoke-WebRequest https://packages.couchbase.com/releases/couchbase-lite-log/2.6.0/couchbase-lite-log-2.6.0-windows.zip -OutFile couchbase-lite-log-2.6.0-windows.zip
+Invoke-WebRequest https://packages.couchbase.com/releases/couchbase-lite-log/2.7.0/couchbase-lite-log-2.7.0-windows.zip -OutFile couchbase-lite-log-2.7.0-windows.zip
 ----
 
 Run the `cbl-log` executable.


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6170

Replace 2..6.0 version with 2.7.0

Look to replace this with {version-full} if applicable to  _partials