### PR TITLE
DOC-5786 -- Backport from 2.7

### DIFF
--- a/modules/ROOT/pages/_partials/logging.adoc
+++ b/modules/ROOT/pages/_partials/logging.adoc
@@ -43,6 +43,10 @@ And set it on the `custom` property.
 include::{snippet}[tag=set-custom-logging,indent=0]
 ----
 
+ifeval::["{packagenm}"=="couchbase-lite-android"]
+*Note* the number returned by `LogLevel.getValue()` is not the Android log level and should not be used
+endif::[]
+
 ==== Decoding binary logs
 
 The *cbl-log* tool should be used to decode binary log files.

--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -12,7 +12,7 @@ include::partial$_attributes-local.adoc[]
 :url-issues-ios: {url-github-root}/couchbase-lite-android/issues
 :tabs:
 :url-api-references: {url-mobDocs-root}/{docsVersion}/couchbase-lite-java
-//
+:packagenm: couchbase-lite-android
 // End local attributes
 
 WARNING: Currently, Couchbase Lite 2.6 and below is available for Android only.


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-5786
Custom loglevel.getvalue() wrong number