### PR TITLE
DOC-5786 -- Backport from 2.7

### DIFF
--- a/modules/ROOT/pages/_partials/logging.adoc
+++ b/modules/ROOT/pages/_partials/logging.adoc
@@ -43,6 +43,10 @@ And set it on the `custom` property.
 include::{snippet}[tag=set-custom-logging,indent=0]
 ----
 
+ifeval::["{packagenm}"=="couchbase-lite-android"]
+*Note* the number returned by `LogLevel.getValue()` is not the Android log level and should not be used
+endif::[]
+
 ==== Decoding binary logs
 
 The *cbl-log* tool should be used to decode binary log files.

--- a/modules/ROOT/pages/java.adoc
+++ b/modules/ROOT/pages/java.adoc
@@ -16,6 +16,7 @@ include::partial$_attributes-local.adoc[]
 :blank-field: ____
 :url-issues-java: https://github.com/couchbase/couchbase-lite-android/issues
 :url-api-references: http://docs.couchbase.com/mobile/2.5.0/couchbase-lite-java
+:packagenm: couchbase-lite-android
 
 WARNING: Currently, Couchbase Lite 2.0 and above is available for Android only.
 The SDK cannot be used in Java applications.


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-5786
Custom loglevel.getvalue() wrong number