### PR TITLE
DOC-7852 -- Backport-DOC-7833-2x7 - Remove dev/test clause for Java o…

### DIFF
--- a/modules/ROOT/pages/java-platform.adoc
+++ b/modules/ROOT/pages/java-platform.adoc
@@ -1483,12 +1483,7 @@ Couchbase Lite Java will be supported on x86 64-bit platforms. These are the tar
 |Windows 10
 |Desktop
 
-|===
-.Table Supported OS Versions (DEVELOPMENT & TESTING ONLY)
-|===
-| OS|Version|Type
-
-|macOS
+|Apple
 |macOS 10.12.6 (High Sierra)
 |Desktop & Web Service/Servlet (Tomcat)
 |===


### PR DESCRIPTION
…n macOS

https://issues.couchbase.com/browse/DOC-7852