### PR TITLE
DOC-6157-AutoConflictResolution-Desc-Incorrect-backport-to2.6-2

### DIFF
--- a/modules/ROOT/pages/_partials/handling-conflicts.adoc
+++ b/modules/ROOT/pages/_partials/handling-conflicts.adoc
@@ -1,30 +1,56 @@
-Document conflicts can occur when changes are made to the same version of a document by multiple peers in a distributed system.
-With Couchbase Mobile, this can be a Couchbase Lite or Sync Gateway database instance, and conflicts can occur in the following scenarios:
+// cater for instances where the inclusion's container does not include the attributes
+ifndef::url-cb-blog[]
+include::mobAttrCBL.adoc[]
+endif::url-cb-blog[]
 
-* When a replication is in progress, or
-* When saving a document
+Document conflicts can occur if multiple changes are made to the same version of a document by multiple peers in a distributed system. For Couchbase Mobile, this can be a Couchbase Lite or Sync Gateway database instance.
+
+Such conflicts can occur after either of the following events:
+
+* *A replication saves a document change* -- in which case the change with the _most-revisions wins_ (unless one change is a delete). See the example <<Case 1: Conflicts when a replication is in progress>>
+* *An application saves a document change directly to a database instance* -- in which case, _last write wins_, unless one change is a delete -- see <<Case 2: Conflicts when saving a document>>
+
+NOTE: *_Deletes_ always win.* So, in either of the above cases, if one of the changes was a _Delete_ then that change wins.
 
 The following sections discuss each scenario in more detail.
 
+[TIP]
+.Dive deeper ...
+Read more about link:{url-cb-blog}/document-conflicts-couchbase-mobile[Document Conflicts and Automatic Conflict Resolution in Couchbase Mobile] on {nmCbBlogLink}.
+
 === Case 1: Conflicts when a replication is in progress
 
-There's no practical way to prevent a conflict when two updates to a document are made on different instances of the app.
-Neither app even knows that the other one has changed the document, until later on when replication propagates their incompatible changes to each other.
-A typical scenario is:
+There's no practical way to prevent a conflict when incompatible changes to a document are be made in multiple instances of an app.
+The conflict is realized only when replication propagates the incompatible changes to each other.
+anchor:bmkRepConScene[A typical replication conflict scenario]
 
-. Molly creates DocumentA.
-. DocumentA is synced to Naomi's device.
-. Molly updates DocumentA, let's call it ChangeX for the purpose of this example.
-. Naomi makes a different change to DocumentA, let's call it ChangeY.
-. ChangeY is synced to Molly's device, which already has ChangeX, putting the document in conflict.
-. ChangeX is synced to Naomi's device, which already has ChangeY, similarly putting the local document in conflict.
-
+.A typical replication conflict scenario:
+====
+. Molly uses her device to create _DocumentA_.
+. Replication syncs _DocumentA_ to Naomi's device.
+. Molly uses her device to apply _ChangeX_ to _DocumentA_.
+. Naomi uses her device to make a different change, _ChangeY_, to _DocumentA_.
+. Replication syncs _ChangeY_ to Molly's device.
++
+This device already has _ChangeX_ putting the local document in conflict.
+. Replication syncs _ChangeX_ to Naomi's device.
++
+This device already has _ChangeY_ and now Naomi's local document is in conflict.
+====
 ==== Automatic Conflict Resolution
 
-Couchbase Lite uses the following rules to handle the conflicts occurring in steps 5 and 6.
+NOTE: These rules apply only to conflicts arising from replication.
 
-* A deleted document (i.e tombstone) always wins over a document update.
-* If both changes are document updates, the Last-Write-Win (LWW) algorithm is used to pick the winning update.
+Couchbase Lite uses the following rules to handle conflicts such as those described in <<bmkRepConScene>>:
+
+* If one of the changes is a deletion:
++
+A deleted document (that is, a _tombstone_) always wins over a document update.
+* If both changes are document changes:
++
+The change with the most revisions will win.
++
+Since each change creates a revision with an ID prefixed by an incremented version number, the winner is the change with the highest version number.
 
 The result is saved internally by the Couchbase Lite replicator.
 Those rules describe the internal behavior of the replicator.

--- a/modules/ROOT/pages/_partials/mobAttrCBL.adoc
+++ b/modules/ROOT/pages/_partials/mobAttrCBL.adoc
@@ -1,4 +1,92 @@
-// Common attributes
+// CB Mobile Common Attributes File
+// include:m.m.p@:docs-common::partial$mobAttr.adoc[]
+
+// COMMON ATTRIBUTE DECLARATION
+
+// Product terms
+:sg: Sync Gateway
+:sgTechNm: sync-Gateway
+:cbl: Couchbase Lite
+:cblTechNM: couchbase-Lite
+:cblFrmWk: {cbl} Java Framework
+:svr: Couchbase server
+:svrTechNM: couchbase-Server
+//
+
+// Generic products
+
+:gpWebServerEnv: Tomcat
+:gpBuildTool: gradle
+:gpIDE: Intellij IDEA
+:gpIDEce: gpIDE Community Edition
+:gpIDEee: gpIDE Ultimate Edition
+
+
+// Release Note headings
+:natt: None at this time
+:ke: Known issues
+:fixed: Fixed at this Release
+:enh: Enhancements
+:nftr: New Features
+:api: API Changes
+:more: Read More
+//
+// END OF COMMON ATTRIBUTE DECLARATION
+
+// COMPONENT COMMON ATTRIBUTE DECLARATION
+// Product and Versioning Attributes
+//
+:company: Couchbase
+:product: {cbl}
+:prodTechNm: {cblTechNm}
+
+:major: 2
+:minor: 6
+:patch: 4
+:version: {major}.{minor}
+:version-full: {major}.{minor}.0
+:vrsnLatestRel: {major}.{minor}
+:vrsnLatestRelFull: {version-full}
+:vrsnMaintRelFull: {major}.{minor}.{patch}
+//
+// End Product Versioning attributes
+
+// Component Features
+:ftr_jPlatNm: {product} for Java Platform
+:ftr_jAndNM: {product} for Java Android
+:ftr_SwiftNM: {product} for Swift
+// End of Component Features
+
+
+//  Standard URL Attributes
+//
+
+:snippet-java-android: example$java-android/app/src/main/java/com/couchbase/code_snippets/Examples.java
+:snippet-java-jvm: example$java/src/com/couchbase/code_snippets/Examples.java
+:url-cb-website: https://www.couchbase.com
+:url-issues-java: TBA
+// :url-api-references: Now defined locally in pages
+:url-cb-downloads-all: {url-cb-website}/downloads
+:url-cb-downloads-mobile: {url-cb-downloads-all}?family=mobile
+:url-cb-mobStarterApp: https://github.com/ibsoln/cblGettingStarted.git
+:url-cb-blog: https://blog.couchbase.com
+
+//
+// End Standard URL Attributes
+
+// List styles
+:ordered: [loweralpha]
+:unordered:
+:steps: [arabic]
+:steps2: [lowerroman]
+:steps3: [loweralpha]
+
+
+//
+
+
+
+// misc attributes
 //
 :tabs: tabs
 :idprefix:
@@ -14,4 +102,37 @@
 :url-mobDocs-root: http://docs.couchbase.com/mobile
 :url-mobDownloads-root: https://www.couchbase.com/downloads/?family=mobile
 //
-// End common attributes
+// End misc attributes
+
+// Begin Source Languages
+:langAndroid: android
+:langAndroidFull: java-android
+:langCsharp: csharp
+:langJava: java
+:langJavaFull: java-platform
+:langJavascript: javascript
+:langObjc: objc
+:langObjcFull: objective-c
+:langSwift: swift
+// End Source Languages
+
+
+
+:nmCBdwnlds: Couchbase Downloads
+:nmSampleAppDb: getting-started.cblite2
+// :nmSampleAppDbPath: /resources/getting-started.cblite2
+:nmSampleAppDbPath: /getting-started.cblite2
+:nmMobStarterApp: GettingStarted
+:nmStarterCode: StarterCode1.0
+:nmSampleAppUser: admin
+:nmSampleAppPassword: password
+:nmCbBlogLink: {url-cb-blog}[The Couchbase Blog]
+:nmLangJava: java
+:nmLangJS: javascript
+:nmLangNet: C#/.Net
+:nmLangSwift: Swift
+:nmLangObcJ: Objective-C
+:nmLangAndroid: Android
+
+
+// END OF COMPONENT COMMON ATTRIBUTE DECLARATION

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -1173,6 +1173,9 @@ xref:index.adoc[Read more]
 
 NOTE: Support for MAC OS 10.9 and 10.10 is deprecated in this release. Support will be removed within two (non-maintenance) releases following this  announcement  -- see <<Supported Versions>>.
 
+.macOS Support
+NOTE: MacOS is supported ONLY for testing and development purposes. Support for macOS 10.9 and 10.10 is now deprecated and will cease at Release 2.8. -- see <<supported-versions>>.
+
 *Performance Improvements*
 
 * {url-issues-ios}/168[*#168*]

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -1155,6 +1155,9 @@ Support will be removed within two (non-maintenance) releases following this ann
 +
 xref:index.adoc[Read more]
 
+.macOS Support
+NOTE: MacOS is supported ONLY for testing and development purposes. Support for macOS 10.9 and 10.10 is now deprecated and will cease at Release 2.8. -- see <<supported-versions>>.
+
 *Performance Improvements*
 
 * {url-issues-ios}/168[*#168*]


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6157

- Auto Conflict Resolution description incorrect
- Also reinstate deprecation note in 2.5.0 Release Notes, which was omitted when merging DOC-5618 forward (PR#185) from 2.5-2.6 to 2.7 (March 5th, 2020).