### PR TITLE
DOC-6176: URI corrected to 2.7.0 instead of 2.6.0

### DIFF
--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -7,7 +7,7 @@
 :blank-field: ____
 :url-issues-ios: https://github.com/couchbase/couchbase-lite-ios/issues
 :tabs:
-:url-api-references: http://docs.couchbase.com/mobile/2.6.0/couchbase-lite-objc
+:url-api-references: http://docs.couchbase.com/mobile/2.7.0/couchbase-lite-objc
 
 include::_attributesLocal.adoc[]
 


### PR DESCRIPTION
URI corrected to 2.7.0 instead of 2.6.0