### PR TITLE
DOC-6175: swift class reference version

### DIFF
--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -9,7 +9,7 @@ include::_attributesLocal.adoc[]
 :blank-field: ____
 :url-issues-ios: https://github.com/couchbase/couchbase-lite-ios/issues
 :tabs:
-:url-api-references: http://docs.couchbase.com/mobile/{version-full/couchbase-lite-swift
+:url-api-references: http://docs.couchbase.com/mobile/2.7.0/couchbase-lite-swift
 
 
 


### PR DESCRIPTION
replaced the version text to 2.7.0