### PR TITLE
Updated the Swift SDK API References link

### DIFF
--- a/modules/ROOT/pages/swift.adoc
+++ b/modules/ROOT/pages/swift.adoc
@@ -150,7 +150,7 @@ xref:sync-gateway::getting-started.adoc#_installation[Installing Sync Gateway ->
 
 == API References
 
-http://docs.couchbase.com/mobile/2.0/couchbase-lite-swift[Swift SDK API References]
+https://docs.couchbase.com/mobile/2.0/couchbase-lite-swift[Swift SDK API References]
 
 == Upgrading
 


### PR DESCRIPTION
Updated the Swift SDK API References link to have https protocol in order to avoid the SEO Redirect chain issue.

Thank you