### PR TITLE
Doc 6229 Update Deprecation Notice for Xamarin Android-for 2.7

### DIFF
--- a/modules/ROOT/pages/_partials/deprecationNotice.adoc
+++ b/modules/ROOT/pages/_partials/deprecationNotice.adoc
@@ -1,0 +1,13 @@
+ifdef::deprecated_component[]
+[IMPORTANT]
+.Deprecation Notice
+====
+Support for {deprecated_component} is being deprecated in this release and will be removed in a future release.
+
+ifdef::deprecated_action[_Action:_ {deprecated_action}]
+ifndef::deprecated_action[_Action:_ Please plan to migrate your apps to use an appropriate alternative version.]
+====
+
+:!deprecated_component:
+:!deprecated_action:
+endif::deprecated_component[]

--- a/modules/ROOT/pages/_partials/deprecationNotice.adoc
+++ b/modules/ROOT/pages/_partials/deprecationNotice.adoc
@@ -1,13 +1,26 @@
-ifdef::deprecated_component[]
+//  BLOCK USAGE EXAMPLE:
+//  :msg_component: API 19 and 21
+//  :msg_action:  Please plan to migrate to API 22+
+//  :msg_release: 2.5
+//  :msg_endRel: 2.8
+//  include::_partials/deprecationNotice.adoc[]
+//
+ifdef::msg_component[]
 [IMPORTANT]
 .Deprecation Notice
 ====
-Support for {deprecated_component} is being deprecated in this release and will be removed in a future release.
+Support for {msg_component}
+ifdef::msg_release[was deprecated in release {msg_release}]
+ifndef::msg_release[is being deprecated in this release]
+and will be removed in
+ifdef::msg_endRel[ release {msg_endRel}]
+ifndef::msg_endRel[ a future release]
 
-ifdef::deprecated_action[_Action:_ {deprecated_action}]
-ifndef::deprecated_action[_Action:_ Please plan to migrate your apps to use an appropriate alternative version.]
+ifdef::msg_action[_Action:_ {msg_action}]
+ifndef::msg_action[_Action:_ Please plan to migrate your apps to use an appropriate alternative version.]
 ====
-
-:!deprecated_component:
-:!deprecated_action:
-endif::deprecated_component[]
+:!msg_component:
+:!msg_action:
+:!msg_release:
+:!deprecation_endRel:
+endif::msg_component[]

--- a/modules/ROOT/pages/java-android.adoc
+++ b/modules/ROOT/pages/java-android.adoc
@@ -79,8 +79,9 @@ xref:sync-gateway::getting-started.adoc#installation[Installing Sync Gateway ->]
 The operating systems listed below refer to "Certified" versions of Android.
 We do not test against, nor guarantee support for, uncertified Android versions such as versions built from source.
 
-:deprecated_component: API 19 and 21
-:deprecated_action:  Please plan to migrate your apps to use API versions greater than API 21
+:msg_component: API 19 and 21
+:msg_action:  Please plan to migrate your apps to use API versions greater than API 21
+:msg_release: 2.6
 include::_partials/deprecationNotice.adoc[]
 
 |===
@@ -1252,8 +1253,9 @@ xref:index.adoc[{more}]
 
 *Android API Support*
 
-:deprecated_component: API 19 and 21
-:deprecated_action:  Please plan to migrate your apps to use API versions greater than API 21
+:msg_component: API 19 and 21
+:msg_action:  Please plan to migrate your apps to use API versions greater than API 21
+:msg_release: 2.6
 include::_partials/deprecationNotice.adoc[]
 
 *{api}*

--- a/modules/ROOT/pages/java-android.adoc
+++ b/modules/ROOT/pages/java-android.adoc
@@ -79,6 +79,9 @@ xref:sync-gateway::getting-started.adoc#installation[Installing Sync Gateway ->]
 The operating systems listed below refer to "Certified" versions of Android.
 We do not test against, nor guarantee support for, uncertified Android versions such as versions built from source.
 
+:deprecated_component: API 19 and 21
+:deprecated_action:  Please plan to migrate your apps to use API versions greater than API 21
+include::_partials/deprecationNotice.adoc[]
 
 |===
 |Platform |Runtime architectures |Minimum API Level
@@ -1249,7 +1252,9 @@ xref:index.adoc[{more}]
 
 *Android API Support*
 
-Support for Android API 19 and 21 is being deprecated in this release and will be removed in a future release.
+:deprecated_component: API 19 and 21
+:deprecated_action:  Please plan to migrate your apps to use API versions greater than API 21
+include::_partials/deprecationNotice.adoc[]
 
 *{api}*
 


### PR DESCRIPTION
DOC-6229 Update Deprecation Notice for Xamarin Android for 2.7

https://issues.couchbase.com/browse/DOC-6229

Amend deprecation notice and create a standard deprecation notice block for inclusion in future content.
Extend the functionality of deprecation block.