### PR TITLE
Doc 6164 hyperlink for cbl log for2.7

### DIFF
--- a/modules/ROOT/pages/_partials/logging-pre2.5.adoc
+++ b/modules/ROOT/pages/_partials/logging-pre2.5.adoc
@@ -1,0 +1,8 @@
+// Begin required attributes
+// none required
+// End required attributes
+
+NOTE: This Logging functionality is deprecated. It was replaced by the current Logging API in release 2.5 and so this information is included for completeness only.
+
+The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
+The following example enables `verbose` logging for the `replicator` and `query` domains.

--- a/modules/ROOT/pages/_partials/logging.adoc
+++ b/modules/ROOT/pages/_partials/logging.adoc
@@ -18,7 +18,8 @@ It is the default configuration for file based logging.
 +
 It is recommended that you use binary log format.
 However, in order to view the binary encoded log files, you will need a decoder.
-To decode the binary logs, a log decoder called the *cbl-log* is available -- see <<Decoding binary bogs>> for more information.
+
+A binary log decoder called the *cbl-log* is available -- see <<Decoding binary bogs>>, below.
 +
 The following example enables file based logging.
 +
@@ -48,6 +49,11 @@ include::{snippet}[tag=set-custom-logging,indent=0]
 
 The *cbl-log* tool should be used to decode binary log files.
 
+TIP: You can also get cbl-log on github -- link:https://github.com/couchbaselabs/couchbase-mobile-tools/blob/master/README.cbl-log.md[couchbaselabs/couchbase-mobile-tools].
+
+The instructions below explain how to download and deploy cbl-log.
+
+.Deploying cbl-log
 [{tabs}]
 ====
 macOS::

--- a/modules/ROOT/pages/_partials/logging.adoc
+++ b/modules/ROOT/pages/_partials/logging.adoc
@@ -1,59 +1,69 @@
-// Starting version 2.5
-Couchbase Lite provides a logging API that unifies logging behavior across all platforms, making debugging and troubleshooting easier during development and in production.
-The actual retrieval of the logs from the device is out of scope of this feature.
+// Begin required attributes
+// :cbl-log-version: the required cbl-log version number (eg 2.7.0)
+// :snippet: the path to the language specific example code-snippets
+ifndef::cbl-log-version[:cbl-log-version: UNDEFINED-CBL-LOG-VERSION]
+ifndef::snippet[:snippet: UNDEFINED-SNIPPET-PATH]
+:url-cbl-log-binaries: https://packages.couchbase.com/releases/couchbase-lite-log/{cbl-log-version}/couchbase-lite-log-{cbl-log-version}
+//  End required attributes
 
-There are three different logging features:
+// Begin text block
+From version 2.5, Couchbase Lite provides a logging API that unifies the logging behavior across all platforms, making debugging and troubleshooting easier during development and in production.
 
-Console based logging::
-Enabled by default.
-Console based logging is often used to facilitate troubleshooting during development. The default log level is `WARNING`.
-+
-File based logging::
-Disabled by default.
-File based logging is supported in two formats:
+NOTE: The retrieval of logs from the device is out of scope of this feature.
 
-* a binary format mode which is much more efficient in terms of storage and performance.
-It is the default configuration for file based logging.
-* a plaintext mode
-+
-It is recommended that you use binary log format.
-However, in order to view the binary encoded log files, you will need a decoder.
+Available logging features include:
 
-A binary log decoder called the *cbl-log* is available -- see <<Decoding binary bogs>>, below.
-+
+* Console based logging
+* File based logging
+* Custom logging
+
+== Console based logging
+Default: Enabled.
+
+Console based logging is often used to facilitate troubleshooting during development.
+
+== File based logging
+Default: Disabled.
+
+Available file based logging formats:
+
+* Binary -- most efficient for storage and performance. It is the default for file based logging.
+* Plaintext
+
+We recommend using the binary log format and
+a decoder, such as *cbl-log*, to view them. Download *cbl-log* from link:https://github.com/couchbaselabs/couchbase-mobile-tools/blob/master/README.cbl-log.md[couchbaselabs/couchbase-mobile-tools, window=_blank].
+
+NOTE: See  <<Decoding binary logs>>.
+
 The following example enables file based logging.
-+
+
 [source]
 ----
 include::{snippet}[tag=file-logging,indent=0]
 ----
-+
-Custom logging::
-Disabled by default.
-Provides apps the ability to register a callback function in order to receive Couchbase Lite log messages.
-The messages can be logged using any external logging framework.
-Apps must implement the `Logger` interface.
-+
-[source]
+
+== Custom logging
+Default: Disabled.
+
+Allows registration of a callback function to receive Couchbase Lite log messages, which may be logged using any external logging framework.
+
+Apps must implement the `Logger` interface, as shown below:
+
+[source, {source-language}]
 ----
 include::{snippet}[tag=custom-logging,indent=0]
 ----
 And set it on the `custom` property.
-+
-[source]
+
+[source, {source-language}]
 ----
 include::{snippet}[tag=set-custom-logging,indent=0]
 ----
 
-==== Decoding binary logs
+== Decoding binary logs
 
-The *cbl-log* tool should be used to decode binary log files.
+The *cbl-log* tool should be used to decode binary log files as shown in these examples.
 
-TIP: You can also get cbl-log on github -- link:https://github.com/couchbaselabs/couchbase-mobile-tools/blob/master/README.cbl-log.md[couchbaselabs/couchbase-mobile-tools].
-
-The instructions below explain how to download and deploy cbl-log.
-
-.Deploying cbl-log
 [{tabs}]
 ====
 macOS::
@@ -63,7 +73,7 @@ Download the *cbl-log* tool using `wget`.
 
 [source,console]
 ----
-wget https://packages.couchbase.com/releases/couchbase-lite-log/2.7.0/couchbase-lite-log-2.7.0-macos.zip
+wget {url-cbl-log-binaries}-macos.zip
 ----
 
 Navigate to the *bin* directory and run the `cbl-log` executable.
@@ -81,7 +91,7 @@ Download the *cbl-log* tool using `wget`.
 
 [source,console]
 ----
-wget https://packages.couchbase.com/releases/couchbase-lite-log/2.7.0/couchbase-lite-log-2.7.0-centos.zip
+wget {url-cbl-log-binaries}-centos.zip
 ----
 
 Navigate to the *bin* directory and run the `cbl-log` executable.
@@ -99,7 +109,7 @@ Download the *cbl-log* tool using PowerShell.
 
 [source,powershell]
 ----
-Invoke-WebRequest https://packages.couchbase.com/releases/couchbase-lite-log/2.7.0/couchbase-lite-log-2.7.0-windows.zip -OutFile couchbase-lite-log-2.7.0-windows.zip
+Invoke-WebRequest {url-cbl-log-binaries}-windows.zip -OutFile couchbase-lite-log-{cbl-log-version}-windows.zip
 ----
 
 Run the `cbl-log` executable.

--- a/modules/ROOT/pages/_partials/mobAttrCBL.adoc
+++ b/modules/ROOT/pages/_partials/mobAttrCBL.adoc
@@ -45,6 +45,8 @@
 :patch: 0
 :version: {major}.{minor}
 :version-full: {major}.{minor}.{patch}
+:vrsnLatestRel: {major}.{minor}
+:vrsnLatestRelFull: {version-full}
 //
 // End Product Versioning attributes
 
@@ -58,8 +60,8 @@
 //  Standard URL Attributes
 //
 
-:snippet: {examplesdir}/java-android/app/src/main/java/com/couchbase/code_snippets/Examples.java
-:snippet-java-jvm: {examplesdir}/java/src/com/couchbase/code_snippets/Examples.java
+:snippet-java-android: example$java-android/app/src/main/java/com/couchbase/code_snippets/Examples.java
+:snippet-java-jvm: example$java/src/com/couchbase/code_snippets/Examples.java
 :url-cb-website: https://www.couchbase.com
 :url-issues-java: TBA
 // :url-api-references: Now defined locally in pages
@@ -86,10 +88,22 @@
 //
 :idprefix:
 :idseparator: -
-:source-language: java
 :blank-field: ____
 //
 // End misc attributes
+
+// Begin Source Languages
+:langAndroid: android
+:langAndroidFull: java-android
+:langCsharp: csharp
+:langJava: java
+:langJavaFull: java-platform
+:langJavascript: javascript
+:langObjc: objc
+:langObjcFull: objective-c
+:langSwift: swift
+// End Source Languages
+
 
 
 :nmCBdwnlds: Couchbase Downloads

--- a/modules/ROOT/pages/csharp.adoc
+++ b/modules/ROOT/pages/csharp.adoc
@@ -1,13 +1,15 @@
 = C#
+include::partial$mobAttrCBL.adoc[]
+:cbl-log-version: {version-full}
 :idprefix:
 :idseparator: -
-:snippet: {examplesdir}/csharp/Program.cs
-:source-language: csharp
+:snippet: example$csharp/Program.cs
+:source-language: {langCsharp}
 :blank-field: ____
 :url-issues-net: https://github.com/couchbase/couchbase-lite-net/issues
-:url-api-references: http://docs.couchbase.com/mobile/2.6.0/couchbase-lite-net
-include::_attributesLocal.adoc[]
-
+:url-api-references: http://docs.couchbase.com/mobile/{version-full}/couchbase-lite-net
+//
+// End header
 
 == Getting Started
 
@@ -192,7 +194,7 @@ The Couchbase Lite 2.1 release includes the ability to encrypt Couchbase Lite da
 This allows mobile applications to secure the data at rest, when it is being stored on the device.
 The algorithm used to encrypt the database is 256-bit AES.
 
-include::{partialsdir}/database-encryption.adoc[]
+include::partial$database-encryption.adoc[]
 
 === Finding a Database File
 
@@ -212,21 +214,21 @@ Note that this sandbox gets deleted sometimes when debugging from inside Visual 
 You can download and build it from the couchbaselabs https://github.com/couchbaselabs/couchbase-mobile-tools/blob/master/README.cblite.md[GitHub repository].
 Note that the `cblite` tool is not supported by the https://www.couchbase.com/support-policy[Couchbase Support Policy].
 
-=== Logging [DEPRECATED]
-
-CAUTION: The following API is deprecated and superseded by the <<logging,Logging API>> introduced in Couchbase Lite 2.5.
-
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-The following example enables `verbose` logging for the `replicator` and `query` domains.
-
-[source]
-----
-include::{snippet}[tag=logging,indent=0]
-----
-
 === Logging
 
-include::{partialsdir}/logging.adoc[]
+If you are using a Couchbase Lite release prior to 2.5 see <<Logging functionality prior to Release 2.5, Deprecated functionality>>
+
+include::partial$logging.adoc[leveloffset=+2]
+
+==== Logging functionality prior to Release 2.5
+
+include::partial$logging-pre2.5.adoc[]
+
+[source, {source-language}]
+
+----
+include::{snippet}[tags=logging,indent=0]
+----
 
 === Loading a pre-built database
 
@@ -309,7 +311,7 @@ But Couchbase Mobile is a distributed system, and due to the way replication wor
 
 === Document Expiration
 
-include::{partialsdir}/document-expiration.adoc[]
+include::partial$document-expiration.adoc[]
 
 == Blobs
 
@@ -638,7 +640,7 @@ Avignon
 
 === Date/Time Functions
 
-include::{partialsdir}/query/date-time-functions.adoc[]
+include::partial$query/date-time-functions.adoc[]
 
 == Live Query
 
@@ -691,7 +693,7 @@ Thus, good performance depends on designing and creating the _right_ indexes to 
 
 == Predictive Query
 
-include::{partialsdir}/predictive-query.adoc[]
+include::partial$predictive-query.adoc[]
 
 == Full-Text Search
 
@@ -799,7 +801,7 @@ In the `OrderBy` array, use a string of the form `Rank(X)`, where `X` is the pro
 
 == Replication
 
-include::{partialsdir}/replication-introduction.adoc[]
+include::partial$replication-introduction.adoc[]
 
 === Compatibility
 
@@ -856,7 +858,7 @@ To keep a reference to the `replicator` object, you can set it as an instance pr
 <2> The URL scheme for remote database URLs has changed in Couchbase Lite 2.0.
 You should now use `ws:`, or `wss:` for SSL/TLS connections.
 
-include::{partialsdir}/verify-replication.adoc[]
+include::partial$verify-replication.adoc[]
 
 Couchbase Lite 2.0 uses WebSockets as the communication protocol to transmit data.
 Some load balancers are not configured for WebSocket connections by default (NGINX for example);
@@ -993,11 +995,11 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 === Replication Events
 
-include::{partialsdir}/replication-events.adoc[]
+include::partial$replication-events.adoc[]
 
 === Custom Headers
 
-include::{partialsdir}/replication-custom-header.adoc[]
+include::partial$replication-custom-header.adoc[]
 
 [source]
 ----
@@ -1006,7 +1008,7 @@ include::{snippet}[tag=replication-custom-header,indent=0]
 
 === Replication Checkpoint Reset
 
-include::{partialsdir}/replication-checkpoint.adoc[]
+include::partial$replication-checkpoint.adoc[]
 
 [source]
 ----
@@ -1015,11 +1017,11 @@ include::{snippet}[tag=replication-reset-checkpoint,indent=0]
 
 === Replication Filters
 
-include::{partialsdir}/replication-filters.adoc[]
+include::partial$replication-filters.adoc[]
 
 == Handling Conflicts
 
-include::{partialsdir}/handling-conflicts.adoc[]
+include::partial$handling-conflicts.adoc[]
 
 == Database Replicas
 
@@ -1036,7 +1038,7 @@ include::{snippet}[tag=database-replica,indent=0]
 
 == Certificate Pinning
 
-include::{partialsdir}/certificate-pinning.adoc[]
+include::partial$certificate-pinning.adoc[]
 
 == Peer-to-Peer Sync
 
@@ -1065,23 +1067,23 @@ The passive side reacts to things that it receives but does not initiate any com
 
 === Peer Discovery
 
-include::{partialsdir}/p2p-peer-discovery.adoc[]
+include::partial$p2p-peer-discovery.adoc[]
 
 === Peer Selection and Connection Setup
 
-include::{partialsdir}/p2p-peer-selection.adoc[]
+include::partial$p2p-peer-selection.adoc[]
 
 === Replication Setup
 
-include::{partialsdir}/p2p-replication-setup.adoc[]
+include::partial$p2p-replication-setup.adoc[]
 
 === Push/Pull Replication
 
-include::{partialsdir}/p2p-push-pull-repl.adoc[]
+include::partial$p2p-push-pull-repl.adoc[]
 
 === Connection Teardown
 
-include::{partialsdir}/p2p-connection-teardown.adoc[]
+include::partial$p2p-connection-teardown.adoc[]
 
 == Thread Safety
 

--- a/modules/ROOT/pages/java-android.adoc
+++ b/modules/ROOT/pages/java-android.adoc
@@ -190,7 +190,7 @@ The Couchbase Lite 2.1 release includes the ability to encrypt Couchbase Lite da
 This allows mobile applications to secure the data at rest, when it is being stored on the device.
 The algorithm used to encrypt the database is 256-bit AES.
 
-include::{partialsdir}/database-encryption.adoc[]
+include::partial$database-encryption.adoc[]
 
 === Finding a Database File
 
@@ -220,21 +220,21 @@ $ adb pull /data/data/{APPLICATION_ID}/files/{DATABASE_NAME}.cblite2 .
 You can download and build it from the couchbaselabs https://github.com/couchbaselabs/couchbase-mobile-tools/blob/master/README.cblite.md[GitHub repository].
 Note that the `cblite` tool is not supported by the https://www.couchbase.com/support-policy[Couchbase Support Policy].
 
-=== Logging [DEPRECATED]
-
-CAUTION: The following API is deprecated and superseded by the <<logging,Logging API>> introduced in Couchbase Lite 2.5.
-
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-The following example enables `verbose` logging for the `replicator` and `query` domains.
-
-[source]
-----
-include::{snippet}[tag=logging,indent=0]
-----
-
 === Logging
 
-include::{partialsdir}/logging.adoc[]
+If you are using a Couchbase Lite release prior to 2.5 see <<Logging functionality prior to Release 2.5, Deprecated functionality>>
+
+include::partial$logging.adoc[leveloffset=+2]
+
+==== Logging functionality prior to Release 2.5
+
+include::partial$logging-pre2.5.adoc[]
+
+[source, {source-language}]
+
+----
+include::{snippet}[tags=logging,indent=0]
+----
 
 === Loading a pre-built database
 
@@ -335,7 +335,7 @@ include::{snippet}[tag=document-listener,indent=0]
 
 === Document Expiration
 
-include::{partialsdir}/document-expiration.adoc[]
+include::partial$document-expiration.adoc[]
 
 == Blobs
 
@@ -634,15 +634,15 @@ Avignon
 
 === Date/Time Functions
 
-include::{partialsdir}/query/date-time-functions.adoc[]
+include::partial$query/date-time-functions.adoc[]
 
 == Live Query
 
-include::{partialsdir}/live-query.adoc[]
+include::partial$live-query.adoc[]
 
 == Predictive Query
 
-include::{partialsdir}/predictive-query.adoc[]
+include::partial$predictive-query.adoc[]
 
 == Indexing
 
@@ -777,7 +777,7 @@ In the `OrderBy` array, use a string of the form `Rank(X)`, where `X` is the pro
 
 == Replication
 
-include::{partialsdir}/replication-introduction.adoc[]
+include::partial$replication-introduction.adoc[]
 
 === Compatibility
 
@@ -838,7 +838,7 @@ In this example the hostname is `10.0.2.2` because the Android emulator runs in 
 NOTE: As of Android Pie, version 9, API 28, cleartext support is disabled, by default.
 Although `wss:` protocol URLs are not affected, in order to use the `ws:` protocol, applications must target API 27 or lower, or must configure application network security as described https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted[here].
 
-include::{partialsdir}/verify-replication.adoc[]
+include::partial$verify-replication.adoc[]
 
 Couchbase Lite 2.0 uses WebSockets as the communication protocol to transmit data.
 Some load balancers are not configured for WebSocket connections by default (NGINX for example);
@@ -1011,7 +1011,7 @@ include::{snippet}[tag=replication-logging,indent=0]
 
 === Authentication
 
-include::{partialsdir}/authentication.adoc[]
+include::partial$authentication.adoc[]
 
 === Replication Status
 
@@ -1056,7 +1056,7 @@ anchor:repstatus-and-lifecycle[]
 
 Couchbase Lite replications will continue running until the app terminates, unless the remote system, or the application, terminates the connection.
 
-NOTE: Recall that the Android OS may kill an application without warning. 
+NOTE: Recall that the Android OS may kill an application without warning.
 You should explicitly stop replication processes when they are no longer useful (for example, when they are `suspended` or `idle`) to avoid socket connections being closed by the OS, which may interfere with the replication process.
 
 === Handling Network Errors
@@ -1083,11 +1083,11 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 === Replication Events
 
-include::{partialsdir}/replication-events.adoc[]
+include::partial$replication-events.adoc[]
 
 === Custom Headers
 
-include::{partialsdir}/replication-custom-header.adoc[]
+include::partial$replication-custom-header.adoc[]
 
 [source]
 ----
@@ -1096,7 +1096,7 @@ include::{snippet}[tag=replication-custom-header,indent=0]
 
 === Replication Checkpoint Reset
 
-include::{partialsdir}/replication-checkpoint.adoc[]
+include::partial$replication-checkpoint.adoc[]
 
 [source]
 ----
@@ -1105,19 +1105,19 @@ include::{snippet}[tag=replication-reset-checkpoint,indent=0]
 
 === Replication Filters
 
-include::{partialsdir}/replication-filters.adoc[]
+include::partial$replication-filters.adoc[]
 
 == Handling Conflicts
 
-include::{partialsdir}/handling-conflicts.adoc[]
+include::partial$handling-conflicts.adoc[]
 
 == Database Replicas
 
-include::{partialsdir}/database-replicas.adoc[]
+include::partial$database-replicas.adoc[]
 
 == Certificate Pinning
 
-include::{partialsdir}/certificate-pinning.adoc[]
+include::partial$certificate-pinning.adoc[]
 
 == Peer-to-Peer Sync
 
@@ -1144,23 +1144,23 @@ In Couchbase Lite, a peer can take on one of these two roles:
 
 === Peer Discovery
 
-include::{partialsdir}/p2p-peer-discovery.adoc[]
+include::partial$p2p-peer-discovery.adoc[]
 
 === Peer Selection and Connection Setup
 
-include::{partialsdir}/p2p-peer-selection.adoc[]
+include::partial$p2p-peer-selection.adoc[]
 
 === Replication Setup
 
-include::{partialsdir}/p2p-replication-setup.adoc[]
+include::partial$p2p-replication-setup.adoc[]
 
 === Push/Pull Replication
 
-include::{partialsdir}/p2p-push-pull-repl.adoc[]
+include::partial$p2p-push-pull-repl.adoc[]
 
 === Connection Teardown
 
-include::{partialsdir}/p2p-connection-teardown.adoc[]
+include::partial$p2p-connection-teardown.adoc[]
 
 == Thread Safety
 

--- a/modules/ROOT/pages/java-platform.adoc
+++ b/modules/ROOT/pages/java-platform.adoc
@@ -1,6 +1,5 @@
 = Couchbase Lite Java Framework
-include::_partials/mobAttrCBL.adoc[]
-include::_attributesLocal.adoc[]
+include::partial$mobAttrCBL.adoc[]
 :JP: Java
 :Android: Java (android)
 :cblJP: {product} {JP}
@@ -8,10 +7,12 @@ include::_attributesLocal.adoc[]
 :packageNmEE: couchbase-lite-java-ee-{version-full}
 :url-api-references: http://docs.couchbase.com/mobile/{version-full}/couchbase-lite-java
 :hdIndent:
+:snippet: {snippet-java-jvm}
 :sgGetStartedDoc: sync-gateway::getting-started.adoc
 :sgGetStartedDoc-installation: {sgGetStartedDoc}#installation
 :sgGetStartedDoc-createRBACuser: {sgGetStartedDoc}#creating-an-rbac-user
 :sgGetStartedDoc-createBucket: {sgGetStartedDoc}#creating-a-bucket
+:tabs:
 
 == GET STARTED
 
@@ -65,7 +66,7 @@ anchor:bmkUsingMavenRepos[Using Maven repositories]
 
 === Defining Dependencies and Repositories
 
-[tabs]
+[{tabs}]
 ====
 
 Console App Development::
@@ -123,7 +124,7 @@ That's it. You're all set to start building your own {cblJP} applications -- see
 
 [source,groovy,subs=attributes+]
 ----
-include::{snippet-java-jvm}[tags=gsGradleMavenExample,indent=0]
+include::{snippet}[tags=gsGradleMavenExample,indent=0]
 ----
 
 --
@@ -220,7 +221,7 @@ That's it. You're all set to start building your own {cblJP} applications -- see
 
 [source,groovy,subs=attributes+]
 ----
-include::{snippet-java-jvm}[tags=GsEmbeddedTomcatBuildGradle,indent=0]
+include::{snippet}[tags=GsEmbeddedTomcatBuildGradle,indent=0]
 ----
 
 --
@@ -238,7 +239,7 @@ This section explains how to validate your configured build environment by build
 The {nmMobStarterApp} app demonstrates how to use {cblJP}. Console and Web App versions are available.
 
 .Development-type Scenarios
-[tabs]
+[{tabs}]
 ====
 
 Console App::
@@ -254,7 +255,7 @@ Create, build and run a new project using the following `GettingStarted.java` co
 [source,java]
 
 ----
-include::{snippet-java-jvm}[tags=getting-started,indent=0]
+include::{snippet}[tags=getting-started,indent=0]
 ----
 <1> The app will start a replicator pointing to `ws://localhost:4984/db`, where `db` is the name of your {sg} database
 <2> This is the only API that differs from the {android} version. It accepts no parameters and should be called once only
@@ -282,7 +283,7 @@ This section explains how to set-up a build project to create {cblJP} web apps u
 +
 [source,groovy,subs=attributes+]
 ----
-include::{snippet-java-jvm}[tags=GsEmbeddedTomcatBuildGradle,indent=0]
+include::{snippet}[tags=GsEmbeddedTomcatBuildGradle,indent=0]
 ----
 
 . Within {gpIDE}, open the new project folder
@@ -293,7 +294,7 @@ If you don't have auto-import enabled, then accept the *Import from Gradle* prom
 [source, java]
 
 ----
-include::{snippet-java-jvm}[tags=GsWebApp_GettingStarted,indent=0]
+include::{snippet}[tags=GsWebApp_GettingStarted,indent=0]
 ----
 +
 <1> It is advisable to set a specific directory path for the database.
@@ -304,7 +305,7 @@ include::{snippet-java-jvm}[tags=GsWebApp_GettingStarted,indent=0]
 [source, java]
 
 ----
-include::{snippet-java-jvm}[tags=GsWebApp_Listener,indent=0]
+include::{snippet}[tags=GsWebApp_Listener,indent=0]
 ----
 +
 
@@ -313,7 +314,7 @@ include::{snippet-java-jvm}[tags=GsWebApp_Listener,indent=0]
 [source, java]
 
 ----
-include::{snippet-java-jvm}[tags=GsWebApp_DbManager,indent=0]
+include::{snippet}[tags=GsWebApp_DbManager,indent=0]
 ----
 +
 <1> This is the only API that differs from the {android} version. It accepts no parameters and should be called once only
@@ -325,7 +326,7 @@ include::{snippet-java-jvm}[tags=GsWebApp_DbManager,indent=0]
 [source, html]
 
 ----
-include::{snippet-java-jvm}[tags=GsWebApp_Index,indent=0]
+include::{snippet}[tags=GsWebApp_Index,indent=0]
 ----
 
 . Create a `showDbItems.jsp` file in `src/main/web app` with the following content:
@@ -333,7 +334,7 @@ include::{snippet-java-jvm}[tags=GsWebApp_Index,indent=0]
 [source, html]
 
 ----
-include::{snippet-java-jvm}[tags=GsWebApp_ShowDbItems,indent=0]
+include::{snippet}[tags=GsWebApp_ShowDbItems,indent=0]
 ----
 
 . Build, deploy and run the app using `tomcatRun`
@@ -409,7 +410,7 @@ The `init()` API accepts no parameters.
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=sdk-initializer,indent=0]
+include::{snippet}[tags=sdk-initializer,indent=0]
 ----
 
 == New Database
@@ -419,7 +420,7 @@ The following example creates a database using the `Database(String name, Databa
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=new-database,indent=0]
+include::{snippet}[tags=new-database,indent=0]
 ----
 
 Just as before, the database will be created in a default location.
@@ -434,7 +435,7 @@ The Couchbase Lite 2.1 release includes the ability to encrypt Couchbase Lite da
 This allows mobile applications to secure the data at rest, when it is being stored on the device.
 The algorithm used to encrypt the database is 256-bit AES.
 
-include::{partialsdir}/database-encryption.adoc[leveloffset=-2]
+include::partial$database-encryption.adoc[leveloffset=-2]
 
 == Finding a Database File
 
@@ -453,23 +454,24 @@ Database thisDB = new Database("db", thisConfig);
 `cblite` is a command-line tool for inspecting and querying Couchbase Lite 2.x databases.
 
 You can download and build it from the couchbaselabs https://github.com/couchbaselabs/couchbase-mobile-tools/blob/master/README.cblite.md[GitHub repository].
-Note that the `cblite` tool is not supported by the https://www.couchbase.com/support-policy[Couchbase Support Policy].
 
-// == Logging [DEPRECATED]
-//
-// CAUTION: The following API is deprecated and superseded by the <<logging,Logging API>> introduced in Couchbase Lite 2.5.
-//
-// The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-// The following example enables `verbose` logging for the `replicator` and `query` domains.
+NOTE: The `cblite` tool is not supported by the https://www.couchbase.com/support-policy[Couchbase Support Policy].
 
-[source]
+=== Logging
+
+If you are using a Couchbase Lite release prior to 2.5 see <<Logging functionality prior to Release 2.5, Deprecated functionality>>
+
+include::partial$logging.adoc[leveloffset=+2]
+
+==== Logging functionality prior to Release 2.5
+
+include::partial$logging-pre2.5.adoc[]
+
+[source, {source-language}]
+
 ----
-include::{snippet-java-jvm}[tags=logging,indent=0,leveloffset=-1 ]
+include::{snippet}[tags=logging,indent=0]
 ----
-
-== Logging
-
-include::{partialsdir}/logging.adoc[leveloffset=-1 ]
 
 == Loading a pre-built database
 
@@ -482,7 +484,7 @@ If the database does not exist, the application should copy it from the assets f
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=prebuilt-database,indent=0]
+include::{snippet}[tags=prebuilt-database,indent=0]
 ----
 
 In the example below, the `ZipUtils.unzip` method copies the zipped pre-built database from the application's `resource` directory to the *files* directory.
@@ -490,7 +492,7 @@ This method is provided below for information as it isn't included in the Couchb
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=ziputils-unzip,indent=0]
+include::{snippet}[tags=ziputils-unzip,indent=0]
 ----
 
 == Document
@@ -513,7 +515,7 @@ The following code example creates a document and persists it to the database.
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=initializer,indent=0]
+include::{snippet}[tags=initializer,indent=0]
 ----
 
 == Mutability
@@ -523,7 +525,7 @@ Use the `document.toMutable()` method to create an updateable instance of the do
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=update-document,indent=0]
+include::{snippet}[tags=update-document,indent=0]
 ----
 
 Changes to the document are persisted to the database when the `save` method is called.
@@ -539,7 +541,7 @@ The following example sets the date on the `createdAt` property and reads it bac
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=date-getter,indent=0]
+include::{snippet}[tags=date-getter,indent=0]
 ----
 
 If the property doesn't exist in the document it will return the default value for that getter method (0 for `getInt`, 0.0 for `getFloat` etc.).
@@ -552,7 +554,7 @@ The following example persists a few documents in batch.
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=batch,indent=0]
+include::{snippet}[tags=batch,indent=0]
 ----
 
 At the *local* level this operation is still transactional: no other `Database` instances, including ones managed by the replicator can make changes during the execution of the block, and other instances will not see partial changes.
@@ -565,12 +567,12 @@ The following example registers for changes to the document with ID `user.john` 
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=document-listener,indent=0]
+include::{snippet}[tags=document-listener,indent=0]
 ----
 
 == Document Expiration
 
-include::{partialsdir}/document-expiration.adoc[]
+include::partial$document-expiration.adoc[]
 
 == Blobs
 
@@ -581,7 +583,7 @@ The following code example adds a blob to the document under the `avatar` proper
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=blob,indent=0]
+include::{snippet}[tags=blob,indent=0]
 ----
 
 The `Blob` API lets you access the contents as an in-memory byte array (
@@ -637,7 +639,7 @@ In the query result, we print the `_id` and `name` properties of each row using 
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-select-meta,indent=0]
+include::{snippet}[tags=query-select-meta,indent=0]
 ----
 
 The `SelectResult.all()` method can be used to query all the properties of a document.
@@ -646,7 +648,7 @@ The following snippet shows the same query using `SelectResult.all()` and the re
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-select-all,indent=0]
+include::{snippet}[tags=query-select-all,indent=0]
 ----
 
 [source,json]
@@ -699,7 +701,7 @@ In the example below, we use the `equalTo` operator to query documents where the
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-where,indent=0]
+include::{snippet}[tags=query-where,indent=0]
 ----
 
 === Collection Operators
@@ -721,7 +723,7 @@ The following example uses the `Function.arrayContains` to find documents whose 
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-collection-operator-contains,indent=0]
+include::{snippet}[tags=query-collection-operator-contains,indent=0]
 ----
 
 ==== IN Operator
@@ -731,7 +733,7 @@ The following example compiles a list of values from `first`, `last` and `userna
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-collection-operator-in,indent=0]
+include::{snippet}[tags=query-collection-operator-in,indent=0]
 ----
 
 ==== Like Operator
@@ -751,7 +753,7 @@ The following query returns "landmark" type documents regardless of the name's c
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-like-operator,indent=0]
+include::{snippet}[tags=query-like-operator,indent=0]
 ----
 
 ==== Wildcard Match
@@ -769,7 +771,7 @@ NOTE: The matches may span word boundaries.
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-like-operator-wildcard-match,indent=0]
+include::{snippet}[tags=query-like-operator-wildcard-match,indent=0]
 ----
 
 ==== Wildcard Character Match
@@ -781,7 +783,7 @@ The following query will return "landmark" `type` documents with the `name` matc
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-like-operator-wildcard-character-match,indent=0]
+include::{snippet}[tags=query-like-operator-wildcard-character-match,indent=0]
 ----
 
 ==== Regex Operator
@@ -798,7 +800,7 @@ Note that the `\b` specifies that the match must occur on word boundaries.
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-regex-operator,indent=0]
+include::{snippet}[tags=query-regex-operator,indent=0]
 ----
 
 === Query Deleted Document
@@ -808,7 +810,7 @@ The following example shows how to query deleted documents in the database.
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-deleted-documents,indent=0]
+include::{snippet}[tags=query-deleted-documents,indent=0]
 ----
 
 === JOIN statement
@@ -820,7 +822,7 @@ This example JOINS the document of type "route" with documents of type "airline"
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-join,indent=0]
+include::{snippet}[tags=query-join,indent=0]
 ----
 
 === GROUP BY statement
@@ -841,7 +843,7 @@ The following example looks for the number of airports at an altitude of 300 ft 
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-groupby,indent=0]
+include::{snippet}[tags=query-groupby,indent=0]
 ----
 
 [source,text]
@@ -860,7 +862,7 @@ The example below returns documents of type equal to "hotel" sorted in ascending
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-orderby,indent=0]
+include::{snippet}[tags=query-orderby,indent=0]
 ----
 
 [source,text]
@@ -877,15 +879,15 @@ Avignon
 
 === Date/Time Functions
 
-include::{partialsdir}/query/date-time-functions.adoc[]
+include::partial$query/date-time-functions.adoc[]
 
 === Live Query
 
-include::{partialsdir}/live-query.adoc[]
+include::partial$live-query.adoc[]
 
 === Predictive Query
 
-include::{partialsdir}/predictive-query.adoc[]
+include::partial$predictive-query.adoc[]
 
 === Indexing
 
@@ -906,7 +908,7 @@ The following example creates a new index for the `type` and `name` properties.
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=query-index,indent=0]
+include::{snippet}[tags=query-index,indent=0]
 ----
 
 If there are multiple expressions, the first one will be the primary key, the second the secondary key, etc.
@@ -922,7 +924,7 @@ The following example creates an FTS index on the `name` property.
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=fts-index,indent=0]
+include::{snippet}[tags=fts-index,indent=0]
 ----
 
 Multiple properties to index can be specified in the index creation method.
@@ -933,7 +935,7 @@ The left-hand side is the full-text index to use and the right-hand side is the 
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=fts-query,indent=0]
+include::{snippet}[tags=fts-query,indent=0]
 ----
 
 In the example above, the pattern to match is a word, the full-text search query matches all documents that contain the word "buy" in the value of the `doc.name` property.
@@ -1019,7 +1021,7 @@ In the `OrderBy` array, use a string of the form `Rank(X)`, where `X` is the pro
 
 == Replication
 
-include::{partialsdir}/replication-introduction.adoc[leveloffset=3]
+include::partial$replication-introduction.adoc[leveloffset=3]
 
 == Compatibility
 
@@ -1078,7 +1080,7 @@ You should now use `ws:`, or `wss:` for SSL/TLS connections.
 In this example the hostname is `10.0.2.2`.
 +
 
-include::{partialsdir}/verify-replication.adoc[]
+include::partial$verify-replication.adoc[]
 
 Couchbase Lite 2.0 uses WebSockets as the communication protocol to transmit data.
 Some load balancers are not configured for WebSocket connections by default (NGINX for example);
@@ -1247,12 +1249,12 @@ The following example increases the log output for activity related to replicati
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=replication-logging,indent=0]
+include::{snippet}[tags=replication-logging,indent=0]
 ----
 
 == Authentication
 
-include::{partialsdir}/authentication.adoc[leveloffset=-1]
+include::partial$authentication.adoc[leveloffset=-1]
 
 == Replication Status
 
@@ -1261,7 +1263,7 @@ For example, when the replication is actively transferring data and when it has 
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=replication-status,indent=0]
+include::{snippet}[tags=replication-status,indent=0]
 ----
 
 The following table lists the different activity levels in the API and the meaning of each one.
@@ -1300,7 +1302,7 @@ The following code snippet adds a `Change Listener`, which monitors a replicatio
 .Monitoring for network errors
 [source]
 ----
-include::{snippet-java-jvm}[tags=replication-error-handling,indent=0]
+include::{snippet}[tags=replication-error-handling,indent=0]
 ----
 
 *For permanent network errors* (for example, `404` not found, or `401` unauthorized):
@@ -1323,42 +1325,42 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 == Replication Events
 
-include::{partialsdir}/replication-events.adoc[leveloffset=-1]
+include::partial$replication-events.adoc[leveloffset=-1]
 
 
 == Custom Headers
 
-include::{partialsdir}/replication-custom-header.adoc[]
+include::partial$replication-custom-header.adoc[]
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=replication-custom-header,indent=0]
+include::{snippet}[tags=replication-custom-header,indent=0]
 ----
 
 == Replication Checkpoint Reset
 
-include::{partialsdir}/replication-checkpoint.adoc[]
+include::partial$replication-checkpoint.adoc[]
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=replication-reset-checkpoint,indent=0]
+include::{snippet}[tags=replication-reset-checkpoint,indent=0]
 ----
 
 == Replication Filters
 
-include::{partialsdir}/replication-filters.adoc[leveloffset=-1]
+include::partial$replication-filters.adoc[leveloffset=-1]
 
 == Handling Conflicts
 
-include::{partialsdir}/handling-conflicts.adoc[]
+include::partial$handling-conflicts.adoc[]
 
 == Database Replicas
 
-include::{partialsdir}/database-replicas.adoc[]
+include::partial$database-replicas.adoc[]
 
 == Certificate Pinning
 
-include::{partialsdir}/certificate-pinning.adoc[]
+include::partial$certificate-pinning.adoc[]
 
 == Peer-to-Peer Sync
 
@@ -1382,23 +1384,23 @@ In Couchbase Lite, a peer can take on one of these two roles:
 
 == Peer Discovery
 
-include::{partialsdir}/p2p-peer-discovery.adoc[leveloffset=-1]
+include::partial$p2p-peer-discovery.adoc[leveloffset=-1]
 
 == Peer Selection and Connection Setup
 
-include::{partialsdir}/p2p-peer-selection.adoc[leveloffset=-1]
+include::partial$p2p-peer-selection.adoc[leveloffset=-1]
 
 == Replication Setup
 
-include::{partialsdir}/p2p-replication-setup.adoc[leveloffset=-1]
+include::partial$p2p-replication-setup.adoc[leveloffset=-1]
 
 == Push/Pull Replication
 
-include::{partialsdir}/p2p-push-pull-repl.adoc[leveloffset=-1]
+include::partial$p2p-push-pull-repl.adoc[leveloffset=-1]
 
 == Connection Teardown
 
-include::{partialsdir}/p2p-connection-teardown.adoc[leveloffset=-1]
+include::partial$p2p-connection-teardown.adoc[leveloffset=-1]
 
 == Thread Safety
 
@@ -1415,8 +1417,6 @@ Additionally, the automatic migration feature does not support encrypted databas
 === Handling of Existing Conflicts
 
 If there are existing conflicts in the 1.x database, the automatic upgrade process copies the default winning revision to the new database and does NOT copy any conflicting revisions.
-This functionality is related to the way conflicts are now being handled in Couchbase Lite (see xref:{source-language}.adoc#handling-conflicts[Handling Conflicts]).
-Optionally, existing conflicts in the 1.x database can be resolved with the xref:1.4@{source-language}.adoc#resolving-conflicts[1.x API] prior to the database being upgraded to 2.x.
 
 === Handling of Existing Attachments
 
@@ -1431,7 +1431,7 @@ The following example shows how to retrieve an attachment that was created in a 
 
 [source]
 ----
-include::{snippet-java-jvm}[tags=1x-attachment,indent=0]
+include::{snippet}[tags=1x-attachment,indent=0]
 ----
 
 == Replication Compatibility
@@ -1564,7 +1564,7 @@ Where <pathToCbl> is the location of the downloaded {cbl} library.
 
 .Sample build gradle
 ----
-include::{snippet-java-jvm}[tags=GsWebAppBuildGradle,indent=0]
+include::{snippet}[tags=GsWebAppBuildGradle,indent=0]
 ----
 
 Back to <<Preparing Your Build Environment>>

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -1,13 +1,14 @@
 = Objective-C
+include::partial$mobAttrCBL.adoc[]
 :idprefix:
 :idseparator: -
-:snippet: {examplesdir}/objc/code-snippets/SampleCodeTest.m
-:source-language: objectivec
-:version: 2.6.0
+:version: 2.7.0
+:snippet: example$objc/code-snippets/SampleCodeTest.m
+:source-language: {langObjc}
 :blank-field: ____
 :url-issues-ios: https://github.com/couchbase/couchbase-lite-ios/issues
 :tabs:
-:url-api-references: http://docs.couchbase.com/mobile/2.7.0/couchbase-lite-objc
+:url-api-references: http://docs.couchbase.com/mobile/{version}/couchbase-lite-{source-language}
 
 include::_attributesLocal.adoc[]
 
@@ -125,7 +126,7 @@ xref:sync-gateway::getting-started.adoc#installation[Installing Sync Gateway ->]
 
 == Couchbase Lite Framework Size
 
-include::{partialsdir}/ios-framework-size.adoc[]
+include::partial$ios-framework-size.adoc[]
 
 == Supported Versions
 
@@ -222,7 +223,7 @@ The Couchbase Lite 2.1 release includes the ability to encrypt Couchbase Lite da
 This allows mobile applications to secure the data at rest, when it is being stored on the device.
 The algorithm used to encrypt the database is 256-bit AES.
 
-include::{partialsdir}/database-encryption.adoc[]
+include::partial$database-encryption.adoc[]
 
 === Finding a Database File
 
@@ -235,21 +236,21 @@ When the application is running on the iOS simulator, you can locate the applica
 You can download and build it from the couchbaselabs https://github.com/couchbaselabs/couchbase-mobile-tools/blob/master/README.cblite.md[GitHub repository].
 Note that the `cblite` tool is not supported by the https://www.couchbase.com/support-policy[Couchbase Support Policy].
 
-=== Logging [DEPRECATED]
-
-CAUTION: The following API is deprecated and superseded by the <<logging,Logging API>> introduced in Couchbase Lite 2.5.
-
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-The following example enables `verbose` logging for the `replicator` and `query` domains.
-
-[source]
-----
-include::{snippet}[tag=logging,indent=0]
-----
-
 === Logging
 
-include::{partialsdir}/logging.adoc[]
+If you are using a Couchbase Lite release prior to 2.5 see <<Logging functionality prior to Release 2.5, Deprecated functionality>>
+
+include::partial$logging.adoc[leveloffset=+2]
+
+==== Logging functionality prior to Release 2.5
+
+include::partial$logging-pre2.5.adoc[]
+
+[source]
+
+----
+include::{snippet}[tags=logging,indent=0]
+----
 
 === Loading a pre-built database
 
@@ -333,7 +334,7 @@ But Couchbase Mobile is a distributed system, and due to the way replication wor
 
 === Document Expiration
 
-include::{partialsdir}/document-expiration.adoc[]
+include::partial$document-expiration.adoc[]
 
 == Blobs
 
@@ -636,15 +637,15 @@ Avignon
 
 === Date/Time Functions
 
-include::{partialsdir}/query/date-time-functions.adoc[]
+include::partial$query/date-time-functions.adoc[]
 
 == Live Query
 
-include::{partialsdir}/live-query.adoc[]
+include::partial$live-query.adoc[]
 
 == Predictive Query
 
-include::{partialsdir}/predictive-query.adoc[]
+include::partial$predictive-query.adoc[]
 
 === Integrate a Model with CoreMLPredictiveModel (iOS only)
 
@@ -792,7 +793,7 @@ In the `OrderBy` array, use a string of the form `Rank(X)`, where `X` is the pro
 
 == Replication
 
-include::{partialsdir}/replication-introduction.adoc[]
+include::partial$replication-introduction.adoc[]
 
 === Compatibility
 
@@ -849,7 +850,7 @@ To keep a reference to the `replicator` object, you can set it as an instance pr
 <2> The URL scheme for remote database URLs has changed in Couchbase Lite 2.0.
 You should now use `ws:`, or `wss:` for SSL/TLS connections.
 
-include::{partialsdir}/verify-replication.adoc[]
+include::partial$verify-replication.adoc[]
 
 Couchbase Lite 2.0 uses WebSockets as the communication protocol to transmit data.
 Some load balancers are not configured for WebSocket connections by default (NGINX for example);
@@ -995,11 +996,11 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 === Replication Events
 
-include::{partialsdir}/replication-events.adoc[]
+include::partial$replication-events.adoc[]
 
 === Custom Headers
 
-include::{partialsdir}/replication-custom-header.adoc[]
+include::partial$replication-custom-header.adoc[]
 
 [source]
 ----
@@ -1008,7 +1009,7 @@ include::{snippet}[tag=replication-custom-header,indent=0]
 
 === Replication Checkpoint Reset
 
-include::{partialsdir}/replication-checkpoint.adoc[]
+include::partial$replication-checkpoint.adoc[]
 
 [source]
 ----
@@ -1017,11 +1018,11 @@ include::{snippet}[tag=replication-reset-checkpoint,indent=0]
 
 === Replication Filters
 
-include::{partialsdir}/replication-filters.adoc[]
+include::partial$replication-filters.adoc[]
 
 == Handling Conflicts
 
-include::{partialsdir}/handling-conflicts.adoc[]
+include::partial$handling-conflicts.adoc[]
 
 == Database Replicas
 
@@ -1038,7 +1039,7 @@ include::{snippet}[tag=database-replica,indent=0]
 
 == Certificate Pinning
 
-include::{partialsdir}/certificate-pinning.adoc[]
+include::partial$certificate-pinning.adoc[]
 
 == Peer-to-Peer Sync
 
@@ -1064,23 +1065,23 @@ Passive Peer:: The passive side reacts to things that it receives but does not i
 
 === Peer Discovery
 
-include::{partialsdir}/p2p-peer-discovery.adoc[]
+include::partial$p2p-peer-discovery.adoc[]
 
 === Peer Selection and Connection Setup
 
-include::{partialsdir}/p2p-peer-selection.adoc[]
+include::partial$p2p-peer-selection.adoc[]
 
 === Replication Setup
 
-include::{partialsdir}/p2p-replication-setup.adoc[]
+include::partial$p2p-replication-setup.adoc[]
 
 === Push/Pull Replication
 
-include::{partialsdir}/p2p-push-pull-repl.adoc[]
+include::partial$p2p-push-pull-repl.adoc[]
 
 === Connection Teardown
 
-include::{partialsdir}/p2p-connection-teardown.adoc[]
+include::partial$p2p-connection-teardown.adoc[]
 
 == Thread Safety
 

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -5,7 +5,7 @@ include::_attributesLocal.adoc[]
 :idseparator: -
 :snippet: {examplesdir}/swift/code-snippets/SampleCodeTest.swift
 :source-language: swift
-// :version: 2.6.0
+:version: 2.7.0
 :blank-field: ____
 :url-issues-ios: https://github.com/couchbase/couchbase-lite-ios/issues
 :tabs:
@@ -132,7 +132,7 @@ xref:sync-gateway::getting-started.adoc#installation[Installing Sync Gateway ->]
 
 == Couchbase Lite Framework Size
 
-include::{partialsdir}/ios-framework-size.adoc[]
+include::partial$ios-framework-size.adoc[]
 
 == Supported Versions
 
@@ -228,7 +228,7 @@ The Couchbase Lite 2.1 release includes the ability to encrypt Couchbase Lite da
 This allows mobile applications to secure the data at rest, when it is being stored on the device.
 The algorithm used to encrypt the database is 256-bit AES.
 
-include::{partialsdir}/database-encryption.adoc[]
+include::partial$database-encryption.adoc[]
 
 === Finding a Database File
 
@@ -241,21 +241,21 @@ When the application is running on the iOS simulator, you can locate the applica
 You can download and build it from the couchbaselabs https://github.com/couchbaselabs/couchbase-mobile-tools/blob/master/README.cblite.md[GitHub repository].
 Note that the `cblite` tool is not supported by the https://www.couchbase.com/support-policy[Couchbase Support Policy].
 
-=== Logging [DEPRECATED]
-
-CAUTION: The following API is deprecated and superseded by the <<logging,Logging API>> introduced in Couchbase Lite 2.5.
-
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-The following example enables `verbose` logging for the `replicator` and `query` domains.
-
-[source]
-----
-include::{snippet}[tag=logging,indent=0]
-----
-
 === Logging
 
-include::{partialsdir}/logging.adoc[]
+If you are using a Couchbase Lite release prior to 2.5 see <<Logging functionality prior to Release 2.5, Deprecated functionality>>
+
+include::partial$logging.adoc[leveloffset=+2]
+
+==== Logging functionality prior to Release 2.5
+
+include::partial$logging-pre2.5.adoc[]
+
+[source, {source-language}]
+
+----
+include::{snippet}[tags=logging,indent=0]
+----
 
 === Loading a pre-built database
 
@@ -357,7 +357,7 @@ include::{snippet}[tag=document-listener,indent=0]
 
 === Document Expiration
 
-include::{partialsdir}/document-expiration.adoc[]
+include::partial$document-expiration.adoc[]
 
 == Blobs
 
@@ -660,15 +660,15 @@ Avignon
 
 === Date/Time Functions
 
-include::{partialsdir}/query/date-time-functions.adoc[]
+include::partial$query/date-time-functions.adoc[]
 
 == Live Query
 
-include::{partialsdir}/live-query.adoc[]
+include::partial$live-query.adoc[]
 
 == Predictive Query
 
-include::{partialsdir}/predictive-query.adoc[]
+include::partial$predictive-query.adoc[]
 
 === Integrate a Model with CoreMLPredictiveModel (iOS only)
 
@@ -816,7 +816,7 @@ In the `OrderBy` array, use a string of the form `Rank(X)`, where `X` is the pro
 
 == Replication
 
-include::{partialsdir}/replication-introduction.adoc[]
+include::partial$replication-introduction.adoc[]
 
 === Compatibility
 
@@ -868,7 +868,7 @@ To keep a reference to the `replicator` object, you can set it as an instance pr
 <2> The URL scheme for remote database URLs has changed in Couchbase Lite 2.0.
 You should now use `ws:`, or `wss:` for SSL/TLS connections.
 
-include::{partialsdir}/verify-replication.adoc[]
+include::partial$verify-replication.adoc[]
 
 Couchbase Lite 2.0 uses WebSockets as the communication protocol to transmit data.
 Some load balancers are not configured for WebSocket connections by default (NGINX for example);
@@ -906,7 +906,7 @@ include::{snippet}[tag=replication-logging,indent=0]
 
 === Authentication
 
-include::{partialsdir}/authentication.adoc[]
+include::partial$authentication.adoc[]
 
 === Replication Status
 
@@ -983,11 +983,11 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 === Replication Events
 
-include::{partialsdir}/replication-events.adoc[]
+include::partial$replication-events.adoc[]
 
 === Custom Headers
 
-include::{partialsdir}/replication-custom-header.adoc[]
+include::partial$replication-custom-header.adoc[]
 
 [source]
 ----
@@ -996,11 +996,11 @@ include::{snippet}[tag=replication-custom-header,indent=0]
 
 === Channels
 
-include::{partialsdir}/replication-channels.adoc[]
+include::partial$replication-channels.adoc[]
 
 === Replication Checkpoint Reset
 
-include::{partialsdir}/replication-checkpoint.adoc[]
+include::partial$replication-checkpoint.adoc[]
 
 [source]
 ----
@@ -1009,19 +1009,19 @@ include::{snippet}[tag=replication-reset-checkpoint,indent=0]
 
 === Replication Filters
 
-include::{partialsdir}/replication-filters.adoc[]
+include::partial$replication-filters.adoc[]
 
 == Handling Conflicts
 
-include::{partialsdir}/handling-conflicts.adoc[]
+include::partial$handling-conflicts.adoc[]
 
 == Database Replicas
 
-include::{partialsdir}/database-replicas.adoc[]
+include::partial$database-replicas.adoc[]
 
 == Certificate Pinning
 
-include::{partialsdir}/certificate-pinning.adoc[]
+include::partial$certificate-pinning.adoc[]
 
 == Peer-to-Peer Sync
 
@@ -1049,23 +1049,23 @@ The passive side reacts to things that it receives but does not initiate any com
 
 === Peer Discovery
 
-include::{partialsdir}/p2p-peer-discovery.adoc[]
+include::partial$p2p-peer-discovery.adoc[]
 
 === Peer Selection and Connection Setup
 
-include::{partialsdir}/p2p-peer-selection.adoc[]
+include::partial$p2p-peer-selection.adoc[]
 
 === Replication Setup
 
-include::{partialsdir}/p2p-replication-setup.adoc[]
+include::partial$p2p-replication-setup.adoc[]
 
 === Push/Pull Replication
 
-include::{partialsdir}/p2p-push-pull-repl.adoc[]
+include::partial$p2p-push-pull-repl.adoc[]
 
 === Connection Teardown
 
-include::{partialsdir}/p2p-connection-teardown.adoc[]
+include::partial$p2p-connection-teardown.adoc[]
 
 == Thread Safety
 


### PR DESCRIPTION
    DOC-6164-Hyperlink-for-CBL-Log
    
   [ https://issues.couchbase.com/browse/DOC-6164]( https://issues.couchbase.com/browse/DOC-6164)
   
    1. Point the hyperlink  to the correct github repository for cbl-log tool.
    2. Pull the common code into partial$logging.adoc and add to each language page
    3. Normalise the use of partial$ in place of _partials or {partialsdir}
    4. Normalise the use of example$ in place of {exampledir} and set {snippets} attribute appropriately