### PR TITLE
DOC-6164-Hyperlink-for-cbl-log-Backport-to2.6

### DIFF
--- a/modules/ROOT/pages/_partials/logging.adoc
+++ b/modules/ROOT/pages/_partials/logging.adoc
@@ -17,7 +17,7 @@ It is the default configuration for file based logging.
 +
 It is recommended that you use binary log format.
 However, in order to view the binary encoded log files, you will need a decoder.
-To decode the binary logs, there is a binary log decoder called the *cbl-log* which is a tool downloadable from xref:#cbl-log[here].
+To decode the binary logs, there is a binary log decoder called the *cbl-log* which is a tool downloadable from link:https://github.com/couchbaselabs/couchbase-mobile-tools/blob/master/README.cbl-log.md[couchbaselabs/couchbase-mobile-tools, window=_blank].
 +
 The following example enables file based logging.
 +


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6164

Back port change 1) (ONLY) from PR#189. That is: Point the hyperlink  to the correct github repository for cbl-log tool.