### PR TITLE
DOC-7712-C1 - Release notes for CBL .NET 2.8.2

### DIFF
--- a/modules/ROOT/pages/_partials/commons/common-releasenotes.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-releasenotes.adoc
@@ -9,47 +9,33 @@ include::{root-partials}block-abstract.adoc[]
 // END DO NOT REMOVE
 
 // BEGIN: Decide which releases are relevant for this platform
+// C# Maintenance Releases
+// Android Maintenance Releases
 ifeval::["{param-module}"=="{lang-mod-android}"]
 :param-2-8-1-java:
 endif::[]
+// Java Maintenance Releases
 ifeval::["{param-module}"=="{lang-mod-java}"]
 :param-2-8-1-java:
 endif::[]
+// iOS Maintenance Releases
 ifeval::["{param-platform}"=="{platform-ios}"]
 :param-2-8-1-ios:
 endif::[]
 // END: Decide which releases are relevant for this platform
 
-// BEGIN: Show the 2-8-1/iOS contents if relevant to the platform
-ifdef::param-2-8-1-ios[]
-[#maint-latest]
-[#maint-2.8.1]
-== 2.8.1 -- November 2020
+// BEGIN: Show Maintenance Releases
 
+// Begin -- Release 2.8.1 (iOS) -- Nov 2020
+ifdef::param-2-8-1-ios[]
+[#maint-2.8.1-ios]
+== 2.8.1 (iOS) -- November 2020
 Version 2.8.1 of Couchbase Lite for {param-title} comprises a number of fixes.
 It supersedes version 2.8.0 released earlier this year.
 
 *If you have already upgraded to 2.8.0 we strongly recommend that you upgrade to version 2.8.1 at the earliest opportunity.*
 
-// Begin -- optional -- text -- Uncomment this text as required (eg release contains new features)
-// .Quick Links
-// <<improvements-2-8-1>> *|* <<issues-and-resolutions-2-8-1>> *|* <<support-notices-2-8-1>> *|* <<Related Content>>
-
-// [#new-features-2-8-1]
-// === New Features
-// include::{root-partials}pn-change-log-2-8-1.adoc[tag=latest-all-new, leveloffset=+1]
-
-// [#improvements-2-8-1]
-// === Improvements
-
-// include::{root-partials}pn-change-log-2-8-1.adoc[tag=latest-all-changed-features, leveloffset=+1]
-
-// include::{module-partials}pn-issues-list.adoc[tag=enhancements]
-
-// include::{root-partials}pn-change-log-2-8-1.adoc[tag=latest-all-changed-api, leveloffset=+1]
-// End -- optional -- text -- Uncomment this text as required (eg release contains new features)
-
-[#issues-and-resolutions-2-8-1]
+[#issues-and-resolutions-2-8-1-ios]
 === Issues and Resolutions
 ==== Known Issues
 include::{module-partials}pn-issues-list.adoc[tag=knownissues-2-8-1]
@@ -58,9 +44,10 @@ include::{module-partials}pn-issues-list.adoc[tag=knownissues-2-8-1]
 include::{module-partials}pn-issues-list.adoc[tag=fixed-2-8-1]
 
 endif::[]
-// END: Show the 2-8-1/iOS contents if relevant to the platform
+// End -- Release 2.8.1 (iOS) -- Nov 2020
 
-// BEGIN: Show the 2-8-1/Java contents if relevant to the platform
+
+// Begin -- Release 2.8.1 (Java) -- Oct 2020
 ifdef::param-2-8-1-java[]
 [#maint-latest]
 [#maint-2.8.1]
@@ -71,22 +58,6 @@ Couchbase Lite for {param-title} 2.8.1 addresses a backward-compatibility issue 
 
 *If you have already upgraded to 2.8.0 we strongly recommend that you upgrade to version 2.8.1 at the earliest opportunity.*
 
-// .Quick Links
-// <<improvements-2-8-1>> *|* <<issues-and-resolutions-2-8-1>> *|* <<support-notices-2-8-1>> *|* <<Related Content>>
-
-// [#new-features-2-8-1]
-// === New Features
-// include::{root-partials}pn-change-log-2-8-1.adoc[tag=latest-all-new, leveloffset=+1]
-
-// [#improvements-2-8-1]
-// === Improvements
-
-// include::{root-partials}pn-change-log-2-8-1.adoc[tag=latest-all-changed-features, leveloffset=+1]
-
-// include::{module-partials}pn-issues-list.adoc[tag=enhancements]
-
-// include::{root-partials}pn-change-log-2-8-1.adoc[tag=latest-all-changed-api, leveloffset=+1]
-
 [#issues-and-resolutions-2-8-1]
 === Issues and Resolutions
 ==== Known Issues
@@ -96,7 +67,9 @@ include::{module-partials}pn-issues-list.adoc[tag=knownissues-2-8-1]
 include::{module-partials}pn-issues-list.adoc[tag=fixed-2-8-1]
 
 endif::[]
-// END: Show the 2-8-1/Java contents if relevant to the platform
+// End -- Release 2.8.1 (Java) -- Oct 2020
+
+// END: Maintenance Releases
 
 [#major]
 == 2.8 -- October 2020


### PR DESCRIPTION
DOC-7712-C1 - Release notes for CBL .NET 2.8.2
Infrastructure changes to accomodate incremental release policy (vs. per platform)