### PR TITLE
DOC-6216-Include-Deprecated-List-In-Supported-OsVersions

### DIFF
--- a/modules/ROOT/pages/java-android.adoc
+++ b/modules/ROOT/pages/java-android.adoc
@@ -79,6 +79,8 @@ xref:sync-gateway::getting-started.adoc#installation[Installing Sync Gateway ->]
 The operating systems listed below refer to "Certified" versions of Android.
 We do not test against, nor guarantee support for, uncertified Android versions such as versions built from source.
 
+.Deprecation Notice
+WARNING: Support for Android API 19 and 21 was deprecated at Release 2.6 and will be removed in a future release.
 
 |===
 |Platform |Runtime architectures |Minimum API Level


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6216

Support for Android API 19 and 21 is deprecated in this release and will 
be removed in a future release