### PR TITLE
DOC-6211 Document Log Redaction for Couchbase Lite (for 2.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+.DS_store
+.gitignore
+0

--- a/modules/ROOT/pages/_partials/feature-LogRedaction-2.0.2.adoc
+++ b/modules/ROOT/pages/_partials/feature-LogRedaction-2.0.2.adoc
@@ -1,0 +1,7 @@
+*New Feature -- Log redaction*
+
+This release adds out-of-the-box support for the redaction of sensitive information in Couchbase Lite logs.
+The redaction requires no configuration.
+It will operate whenever logging is enabled.
+
+For more on adjusting the logging-levels see <<logging,Logging>>

--- a/modules/ROOT/pages/_partials/feature-Logging.adoc
+++ b/modules/ROOT/pages/_partials/feature-Logging.adoc
@@ -1,0 +1,52 @@
+// Begin Block - feature-Logging
+//
+// Begin Required Attributes
+// :snippet:
+// :source-language:
+// :url-apiref-setloglevels:
+// :url-apiref-enumLoglevels:
+// :url-apiref-enumLogDomain:
+// End Required Attributes
+
+// Begin text block
+Couchbase Lite's logging strategy provides for the redaction of sensitive information in CBL logs.
+This redaction requires no configuration.
+It will operate whenever logging is enabled -- that is when `LogLevel` is not `None`.
+
+The log messages are split into different domains (`LogDomains`). Each log domain's logging level can be set independently of any other domain's logging level.
+
+// Begin link to api for appropriate SDK, but only if ANY urls are defined
+ifdef::url-apiref-enumLogLevel,url-apiref-enumLogDomain,url-apiref-setloglevels[]
+For more on logging configuration, see:
+
+// Include a link only if the specific url is defined
+ifdef::url-apiref-setloglevels[]
+* link:{url-apiref-setloglevels}[Set Log Level, window=_blank]
+endif::url-apiref-setloglevels[]
+ifdef::url-apiref-enumLogLevel[]
+* link:{url-apiref-enumLogLevel}[Log Level Enum, window=_blank]
+endif::url-apiref-enumLogLevel[]
+ifdef::url-apiref-enumLogDomain[]
+* link:{url-apiref-enumLogDomain}[Set Log Domain, window=_blank]
+endif::url-apiref-enumLogDomain[]
+
+endif::url-apiref-enumLogLevel,url-apiref-enumLogDomain,url-apiref-setloglevels[]
+// End link to api for appropriate SDK only if that url is defined
+
+// Begin Include a snippet only if that attribute is defined
+ifdef::snippet[]
+The example code snippet below sets the logging level to `verbose` for both the `replicator`, and `query` domains.
+
+[source, {source-language}]
+
+----
+include::{snippet}[tag=logging,indent=0]
+----
+
+endif::snippet[]
+// End Include a snippet only if that attribute is defined
+
+// End text block
+
+
+// End Block - feature-Logging

--- a/modules/ROOT/pages/csharp.adoc
+++ b/modules/ROOT/pages/csharp.adoc
@@ -1,10 +1,21 @@
 = C#
 :idprefix:
 :idseparator: -
-:snippet: {examplesdir}/csharp/Program.cs
-:source-language: csharp
 :blank-field: ____
+:release: 2.1
+:patch: 5
+:version-full: {release}.0
+:this-version: {release}.{patch}
+:couchbase-lite-name: couchbase-lite-net
 :url-issues-net: https://github.com/couchbase/couchbase-lite-net/issues
+:url-api-references: http://docs.couchbase.com/mobile/2.1/couchbase-lite-net
+// Begin define attributes used in INCLUDEs
+:snippet: example$csharp/Program.cs
+:source-language: csharp
+:url-apiref-setloglevels: {url-api-references}/html/M_Couchbase_Lite_Database_SetLogLevel.htm
+:url-apiref-enumLogLevel: {url-api-references}/html/T_Couchbase_Lite_Logging_LogLevel.htm
+:url-apiref-enumLogDomain: {url-api-references}/html/T_Couchbase_Lite_Logging_LogDomain.htm
+// End define attributes used in INCLUDEs
 
 == Getting Started
 
@@ -184,7 +195,7 @@ The Couchbase Lite 2.1 release includes the ability to encrypt Couchbase Lite da
 This allows mobile applications to secure the data at rest, when it is being stored on the device.
 The algorithm used to encrypt the database is 256-bit AES.
 
-include::{partialsdir}/database-encryption.adoc[]
+include::partial$database-encryption.adoc[]
 
 === Finding a Database File
 
@@ -206,13 +217,7 @@ Note that the `cblite` tool is not supported by the https://www.couchbase.com/su
 
 === Logging
 
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-The following example enables `Verbose` logging for the `Replicator` and `Query` domains.
-
-[source]
-----
-include::{snippet}[tag=logging,indent=0]
-----
+include::partial$feature-Logging.adoc[]
 
 === Loading a pre-built database
 
@@ -757,7 +762,7 @@ In the `OrderBy` array, use a string of the form `Rank(X)`, where `X` is the pro
 
 == Replication
 
-include::{partialsdir}/replication-introduction.adoc[]
+include::partial$replication-introduction.adoc[]
 
 === Compatibility
 
@@ -814,7 +819,7 @@ To keep a reference to the `replicator` object, you can set it as an instance pr
 <2> The URL scheme for remote database URLs has changed in Couchbase Lite 2.0.
 You should now use `ws:`, or `wss:` for SSL/TLS connections.
 
-include::{partialsdir}/verify-replication.adoc[]
+include::partial$verify-replication.adoc[]
 
 Couchbase Lite 2.0 uses WebSockets as the communication protocol to transmit data.
 Some load balancers are not configured for WebSocket connections by default (NGINX for example);
@@ -946,7 +951,7 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 === Custom Headers
 
-include::{partialsdir}/replication-custom-header.adoc[]
+include::partial$replication-custom-header.adoc[]
 
 [source]
 ----
@@ -955,7 +960,7 @@ include::{snippet}[tag=replication-custom-header,indent=0]
 
 === Replication Checkpoint Reset
 
-include::{partialsdir}/replication-checkpoint.adoc[]
+include::partial$replication-checkpoint.adoc[]
 
 [source]
 ----
@@ -964,7 +969,7 @@ include::{snippet}[tag=replication-reset-checkpoint,indent=0]
 
 == Handling Conflicts
 
-include::{partialsdir}/handling-conflicts.adoc[]
+include::partial$handling-conflicts.adoc[]
 
 == Database Replicas
 
@@ -1027,23 +1032,23 @@ The passive side reacts to things that it receives but does not initiate any com
 
 === Peer Discovery
 
-include::{partialsdir}/p2p-peer-discovery.adoc[]
+include::partial$p2p-peer-discovery.adoc[]
 
 === Peer Selection and Connection Setup
 
-include::{partialsdir}/p2p-peer-selection.adoc[]
+include::partial$p2p-peer-selection.adoc[]
 
 === Replication Setup
 
-include::{partialsdir}/p2p-replication-setup.adoc[]
+include::partial$p2p-replication-setup.adoc[]
 
 === Push/Pull Replication
 
-include::{partialsdir}/p2p-push-pull-repl.adoc[]
+include::partial$p2p-push-pull-repl.adoc[]
 
 === Connection Teardown
 
-include::{partialsdir}/p2p-connection-teardown.adoc[]
+include::partial$p2p-connection-teardown.adoc[]
 
 == Thread Safety
 
@@ -1090,7 +1095,7 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when <<logging,logging is enabled>>.
+include::partial$feature-LogRedaction-2.0.2.adoc[]
 
 === 2.0 release notes
 

--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -1,12 +1,23 @@
 = Java
 :idprefix:
 :idseparator: -
-:snippet: {examplesdir}/java/app/src/main/java/com/couchbase/code_snippets/MainActivity.java
-:ziputils: {examplesdir}/java/app/src/main/java/com/couchbase/code_snippets/ZipUtils.java
-:source-language: java
-:version: 2.1.2
 :blank-field: ____
-:url-issues-java: https://github.com/couchbase/couchbase-lite-android/issues
+:release: 2.1
+:patch: 2
+:version-full: {release}.0
+:this-version: {release}.{patch}
+:couchbase-lite-name: couchbase-lite-android
+:url-api-references: https://docs.couchbase.com/mobile/2.1.2/couchbase-lite-java
+// Begin define attributes used in INCLUDEs
+:snippet: example$java/app/src/main/java/com/couchbase/code_snippets/MainActivity.java
+:ziputils: example$java/app/src/main/java/com/couchbase/code_snippets/ZipUtils.java
+:source-language: java
+:url-issues-java: https://github.com/couchbase/{couchbase-lite-name}/issues
+:url-apiref-setloglevels: {url-api-references}/index.html?com/couchbase/lite/Database.html#setLogLevel-com.couchbase.lite.LogDomain-com.couchbase.lite.LogLevel-
+:url-apiref-enumLogLevel: {url-api-references}/index.html?com/couchbase/lite/LogLevel.html
+:url-apiref-enumLogDomain: {url-api-references}/index.html?com/couchbase/lite/LogDomain.html
+// End define attributes used in INCLUDEs
+
 
 WARNING: Currently, Couchbase Lite 2.0 is available for Android only.
 The SDK cannot be used in Java applications.
@@ -165,7 +176,7 @@ The Couchbase Lite 2.1 release includes the ability to encrypt Couchbase Lite da
 This allows mobile applications to secure the data at rest, when it is being stored on the device.
 The algorithm used to encrypt the database is 256-bit AES.
 
-include::{partialsdir}/database-encryption.adoc[]
+include::partial$database-encryption.adoc[]
 
 === Finding a Database File
 
@@ -197,13 +208,7 @@ Note that the `cblite` tool is not supported by the https://www.couchbase.com/su
 
 === Logging
 
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-The following example enables `verbose` logging for the `replicator` and `query` domains.
-
-[source]
-----
-include::{snippet}[tag=logging,indent=0]
-----
+include::partial$feature-Logging.adoc[]
 
 === Loading a pre-built database
 
@@ -573,7 +578,7 @@ Avignon
 
 == Live Query
 
-include::{partialsdir}/live-query.adoc[]
+include::partial$live-query.adoc[]
 
 == Indexing
 
@@ -708,7 +713,7 @@ In the `OrderBy` array, use a string of the form `Rank(X)`, where `X` is the pro
 
 == Replication
 
-include::{partialsdir}/replication-introduction.adoc[]
+include::partial$replication-introduction.adoc[]
 
 === Compatibility
 
@@ -769,7 +774,7 @@ In this example the hostname is `10.0.2.2` because the Android emulator runs in 
 NOTE: As of Android Pie, version 9, API 28, cleartext support is disabled, by default.
 Although `wss:` protocol URLs are not affected, in order to use the `ws:` protocol, applications must target API 27 or lower, or must configure application network security as described https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted[here].
 
-include::{partialsdir}/verify-replication.adoc[]
+include::partial$verify-replication.adoc[]
 
 Couchbase Lite 2.0 uses WebSockets as the communication protocol to transmit data.
 Some load balancers are not configured for WebSocket connections by default (NGINX for example);
@@ -795,7 +800,7 @@ include::{snippet}[tag=replication-logging,indent=0]
 
 === Authentication
 
-include::{partialsdir}/authentication.adoc[]
+include::partial$authentication.adoc[]
 
 === Replication Status
 
@@ -858,7 +863,7 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 === Custom Headers
 
-include::{partialsdir}/replication-custom-header.adoc[]
+include::partial$replication-custom-header.adoc[]
 
 [source]
 ----
@@ -867,7 +872,7 @@ include::{snippet}[tag=replication-custom-header,indent=0]
 
 === Replication Checkpoint Reset
 
-include::{partialsdir}/replication-checkpoint.adoc[]
+include::partial$replication-checkpoint.adoc[]
 
 [source]
 ----
@@ -876,11 +881,11 @@ include::{snippet}[tag=replication-reset-checkpoint,indent=0]
 
 == Handling Conflicts
 
-include::{partialsdir}/handling-conflicts.adoc[]
+include::partial$handling-conflicts.adoc[]
 
 == Database Replicas
 
-include::{partialsdir}/database-replicas.adoc[]
+include::partial$database-replicas.adoc[]
 
 == Certificate Pinning
 
@@ -928,23 +933,23 @@ In Couchbase Lite, a peer can take on one of these two roles:
 
 === Peer Discovery
 
-include::{partialsdir}/p2p-peer-discovery.adoc[]
+include::partial$p2p-peer-discovery.adoc[]
 
 === Peer Selection and Connection Setup
 
-include::{partialsdir}/p2p-peer-selection.adoc[]
+include::partial$p2p-peer-selection.adoc[]
 
 === Replication Setup
 
-include::{partialsdir}/p2p-replication-setup.adoc[]
+include::partial$p2p-replication-setup.adoc[]
 
 === Push/Pull Replication
 
-include::{partialsdir}/p2p-push-pull-repl.adoc[]
+include::partial$p2p-push-pull-repl.adoc[]
 
 === Connection Teardown
 
-include::{partialsdir}/p2p-connection-teardown.adoc[]
+include::partial$p2p-connection-teardown.adoc[]
 
 == Thread Safety
 
@@ -987,7 +992,7 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when <<Logging,logging is enabled>>.
+include::partial$feature-LogRedaction-2.0.2.adoc[]
 
 === 2.0.0
 

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -1,12 +1,23 @@
 = Objective-C
 :idprefix:
 :idseparator: -
-:snippet: {examplesdir}/objc/code-snippets/SampleCodeTest.m
-:source-language: objectivec
-:version: 2.1.6
 :blank-field: ____
-:url-issues-ios: https://github.com/couchbase/couchbase-lite-ios/issues
+:release: 2.1
+:patch: 5
+:version-full: {release}.0
+:this-version: {release}.{patch}
+:couchbase-lite-name: couchbase-lite-objc
+:url-api-references: http://docs.couchbase.com/mobile/2.1/couchbase-lite-objc
 :tabs:
+// Begin define attributes used in INCLUDEs
+:snippet: example$objc/code-snippets/SampleCodeTest.m
+:source-language: objc
+:url-issues-ios: https://github.com/couchbase/couchbase-lite-ios/issues
+:url-apiref-setloglevels: {url-api-references}/Classes/CBLDatabase.html#/c:objc(cs)CBLDatabase(cm)setLogLevel:domain:
+:url-apiref-enumLogLevel: {url-api-references}/Enums/CBLLogLevel.html
+:url-apiref-enumLogDomain: {url-api-references}/Enums/CBLLogDomain.html
+// End define attributes used in INCLUDEs
+
 
 == Getting Started
 
@@ -40,13 +51,13 @@ Carthage::
 .Couchbase Lite Community Edition
 [source,ruby,subs=attributes+]
 ----
-binary "https://packages.couchbase.com/releases/couchbase-lite-ios/carthage/CouchbaseLite-Community.json" ~> {version}
+binary "https://packages.couchbase.com/releases/couchbase-lite-ios/carthage/CouchbaseLite-Community.json" ~> {version-full}
 ----
 +
 .Couchbase Lite Enterprise Edition
 [source,ruby,subs=attributes+]
 ----
-binary "https://packages.couchbase.com/releases/couchbase-lite-ios/carthage/CouchbaseLite-Enterprise.json" ~> {version}
+binary "https://packages.couchbase.com/releases/couchbase-lite-ios/carthage/CouchbaseLite-Enterprise.json" ~> {version-full}
 ----
 
 . Run `carthage update --platform ios`.
@@ -65,7 +76,7 @@ CocoaPods::
 ----
 target '<your target name>' do
   use_frameworks!
-  pod 'CouchbaseLite', '~> {version}'
+  pod 'CouchbaseLite', '~> {version-full}'
 end
 ----
 +
@@ -74,7 +85,7 @@ end
 ----
 target '<your target name>' do
   use_frameworks!
-  pod 'CouchbaseLite-Enterprise', '~> {version}'
+  pod 'CouchbaseLite-Enterprise', '~> {version-full}'
 end
 ----
 
@@ -122,7 +133,7 @@ xref:sync-gateway::getting-started.adoc#installation[Installing Sync Gateway ->]
 
 == Couchbase Lite Framework Size
 
-include::{partialsdir}/ios-framework-size.adoc[]
+include::partial$ios-framework-size.adoc[]
 
 == Supported Versions
 
@@ -213,7 +224,7 @@ The Couchbase Lite 2.1 release includes the ability to encrypt Couchbase Lite da
 This allows mobile applications to secure the data at rest, when it is being stored on the device.
 The algorithm used to encrypt the database is 128-bit AES.
 
-include::{partialsdir}/database-encryption.adoc[]
+include::partial$database-encryption.adoc[]
 
 === Finding a Database File
 
@@ -228,13 +239,7 @@ Note that the `cblite` tool is not supported by the https://www.couchbase.com/su
 
 === Logging
 
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-The following example enables `verbose` logging for the `replicator` and `query` domains.
-
-[source]
-----
-include::{snippet}[tag=logging,indent=0]
-----
+include::partial$feature-Logging.adoc[]
 
 === Loading a pre-built database
 
@@ -754,7 +759,7 @@ In the `OrderBy` array, use a string of the form `Rank(X)`, where `X` is the pro
 
 == Replication
 
-include::{partialsdir}/replication-introduction.adoc[]
+include::partial$replication-introduction.adoc[]
 
 === Compatibility
 
@@ -811,7 +816,7 @@ To keep a reference to the `replicator` object, you can set it as an instance pr
 <2> The URL scheme for remote database URLs has changed in Couchbase Lite 2.0.
 You should now use `ws:`, or `wss:` for SSL/TLS connections.
 
-include::{partialsdir}/verify-replication.adoc[]
+include::partial$verify-replication.adoc[]
 
 Couchbase Lite 2.0 uses WebSockets as the communication protocol to transmit data.
 Some load balancers are not configured for WebSocket connections by default (NGINX for example);
@@ -943,7 +948,7 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 === Custom Headers
 
-include::{partialsdir}/replication-custom-header.adoc[]
+include::partial$replication-custom-header.adoc[]
 
 [source]
 ----
@@ -952,7 +957,7 @@ include::{snippet}[tag=replication-custom-header,indent=0]
 
 === Replication Checkpoint Reset
 
-include::{partialsdir}/replication-checkpoint.adoc[]
+include::partial$replication-checkpoint.adoc[]
 
 [source]
 ----
@@ -961,7 +966,7 @@ include::{snippet}[tag=replication-reset-checkpoint,indent=0]
 
 == Handling Conflicts
 
-include::{partialsdir}/handling-conflicts.adoc[]
+include::partial$handling-conflicts.adoc[]
 
 == Database Replicas
 
@@ -1021,23 +1026,23 @@ Passive Peer:: The passive side reacts to things that it receives but does not i
 
 === Peer Discovery
 
-include::{partialsdir}/p2p-peer-discovery.adoc[]
+include::partial$p2p-peer-discovery.adoc[]
 
 === Peer Selection and Connection Setup
 
-include::{partialsdir}/p2p-peer-selection.adoc[]
+include::partial$p2p-peer-selection.adoc[]
 
 === Replication Setup
 
-include::{partialsdir}/p2p-replication-setup.adoc[]
+include::partial$p2p-replication-setup.adoc[]
 
 === Push/Pull Replication
 
-include::{partialsdir}/p2p-push-pull-repl.adoc[]
+include::partial$p2p-push-pull-repl.adoc[]
 
 === Connection Teardown
 
-include::{partialsdir}/p2p-connection-teardown.adoc[]
+include::partial$p2p-connection-teardown.adoc[]
 
 == Thread Safety
 
@@ -1081,7 +1086,7 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when <<logging,logging is enabled>>.
+include::partial$feature-LogRedaction-2.0.2.adoc[]
 
 === 2.0.0
 

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -1,12 +1,20 @@
 = Swift
-:idprefix:
-:idseparator: -
-:snippet: {examplesdir}/swift/code-snippets/SampleCodeTest.swift
-:source-language: swift
-:version: 2.1.6
 :blank-field: ____
-:url-issues-ios: https://github.com/couchbase/couchbase-lite-ios/issues
+:release: 2.1
+:patch: 6
+:version-full: {release}.0
+:this-version: {release}.{patch}
+:couchbase-lite-name: couchbase-lite-swift
+:url-api-references: http://docs.couchbase.com/mobile/2.1/couchbase-lite-swift
 :tabs:
+// Begin define attributes used in INCLUDEs
+:snippet: example$swift/code-snippets/SampleCodeTest.swift
+:source-language: swift
+:url-issues-ios: https://github.com/couchbase/couchbase-lite-ios/issues
+:url-apiref-setloglevels: {url-api-references}/Classes/Database.html#/s:18CouchbaseLiteSwift8DatabaseC11setLogLevelyAA0fG0O_AA0F6DomainO6domaintFZ
+:url-apiref-enumLogLevel: {url-api-references}/Enums/LogLevel.html
+:url-apiref-enumLogDomain: {url-api-references}/Enums/LogDomain.html
+// End define attributes used in INCLUDEs
 
 == Getting Started
 
@@ -126,7 +134,7 @@ xref:sync-gateway::getting-started.adoc#installation[Installing Sync Gateway ->]
 
 == Couchbase Lite Framework Size
 
-include::{partialsdir}/ios-framework-size.adoc[]
+include::partial$ios-framework-size.adoc[]
 
 == Supported Versions
 
@@ -218,7 +226,7 @@ The Couchbase Lite 2.1 release includes the ability to encrypt Couchbase Lite da
 This allows mobile applications to secure the data at rest, when it is being stored on the device.
 The algorithm used to encrypt the database is 128-bit AES.
 
-include::{partialsdir}/database-encryption.adoc[]
+include::partial$database-encryption.adoc[]
 
 === Finding a Database File
 
@@ -233,13 +241,7 @@ Note that the `cblite` tool is not supported by the https://www.couchbase.com/su
 
 === Logging
 
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-The following example enables `verbose` logging for the `replicator` and `query` domains.
-
-[source]
-----
-include::{snippet}[tag=logging,indent=0]
-----
+include::partial$feature-Logging.adoc[]
 
 === Loading a pre-built database
 
@@ -624,7 +626,7 @@ Avignon
 
 == Live Query
 
-include::{partialsdir}/live-query.adoc[]
+include::partial$live-query.adoc[]
 
 == Indexing
 
@@ -759,7 +761,7 @@ In the `OrderBy` array, use a string of the form `Rank(X)`, where `X` is the pro
 
 == Replication
 
-include::{partialsdir}/replication-introduction.adoc[]
+include::partial$replication-introduction.adoc[]
 
 === Compatibility
 
@@ -811,7 +813,7 @@ To keep a reference to the `replicator` object, you can set it as an instance pr
 <2> The URL scheme for remote database URLs has changed in Couchbase Lite 2.0.
 You should now use `ws:`, or `wss:` for SSL/TLS connections.
 
-include::{partialsdir}/verify-replication.adoc[]
+include::partial$verify-replication.adoc[]
 
 Couchbase Lite 2.0 uses WebSockets as the communication protocol to transmit data.
 Some load balancers are not configured for WebSocket connections by default (NGINX for example);
@@ -837,7 +839,7 @@ include::{snippet}[tag=replication-logging,indent=0]
 
 === Authentication
 
-include::{partialsdir}/authentication.adoc[]
+include::partial$authentication.adoc[]
 
 === Replication Status
 
@@ -900,7 +902,7 @@ The following error codes are considered temporary by the Couchbase Lite replica
 
 === Custom Headers
 
-include::{partialsdir}/replication-custom-header.adoc[]
+include::partial$replication-custom-header.adoc[]
 
 [source]
 ----
@@ -909,7 +911,7 @@ include::{snippet}[tag=replication-custom-header,indent=0]
 
 === Replication Checkpoint Reset
 
-include::{partialsdir}/replication-checkpoint.adoc[]
+include::partial$replication-checkpoint.adoc[]
 
 [source]
 ----
@@ -918,11 +920,11 @@ include::{snippet}[tag=replication-reset-checkpoint,indent=0]
 
 == Handling Conflicts
 
-include::{partialsdir}/handling-conflicts.adoc[]
+include::partial$handling-conflicts.adoc[]
 
 == Database Replicas
 
-include::{partialsdir}/database-replicas.adoc[]
+include::partial$database-replicas.adoc[]
 
 == Certificate Pinning
 
@@ -971,23 +973,23 @@ The passive side reacts to things that it receives but does not initiate any com
 
 === Peer Discovery
 
-include::{partialsdir}/p2p-peer-discovery.adoc[]
+include::partial$p2p-peer-discovery.adoc[]
 
 === Peer Selection and Connection Setup
 
-include::{partialsdir}/p2p-peer-selection.adoc[]
+include::partial$p2p-peer-selection.adoc[]
 
 === Replication Setup
 
-include::{partialsdir}/p2p-replication-setup.adoc[]
+include::partial$p2p-replication-setup.adoc[]
 
 === Push/Pull Replication
 
-include::{partialsdir}/p2p-push-pull-repl.adoc[]
+include::partial$p2p-push-pull-repl.adoc[]
 
 === Connection Teardown
 
-include::{partialsdir}/p2p-connection-teardown.adoc[]
+include::partial$p2p-connection-teardown.adoc[]
 
 == Thread Safety
 
@@ -1046,11 +1048,12 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 === 2.0.3
 
-* This release adds compatibility for Swift 4.1.2 (as part of Xcode 9.4).
+.New Feature -- Swift Compatibility
+This release adds compatibility for Swift 4.1.2 (as part of Xcode 9.4).
 
 === 2.0.2
 
-* Support for Log redaction of sensitive information when <<logging,logging is enabled>>.
+include::partial$feature-LogRedaction-2.0.2.adoc[]
 
 === 2.0.0
 


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6211

- Add release notes log-redaction message
- Create (shared) logging topics, including links into API and log redaction.
- Rationalize use of partial$ and example$ in includes
- Tidy-up use of attributes in affected pages