### PR TITLE
DOC-6607-Couchbase-Lite-2-7-1-Release-Notes

### DIFF
--- a/modules/ROOT/pages/csharp.adoc
+++ b/modules/ROOT/pages/csharp.adoc
@@ -1099,6 +1099,7 @@ Note: Support notices remain in force for this maintenance release -- see <<supp
 
 This maintenance release fixes the following issues:
 
+* https://issues.couchbase.com/browse/CBL-849[*CBL-849*] Returning WebProxy null when WINHTTP_PROXY_INFO out as invalid value if that ever happens
 * https://issues.couchbase.com/browse/CBL-789[*CBL-789*] Crash when accessing `connection->name()`
 * https://issues.couchbase.com/browse/CBL-701[*CBL-701*] Pending Document IDs not working correctly
 * https://issues.couchbase.com/browse/CBL-698[*CBL-698*] Wrong query evaluation using expression values instead of expression properties

--- a/modules/ROOT/pages/csharp.adoc
+++ b/modules/ROOT/pages/csharp.adoc
@@ -1091,6 +1091,29 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 == Release Notes
 
+=== 2.7.1
+
+Note: Support notices remain in force for this maintenance release -- see <<support-notices, Support Notices>> below.
+
+==== {fixed}
+
+This maintenance release fixes the following issues:
+
+* https://issues.couchbase.com/browse/CBL-789[*CBL-789*] Crash when accessing `connection->name()`
+* https://issues.couchbase.com/browse/CBL-701[*CBL-701*] Pending Document IDs not working correctly
+* https://issues.couchbase.com/browse/CBL-698[*CBL-698*] Wrong query evaluation using expression values instead of expression properties
+* https://issues.couchbase.com/browse/CBL-657[*CBL-657*] LIKE and CONTAINS are much slower in 2.7
+* https://issues.couchbase.com/browse/CBL-580[*CBL-580*] Native memory leak when save document repeatedly​
+* https://issues.couchbase.com/browse/CBL-579[*CBL-579*] SDK fails for opening Database files over 2GB
+
+==== {ke}
+
+The following issues document known errors:
+
+* https://issues.couchbase.com/browse/CBL-216[*CBL-216*] Ordering null values inconsistent with N1QL expectations
+* https://issues.couchbase.com/browse/CBL-95[*CBL-95*] Pending conflicts could be resolved by a wrong replicator
+* https://issues.couchbase.com/browse/CBL-49[*CBL-49*] Need a way to distinguish boolean types
+
 === 2.7.0
 
 *{nftr}*
@@ -1106,7 +1129,7 @@ xref::index.adoc[{more}]
 - https://issues.couchbase.com/browse/CBL-49[*CBL-49*] Need a way to distinguish boolean types
 
 *{fixed}*
-//
+
 // - https://issues.couchbase.com/browse/CBL-562[*CBL-562*] Can't open existing db read-only; LiteCore test "Database Open Older Encrypted" fails
 // - https://issues.couchbase.com/browse/CBL-550[*CBL-550*] SQLite index creation mistakenly sets user_version backwards
 // - https://issues.couchbase.com/browse/CBL-536[*CBL-536*] Long delay starting replicator, for big databases
@@ -1148,6 +1171,7 @@ xref:index.adoc[{more}]
 
 * Expose the Document Revision ID: the `revisionID` property on a `Document` instance now returns the current revision identifier.
 
+[#support-notices]
 *OS API Support*
 
 Support for Android API 19, API 20 and API 21 on Xamarin is deprecated in this release.

--- a/modules/ROOT/pages/java-android.adoc
+++ b/modules/ROOT/pages/java-android.adoc
@@ -1188,6 +1188,7 @@ Note: Support notices remain in force for this maintenance release -- see <<supp
 
 This maintenance release fixes the following issues:
 
+* https://issues.couchbase.com/browse/CBL-799[*CBL-799*] Crash calling pull validator callback
 * https://issues.couchbase.com/browse/CBL-789[*CBL-789*] Crash when accessing `connection->name()`
 * https://issues.couchbase.com/browse/CBL-701[*CBL-701*] Pending Document IDs not working correctly
 * https://issues.couchbase.com/browse/CBL-698[*CBL-698*] Wrong query evaluation using expression values instead of expression properties

--- a/modules/ROOT/pages/java-android.adoc
+++ b/modules/ROOT/pages/java-android.adoc
@@ -1180,6 +1180,31 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 == Release Notes
 
+=== 2.7.1
+
+Note: Support notices remain in force for this maintenance release -- see <<support-notices, Support Notices>> below.
+
+==== {fixed}
+
+This maintenance release fixes the following issues:
+
+* https://issues.couchbase.com/browse/CBL-789[*CBL-789*] Crash when accessing `connection->name()`
+* https://issues.couchbase.com/browse/CBL-701[*CBL-701*] Pending Document IDs not working correctly
+* https://issues.couchbase.com/browse/CBL-698[*CBL-698*] Wrong query evaluation using expression values instead of expression properties
+* https://issues.couchbase.com/browse/CBL-657[*CBL-657*] LIKE and CONTAINS are much slower in 2.7
+* https://issues.couchbase.com/browse/CBL-581[*CBL-581*] Native memory leak when save document repeatedly​
+* https://issues.couchbase.com/browse/CBL-579[*CBL-579*] SDK fails for opening Database files over 2GB
+
+==== {ke}
+
+The following issues document known errors:
+
+* https://issues.couchbase.com/browse/CBL-608[*CBL-608*] Ordering null values inconsistent with N1QL expectations
+* https://issues.couchbase.com/browse/CBL-370[*CBL-370*] 370	Broken API, Kotlin: Unable to import ReplicatorType
+* https://issues.couchbase.com/browse/CBL-216[*CBL-216*] Ordering null values inconsistent with N1QL expectations
+* https://issues.couchbase.com/browse/CBL-95[*CBL-95*] Pending conflicts could be resolved by a wrong replicator
+* https://issues.couchbase.com/browse/CBL-49[*CBL-49*] Need a way to distinguish boolean types
+
 === 2.7.0
 
 *{nftr}*
@@ -1188,7 +1213,8 @@ New at this release is the Java Platform, which enables development of Java apps
 
 xref::index.adoc[{more}]
 
-*Current Support Notices*
+[#support-notices]
+*Support Notices*
 
 :msg_component: API 19 and 21
 :msg_action:  Please plan to migrate your apps to use API versions greater than API 21

--- a/modules/ROOT/pages/java-platform.adoc
+++ b/modules/ROOT/pages/java-platform.adoc
@@ -1685,6 +1685,7 @@ Back to <<Preparing Your Build Environment>>
 
 This maintenance release fixes the following issues:
 
+* https://issues.couchbase.com/browse/CBL-799[*CBL-799*] Crash calling pull validator callback
 * https://issues.couchbase.com/browse/CBL-789[*CBL-789*] Crash when accessing `connection->name()`
 * https://issues.couchbase.com/browse/CBL-701[*CBL-701*] Pending Document IDs not working correctly
 * https://issues.couchbase.com/browse/CBL-698[*CBL-698*] Wrong query evaluation using expression values instead of expression properties

--- a/modules/ROOT/pages/java-platform.adoc
+++ b/modules/ROOT/pages/java-platform.adoc
@@ -1679,9 +1679,30 @@ Back to <<Preparing Your Build Environment>>
 
 == RELEASE NOTES
 
-=== .
+=== 2.7.1
 
-== 2.7.0
+==== {fixed}
+
+This maintenance release fixes the following issues:
+
+* https://issues.couchbase.com/browse/CBL-789[*CBL-789*] Crash when accessing `connection->name()`
+* https://issues.couchbase.com/browse/CBL-701[*CBL-701*] Pending Document IDs not working correctly
+* https://issues.couchbase.com/browse/CBL-698[*CBL-698*] Wrong query evaluation using expression values instead of expression properties
+* https://issues.couchbase.com/browse/CBL-657[*CBL-657*] LIKE and CONTAINS are much slower in 2.7
+* https://issues.couchbase.com/browse/CBL-581[*CBL-581*] Native memory leak when save document repeatedly​
+* https://issues.couchbase.com/browse/CBL-579[*CBL-579*] SDK fails for opening Database files over 2GB
+
+==== {ke}
+
+The following issues document known errors:
+
+* https://issues.couchbase.com/browse/CBL-647[*CBL-637*] Java Console app doesn't exit
+* https://issues.couchbase.com/browse/CBL-370[*CBL-370*] 370	Broken API, Kotlin: Unable to import ReplicatorType
+* https://issues.couchbase.com/browse/CBL-216[*CBL-216*] Ordering null values inconsistent with N1QL expectations
+* https://issues.couchbase.com/browse/CBL-95[*CBL-95*] Pending conflicts could be resolved by a wrong replicator
+* https://issues.couchbase.com/browse/CBL-49[*CBL-49*] Need a way to distinguish boolean types
+
+=== 2.7.0
 
 *{nftr}*
 

--- a/modules/ROOT/pages/objc.adoc
+++ b/modules/ROOT/pages/objc.adoc
@@ -1101,6 +1101,29 @@ The Couchbase Lite API is thread safe except for calls to mutable objects: `Muta
 
 == Release Notes
 
+=== 2.7.1
+
+Note: Support notices remain in force for this maintenance release -- see <<support-notices, Support Notices>> below.
+
+==== {fixed}
+
+This maintenance release fixes the following issues:
+
+* https://issues.couchbase.com/browse/CBL-789[*CBL-789*] Crash when accessing `connection->name()`
+* https://issues.couchbase.com/browse/CBL-701[*CBL-701*] Pending Document IDs not working correctly
+* https://issues.couchbase.com/browse/CBL-698[*CBL-698*] Wrong query evaluation using expression values instead of expression properties
+* https://issues.couchbase.com/browse/CBL-657[*CBL-657*] LIKE and CONTAINS are much slower in 2.7
+* https://issues.couchbase.com/browse/CBL-582[*CBL-582*] Memory leak of FLDoc
+* https://issues.couchbase.com/browse/CBL-579[*CBL-579*] SDK fails for opening Database files over 2GB
+
+==== {ke}
+
+The following issues document known errors:
+
+* https://issues.couchbase.com/browse/CBL-216[*CBL-216*] Ordering null values inconsistent with N1QL expectations
+* https://issues.couchbase.com/browse/CBL-95[*CBL-95*] Pending conflicts could be resolved by a wrong replicator
+* https://issues.couchbase.com/browse/CBL-49[*CBL-49*] Need a way to distinguish boolean types
+
 === 2.7.0
 
 *{nftr}*
@@ -1109,7 +1132,8 @@ New at this release is the Java Platform, which enables development of Java apps
 
 xref::index.adoc[{more}]
 
-*Current Support Notices*
+[#support-notices]
+*Support Notices*
 
 :msg_level: CAUTION
 :msg_title: Apple Mac OS

--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -1091,6 +1091,29 @@ include::partial$symbolicate-iOS.adoc[leveloffset=2]
 
 == Release Notes
 
+=== 2.7.1
+
+Note: Support notices remain in force for this maintenance release -- see <<support-notices, Support Notices>> below.
+
+==== {fixed}
+
+This maintenance release fixes the following issues:
+
+* https://issues.couchbase.com/browse/CBL-789[*CBL-789*] Crash when accessing `connection->name()`
+* https://issues.couchbase.com/browse/CBL-701[*CBL-701*] Pending Document IDs not working correctly
+* https://issues.couchbase.com/browse/CBL-698[*CBL-698*] Wrong query evaluation using expression values instead of expression properties
+* https://issues.couchbase.com/browse/CBL-657[*CBL-657*] LIKE and CONTAINS are much slower in 2.7
+* https://issues.couchbase.com/browse/CBL-582[*CBL-582*] Memory leak of FLDoc
+* https://issues.couchbase.com/browse/CBL-579[*CBL-579*] SDK fails for opening Database files over 2GB
+
+==== {ke}
+
+The following issues document known errors:
+
+* https://issues.couchbase.com/browse/CBL-216[*CBL-216*] Ordering null values inconsistent with N1QL expectations
+* https://issues.couchbase.com/browse/CBL-95[*CBL-95*] Pending conflicts could be resolved by a wrong replicator
+* https://issues.couchbase.com/browse/CBL-49[*CBL-49*] Need a way to distinguish boolean types
+
 === 2.7.0
 
 *{nftr}*
@@ -1099,7 +1122,8 @@ New at this release is the Java Platform, which enables development of Java apps
 
 xref::index.adoc[{more}]
 
-*Current Support Notices*
+[#support-notices]
+*Support Notices*
 
 :msg_level: CAUTION
 :msg_title: Apple Mac OS


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6607

This epic comprises the following tickets: 

- DOC-6608-Java 2.7.1 Rel Notes - https://issues.couchbase.com/browse/DOC-6608
- DOC-6609-Android 2.7.1 Rel Notes - https://issues.couchbase.com/browse/DOC-6609
- DOC-6610-Net 2.7.1 Rel Notes - https://issues.couchbase.com/browse/DOC-6610
- DOC-6611-ObjC 2.7.1 Rel Notes - https://issues.couchbase.com/browse/DOC-6611
- DOC-6612-Swift 2.7.1 Rel Notes - https://issues.couchbase.com/browse/DOC-6612