### PR TITLE
DOC-7320-Compatibility Matrix issues for Sync Gateway (#247)

### DIFF
--- a/modules/ROOT/pages/_partials/compatibility-cbl-sgw.adoc
+++ b/modules/ROOT/pages/_partials/compatibility-cbl-sgw.adoc
@@ -11,7 +11,7 @@ The table below summarizes the compatible versions of Couchbase Lite with Sync G
 |1.4
 |2.0
 |2.1
-|2.5 - {version}
+|2.5 - 2.7
 
 | Release 1.3
 |✔
@@ -34,7 +34,7 @@ The table below summarizes the compatible versions of Couchbase Lite with Sync G
 |✔
 |✔
 
-| Releases 2.5 to {version} with delta sync disabled
+| Releases 2.5 to 2.7 with delta sync disabled
 |✔
 |✔
 |✔

--- a/modules/ROOT/pages/compatibility.adoc
+++ b/modules/ROOT/pages/compatibility.adoc
@@ -89,4 +89,4 @@ The table below summarizes the compatible versions of Couchbase Lite with Sync G
 include::partial$compatibility-cbl-sgw.adoc[]
 
 
-include::6.0@sdk:shared:partial$interface-stability-pars.adoc[tag=interface-stability-section]
+include::sdk:shared:partial$interface-stability-pars.adoc[tag=interface-stability-section]


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-7320
Remove {version} attribute and add 2.7 to matrix, which is 'included' in the SGW page.
Remove specific version link to server's sdk-commons 6.0 to allow use of 6.5+6.6 content going forward

(cherry picked from commit f9cc3360dd591f47d16f822c43a378466bd6f9c7)