### PR TITLE
DOC-5618-cbl-macos-min-version-for2.7

### DIFF
--- a/modules/ROOT/pages/_partials/deprecationNotice.adoc
+++ b/modules/ROOT/pages/_partials/deprecationNotice.adoc
@@ -5,9 +5,22 @@
 //  :msg_endRel: 2.8
 //  include::_partials/deprecationNotice.adoc[]
 //
+// Begin Test case
+// :msg_title: My Title
+// :msg_component: test component
+// :msg_action: none
+// :msg_release: 2.6
+// :msg_endRel: 2.9
+// End Test case
+
+// Begin BLOCK
+ifndef::msg_level[:msg_level: IMPORTANT]
+ifndef::msg_hdr[:msg_hdr: Deprecation Notice]
 ifdef::msg_component[]
-[IMPORTANT]
-.Deprecation Notice
+[{msg_level}]
+ifndef::msg_title[.{msg_hdr}]
+ifdef::msg_title[.{msg_hdr} -- {msg_title}]
+
 ====
 Support for {msg_component}
 ifdef::msg_release[was deprecated in release {msg_release}]
@@ -15,12 +28,20 @@ ifndef::msg_release[is being deprecated in this release]
 and will be removed in
 ifdef::msg_endRel[ release {msg_endRel}]
 ifndef::msg_endRel[ a future release]
+ifdef::msg_action[]
+ifeval::["{msg_action}"!="none"]
 
-ifdef::msg_action[_Action:_ {msg_action}]
+_Action:_ {msg_action}
+endif::[]
+endif::msg_action[]
 ifndef::msg_action[_Action:_ Please plan to migrate your apps to use an appropriate alternative version.]
 ====
+// Dispose of attributes to ensure they are not propogated to other inclusion instances
+:!msg_hdr:
+:!msg_level:
 :!msg_component:
 :!msg_action:
 :!msg_release:
-:!deprecation_endRel:
+:!msg_endRel:
 endif::msg_component[]
+// End Block

--- a/modules/ROOT/pages/java-android.adoc
+++ b/modules/ROOT/pages/java-android.adoc
@@ -84,6 +84,7 @@ We do not test against, nor guarantee support for, uncertified Android versions 
 :msg_release: 2.6
 include::_partials/deprecationNotice.adoc[]
 
+[%autowidth.stretch]
 |===
 |Platform |Runtime architectures |Minimum API Level
 
@@ -1056,7 +1057,7 @@ anchor:repstatus-and-lifecycle[]
 
 Couchbase Lite replications will continue running until the app terminates, unless the remote system, or the application, terminates the connection.
 
-NOTE: Recall that the Android OS may kill an application without warning. 
+NOTE: Recall that the Android OS may kill an application without warning.
 You should explicitly stop replication processes when they are no longer useful (for example, when they are `suspended` or `idle`) to avoid socket connections being closed by the OS, which may interfere with the replication process.
 
 === Handling Network Errors
@@ -1175,6 +1176,16 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 New at this release is the Java Platform, which enables development of Java apps on any platform that supports the JVM model
 
 xref::index.adoc[{more}]
+
+*Current Support Notices*
+
+:msg_component: API 19 and 21
+:msg_action:  Please plan to migrate your apps to use API versions greater than API 21
+:msg_release: 2.6
+:msg_endRel: 2.9
+include::_partials/deprecationNotice.adoc[]
+
+See also <<Supported Versions>>
 
 *{ke}*
 

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -129,20 +129,31 @@ include::{partialsdir}/ios-framework-size.adoc[]
 
 == Supported Versions
 
-[width="70%"]
+.Support Constraints - Apple Mac OS
+CAUTION: Mac OS is supported ONLY for testing and development purposes.
+
+// [width="70%"]
+[%autowidth.stretch]
 |===
 |Platform |Minimum OS version
 
 |iOS
-|10.0
-
-9.0 [DEPRECATED]
+|*10.0* (9.0 -- DEPRECATED)
 
 |macOS
-|10.9
+|*10.11* (10.9 and 10.10 -- DEPRECATED)
 |===
+:msg_level: CAUTION
+:msg_title: Apple Mac OS
+:msg_component: Mac OS 10.9 and 10.10
+:msg_endrel: 2.8
+:msg_release: 2.5
+include::_partials/deprecationNotice.adoc[]
 
-NOTE: Support for iOS 9.0 is deprecated in this release. Support will be removed within two (non-maintenance) releases following the deprecation announcement.
+:msg_title: Apple iOS
+:msg_component: iOS 9
+include::_partials/deprecationNotice.adoc[]
+
 
 == API References
 
@@ -1095,6 +1106,22 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 New at this release is the Java Platform, which enables development of Java apps on any platform that supports the JVM model
 
 xref::index.adoc[{more}]
+
+*Current Support Notices*
+
+:msg_level: CAUTION
+:msg_title: Apple Mac OS
+:msg_component: Mac OS 10.9 and 10.10
+:msg_endrel: 2.8
+:msg_release: 2.5
+:msg_action: Please plan to migrate your apps to use at least the minimum <<Supported Versions>>.
+include::_partials/deprecationNotice.adoc[]
+
+:msg_title: Apple iOS
+:msg_component: iOS 9
+:msg_endrel: 2.9
+:msg_action: Please plan to migrate your apps to use at least the minimum <<Supported Versions>>.
+include::_partials/deprecationNotice.adoc[]
 
 *{ke}*
 

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -152,6 +152,7 @@ include::_partials/deprecationNotice.adoc[]
 
 :msg_title: Apple iOS
 :msg_component: iOS 9
+:msg_release: 2.6
 include::_partials/deprecationNotice.adoc[]
 
 
@@ -1119,6 +1120,7 @@ include::_partials/deprecationNotice.adoc[]
 
 :msg_title: Apple iOS
 :msg_component: iOS 9
+:msg_release: 2.6
 :msg_endrel: 2.9
 :msg_action: Please plan to migrate your apps to use at least the minimum <<Supported Versions>>.
 include::_partials/deprecationNotice.adoc[]

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -160,6 +160,7 @@ include::_partials/deprecationNotice.adoc[]
 
 :msg_title: Apple iOS
 :msg_component: iOS 9
+:msg_release: 2.6
 include::_partials/deprecationNotice.adoc[]
 == API References
 
@@ -1104,6 +1105,7 @@ include::_partials/deprecationNotice.adoc[]
 
 :msg_title: Apple iOS
 :msg_component: iOS 9
+:msg_release: 2.6
 :msg_endrel: 2.9
 :msg_action: Please plan to migrate your apps to use at least the minimum <<Supported Versions>>.
 include::_partials/deprecationNotice.adoc[]

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -136,20 +136,31 @@ include::{partialsdir}/ios-framework-size.adoc[]
 
 == Supported Versions
 
+.Support Constraints - Apple Mac OS
+CAUTION: Mac OS is supported ONLY for testing and development purposes.
+
+// [width="70%"]
+[%autowidth.stretch]
 |===
 |Platform |Minimum OS version
 
 |iOS
-|10.0
-
-9.0 [DEPRECATED]
+|*10.0* (9.0 -- DEPRECATED)
 
 |macOS
-|10.9
+|*10.11* (10.9 and 10.10 -- DEPRECATED)
 |===
 
-NOTE: Support for iOS 9.0 is deprecated in this release. Support will be removed within two (non-maintenance) releases following the deprecation announcement.
+:msg_level: CAUTION
+:msg_title: Apple Mac OS
+:msg_component: Mac OS 10.9 and 10.10
+:msg_endrel: 2.8
+:msg_release: 2.5
+include::_partials/deprecationNotice.adoc[]
 
+:msg_title: Apple iOS
+:msg_component: iOS 9
+include::_partials/deprecationNotice.adoc[]
 == API References
 
 {url-api-references}[Swift SDK API References]
@@ -1080,6 +1091,22 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 New at this release is the Java Platform, which enables development of Java apps on any platform that supports the JVM model
 
 xref::index.adoc[{more}]
+
+*Current Support Notices*
+
+:msg_level: CAUTION
+:msg_title: Apple Mac OS
+:msg_component: Mac OS 10.9 and 10.10
+:msg_endrel: 2.8
+:msg_release: 2.5
+:msg_action: Please plan to migrate your apps to use at least the minimum <<Supported Versions>>.
+include::_partials/deprecationNotice.adoc[]
+
+:msg_title: Apple iOS
+:msg_component: iOS 9
+:msg_endrel: 2.9
+:msg_action: Please plan to migrate your apps to use at least the minimum <<Supported Versions>>.
+include::_partials/deprecationNotice.adoc[]
 
 *{ke}*
 


### PR DESCRIPTION
DOC-5618: https://issues.couchbase.com/browse/DOC-5618
DOC-6229: https://issues.couchbase.com/browse/DOC-6229

1. Mostly housekeeping changes to present deprecation and other support notices consistently. Both changes brought forward from 2.6
2. Include changes to deprecationBlock.adoc to provide more substitution options
3. Includes new Release Notes section **Current Support Changes**
