### PR TITLE
DOC-6777 Add Xcode compatibility to Swift docs

### DIFF
--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -146,6 +146,60 @@ NOTE: Support for iOS 9.0 is deprecated in this release. Support will be removed
 
 NOTE: Support for MAC OS 10.9 and 10.10 was deprecated in release 2.5. Support will be removed within two (non-maintenance) releases following that deprecation announcement.
 
+=== Compiler Support Matrix
+The table below shows the compatibility of Xcode / Swift compiler versions with Couchbase Lite versions.
+Build your Couchbase Lite apps using the Xcode version(s) corresponding to your Couchbase Lite version.
+
+// |1 |2 |3 |4 |5 |6
+[cols="7*^",options=noheader,autowidth]
+|===
+|
+6+|*Xcode version(s)/Swift version*
+
+|*CBL Version*
+|*10.2.1-10.3/5.0.1*
+|*11.0-11.1/5.1*
+|*11.2/5.1.2*
+|*11.3-11.3.1/5.1.3*
+|*11.4/5.2*
+|*11.4.1/5.2.2*
+
+|2.6.0
+| x
+|
+|
+|
+|
+|
+
+|2.6.1
+|
+| x
+|
+|
+|
+|
+
+|2.6.3
+|
+| x
+| x
+| x
+| x
+| x
+
+|2.6.4
+|
+|
+|
+| x
+| x
+| x
+
+|===
+
+
+
 == API References
 
 {url-api-references}[Swift SDK API References]


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6777
added matrix for 2.6 versions only