### PR TITLE
DOC-6211 Document Log Redaction for Couchbase Lite for 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+.DS_store
+.gitignore
+0

--- a/modules/ROOT/pages/_partials/feature-LogRedaction-2.0.2.adoc
+++ b/modules/ROOT/pages/_partials/feature-LogRedaction-2.0.2.adoc
@@ -1,0 +1,6 @@
+.New Feature -- Log redaction
+This release adds out-of-the-box support for the redaction of sensitive information in CBL logs.
+The redaction requires no configuration.
+It will operate whenever logging is enabled.
+
+For more on adjusting the logging-levels see <<logging,Logging>>

--- a/modules/ROOT/pages/_partials/feature-Logging.adoc
+++ b/modules/ROOT/pages/_partials/feature-Logging.adoc
@@ -1,0 +1,97 @@
+// Begin Block - feature-Logging
+
+// Begin test case
+// :source-language: java
+// :snippet: {examplesdir}/java/code-snippets/app/src/main/java/com/couchbase/code_snippets/MainActivity.java
+// End test case
+
+// Begin init local attributes
+:lang_csharp: csharp
+:lang_swift: swift
+:lang_android: java
+:lang_objective-C: objectivec
+:url-api-prefix: https://docs.couchbase.com/mobile/2.0/couchbase-lite
+ifndef::source-language[:url-for-setloglevels!:]
+ifndef::snippet[:snippet-lnk!:]
+ifdef::snippet[:snippet-lnk: {snippet}]
+// End init local attributes
+
+// Begin set language-specific api url
+ifdef::source-language[]
+
+ifeval::["{source-language}" == "{lang_csharp}"]
+:url-for-setloglevels: {url-api-prefix}-net/html/M_Couchbase_Lite_Database_SetLogLevel.htm
+:url-for-enumLogLevel: {url-api-prefix}-net/html/T_Couchbase_Lite_Logging_LogLevel.htm
+:url-for-enumLogDomain: {url-api-prefix}-net/html/T_Couchbase_Lite_Logging_LogDomain.htm
+endif::[]
+
+ifeval::["{source-language}" == "{lang_swift}"]
+:url-for-setloglevels: {url-api-prefix}-swift/Classes/Database.html#/s:18CouchbaseLiteSwift8DatabaseC11setLogLevelyAA0fG0O_AA0F6DomainO6domaintFZ
+:url-for-enumLogLevel: {url-api-prefix}-swift/Enums/LogLevel.html
+:url-for-enumLogDomain: {url-api-prefix}--swift/Enums/LogDomain.html
+endif::[]
+
+ifeval::["{source-language}" == "{lang_objective-C}"]
+:url-for-setloglevels: {url-api-prefix}-objc/Classes/CBLDatabase.html#/c:objc(cs)CBLDatabase(cm)setLogLevel:domain:
+:url-for-enumLogLevel: {url-api-prefix}-objc/Enums/CBLLogLevel.html
+:url-for-enumLogDomain: {url-api-prefix}-objc/Enums/CBLLogDomain.html
+endif::[]
+
+ifeval::["{source-language}" == "{lang_android}"]
+:url-for-setloglevels: {url-api-prefix}-java/com/couchbase/lite/Database.html#setLogLevel-com.couchbase.lite.LogDomain-com.couchbase.lite.LogLevel-
+:url-for-enumLogLevel: {url-api-prefix}-java/com/couchbase/lite/LogLevel.html
+:url-for-enumLogDomain: {url-api-prefix}-java/com/couchbase/lite/LogDomain.html
+endif::[]
+
+endif::source-language[]
+// End set language-specific api url
+
+// Begin text blocks
+
+Couchbase Lite's logging strategy provides for the redaction of sensitive information in CBL logs.
+This redaction requires no configuration.
+It will operate whenever logging is enabled -- that is when LogLevel is not `None`.
+
+The log messages are split into different domains (`LogDomains`). Each log domain's logging level can be set independently of any other domain's logging level.
+
+ifdef::url-for-enumLogLevel,url-for-enumLogDomain,url-for-setloglevels[]
+For more on logging configuration, see:
+
+ifdef::url-for-setloglevels[]
+* link:{url-for-setloglevels}[Set Log Level]
+endif::url-for-setloglevels[]
+ifdef::url-for-enumLogLevel[]
+* link:{url-for-enumLogLevel}[Log Level Enum]
+endif::url-for-enumLogLevel[]
+ifdef::url-for-enumLogDomain[]
+* link:{url-for-enumLogDomain}[Set Log Domain]
+endif::url-for-enumLogDomain[]
+
+endif::url-for-enumLogLevel,url-for-enumLogDomain,url-for-setloglevels[]
+
+ifdef::snippet-lnk[]
+The code snippet below sets the logging level to `verbose` for the `replicator` and `query` domains.
+
+.Code sample -- Set Log Level
+[source, {source-language}]
+
+----
+include::{snippet-lnk}[tag=logging,indent=0]
+----
+
+endif::snippet-lnk[]
+// End text blocks
+
+// Begin deconstructors
+:url-for-enumLogLevel!:
+:url-for-enumLogDomain!:
+:url-for-setloglevels!:
+:snippet-lnk!:
+:lang_csharp!:
+:lang_swift!:
+:lang_android!:
+:lang_objective-C!:
+:url-api-prefix!:
+// End deconstructors
+
+// End Block - feature-Logging

--- a/modules/ROOT/pages/csharp.adoc
+++ b/modules/ROOT/pages/csharp.adoc
@@ -4,6 +4,8 @@
 :snippet: {examplesdir}/csharp/api-walkthrough/api-walkthrough/Program.cs
 :source-language: csharp
 :blank-field: ____
+ifndef::partialsdir[:partialsdir: partial$]
+ifndef::examplesdir[:examplesdir: example$]
 
 == Getting Started
 
@@ -182,10 +184,16 @@ Note that this sandbox gets deleted sometimes when debugging from inside Visual 
 The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
 The following example enables `Verbose` logging for the `Replicator` and `Query` domains.
 
-[source]
+[source, {source-language}]
 ----
 include::{snippet}[tag=logging,indent=0]
 ----
+
+==== my bits
+
+include::{partialsdir}feature-Logging.adoc[]
+
+
 
 === Loading a pre-built database
 
@@ -876,7 +884,7 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when <<logging,logging is enabled>>.
+include::{partialsdir}/feature-LogRedaction-2.0.2.adoc[]
 
 === 2.0.0
 

--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -4,6 +4,7 @@
 :snippet: {examplesdir}/java/code-snippets/app/src/main/java/com/couchbase/code_snippets/MainActivity.java
 :source-language: java
 :blank-field: ____
+ifndef::partialsdir[:partialsdir: _partials]
 
 WARNING: Currently, Couchbase Lite 2.0 is available for Android only.
 The SDK cannot be used in Java applications.
@@ -176,13 +177,7 @@ $ adb pull /data/data/{APPLICATION_ID}/files/{DATABASE_NAME}.cblite2 .
 
 === Logging
 
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-The following example enables `verbose` logging for the `replicator` and `query` domains.
-
-[source]
-----
-include::{snippet}[tag=logging,indent=0]
-----
+include::{partialsdir}feature-Logging.adoc[]
 
 === Loading a pre-built database
 
@@ -871,7 +866,7 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when <<logging,logging is enabled>>.
+include::{partialsdir}/feature-LogRedaction-2.0.2.adoc[]
 
 === 2.0.0
 

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -5,6 +5,7 @@
 :source-language: objectivec
 :blank-field: ____
 :tabs:
+ifndef::partialsdir[:partialsdir: _partials]
 
 == Getting Started
 
@@ -218,13 +219,7 @@ Instructions for various commands are available in *Tools/README.md*.
 
 === Logging
 
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-The following example enables `verbose` logging for the `replicator` and `query` domains.
-
-[source]
-----
-include::{snippet}[tag=logging,indent=0]
-----
+include::{partialsdir}feature-Logging.adoc[]
 
 === Loading a pre-built database
 
@@ -943,7 +938,7 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when <<logging,logging is enabled>>.
+include::{partialsdir}/feature-LogRedaction-2.0.2.adoc[]
 
 === 2.0.0
 

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -5,6 +5,7 @@
 :source-language: swift
 :blank-field: ____
 :tabs:
+ifndef::partialsdir[:partialsdir: _partials]
 
 == Getting Started
 
@@ -222,13 +223,7 @@ Instructions for various commands are available in *Tools/README.md*.
 
 === Logging
 
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-The following example enables `verbose` logging for the `replicator` and `query` domains.
-
-[source]
-----
-include::{snippet}[tag=logging,indent=0]
-----
+include::{partialsdir}feature-Logging.adoc[]
 
 === Loading a pre-built database
 
@@ -1007,11 +1002,12 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 === 2.0.3
 
-* This release adds compatibility for Swift 4.1.2 (as part of Xcode 9.4).
+.New Feature -- Swift Compatibility
+This release adds compatibility for Swift 4.1.2 (as part of Xcode 9.4).
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when <<logging,logging is enabled>>.
+include::{partialsdir}/feature-LogRedaction-2.0.2.adoc[]
 
 === 2.0.0
 


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6211

- Add release notes log-redaction message
- Add (shared) logging topic, including links into API and log 
redaction.

Will need to be rolled forward to 2.1. 
Note original logging functionality was replaced by new Logging feature in  2.5.