### PR TITLE
DOC-7320-Compatibility Matrix issues for Sync Gateway

### DIFF
--- a/modules/ROOT/pages/_partials/compatibility-cbl-sgw.adoc
+++ b/modules/ROOT/pages/_partials/compatibility-cbl-sgw.adoc
@@ -11,7 +11,7 @@ h|Sync Gateway ↓
 |1.4
 |2.0
 |2.1
-|2.5 - {version}
+|2.5 - 2.7
 
 | Release 1.3
 |✔
@@ -34,7 +34,7 @@ h|Sync Gateway ↓
 |✔
 |✔
 
-| Releases 2.5 to {version} with delta sync disabled
+| Releases 2.5 to 2.7 with delta sync disabled
 |✔
 |✔
 |✔

--- a/modules/ROOT/pages/compatibility.adoc
+++ b/modules/ROOT/pages/compatibility.adoc
@@ -61,4 +61,4 @@ The table below summarizes the compatible versions of Couchbase Lite with Sync G
 include::partial$compatibility-cbl-sgw.adoc[]
 
 
-include::6.0@sdk:shared:partial$interface-stability-pars.adoc[tag=interface-stability-section]
+include::sdk:shared:partial$interface-stability-pars.adoc[tag=interface-stability-section]


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-7320
Remove {version} attribute and add 2.7 to matrix, which is 'included' in the SGW page.
Remove specific version link to server's sdk-commons 6.0 to allow use of 6.5+6.6 content going forward