### PR TITLE
Updated the Swift SDK API References documentation link

### DIFF
--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -150,7 +150,7 @@ include::partial$ios-framework-size.adoc[]
 
 == API References
 
-http://docs.couchbase.com/mobile/2.1/couchbase-lite-swift[Swift SDK API References]
+https://docs.couchbase.com/mobile/2.1/couchbase-lite-swift[Swift SDK API References]
 
 == Upgrading
 


### PR DESCRIPTION
Updated the Swift SDK API References documentation link to have https protocol.

It will be great if you can approve the change.

Thank you