### PR TITLE
Doc 5618 cbl macos min version

### DIFF
--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -133,7 +133,7 @@ include::{partialsdir}/ios-framework-size.adoc[]
 
 |iOS |9.0
 
-|macOS |10.9
+|macOS |10.11
 |===
 
 == API References
@@ -1107,6 +1107,10 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 * Predictive Query
 +
 xref:index.adoc[Read more]
+
+*macOS Support*
+
+Support for macOS 10.9 and 10.10 is being deprecated in this release and will be removed in a future release (see <<supported-versions>>).
 
 *Performance Improvements*
 

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -1108,13 +1108,10 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 +
 xref:index.adoc[Read more]
 
-*macOS Support*
+.macOS Support
+NOTE: MacOS is supported ONLY for testing and development purposes. Support for macOS 10.9 and 10.10 is now deprecated and will cease at Release 2.8 -- see <<supported-versions>>.
 
-Support for macOS 10.9 and 10.10 is being deprecated in the 2.6 release and will be removed after two (non-maintenance) releases following the deprecation announcement. 
---
-
-
-(see <<supported-versions>>).
+// --
 
 *Performance Improvements*
 

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -1110,7 +1110,11 @@ xref:index.adoc[Read more]
 
 *macOS Support*
 
-Support for macOS 10.9 and 10.10 is being deprecated in this release and will be removed in a future release (see <<supported-versions>>).
+Support for macOS 10.9 and 10.10 is being deprecated in the 2.6 release and will be removed after two (non-maintenance) releases following the deprecation announcement. 
+--
+
+
+(see <<supported-versions>>).
 
 *Performance Improvements*
 

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -1090,7 +1090,7 @@ xref:index.adoc[Read more]
 
 *macOS Support*
 
-Support for macOS 10.9 and 10.10 is being deprecated in this release and will be removed in a future release (see <<supported-versions>>).
+Support for macOS 10.9 and 10.10 is being deprecated in the 2.6 release and will be removed after two (non-maintenance) releases following the deprecation announcement.  (see <<supported-versions>>).
 
 *Performance Improvements*
 

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -1088,9 +1088,8 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 +
 xref:index.adoc[Read more]
 
-*macOS Support*
-
-Support for macOS 10.9 and 10.10 is being deprecated in the 2.6 release and will be removed after two (non-maintenance) releases following the deprecation announcement.  (see <<supported-versions>>).
+.macOS Support
+NOTE: MacOS is supported ONLY for testing and development purposes. Support for macOS 10.9 and 10.10 is now deprecated and will cease at Release 2.8. -- see <<supported-versions>>.
 
 *Performance Improvements*
 

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -138,7 +138,7 @@ include::{partialsdir}/ios-framework-size.adoc[]
 |9.0
 
 |macOS
-|10.9
+|10.11
 |===
 
 == API References
@@ -1087,6 +1087,10 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 * Predictive Query
 +
 xref:index.adoc[Read more]
+
+*macOS Support*
+
+Support for macOS 10.9 and 10.10 is being deprecated in this release and will be removed in a future release (see <<supported-versions>>).
 
 *Performance Improvements*
 


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-5618

Rewording of deprecation notice for macOS 10.9 and 10.10
This replaces the backlog PR#138, which was closed un-merged on 24Jan2020 by @ibsoln 