### PR TITLE
update query examples to fix as function

### DIFF
--- a/modules/android/examples/snippets/app/src/main/kotlin/com/couchbase/code_snippets/QueryExamples.kt
+++ b/modules/android/examples/snippets/app/src/main/kotlin/com/couchbase/code_snippets/QueryExamples.kt
@@ -330,9 +330,9 @@ class QueryExamples(private val database: Database) {
             SelectResult.expression(Expression.property("stops").from("route")),
             SelectResult.expression(Expression.property("airline").from("route"))
         )
-            .from(DataSource.database(database).as("airline"))
+            .from(DataSource.database(database).`as`("airline"))
             .join(
-                Join.join(DataSource.database(database).as("route"))
+                Join.join(DataSource.database(database).`as`("route"))
                     .on(
                         Meta.id.from("airline")
                             .equalTo(Expression.property("airlineid").from("route"))
@@ -628,7 +628,7 @@ class QueryExamples(private val database: Database) {
 
         val rs = QueryBuilder
             .select(
-                SelectResult.expression(Function.count(Expression.string("*"))).as("mycount")) // <.>
+                SelectResult.expression(Function.count(Expression.string("*"))).`as`("mycount")) // <.>
             .from(DataSource.database(database))
 
         // end::query-syntax-count-only[]
@@ -647,7 +647,7 @@ class QueryExamples(private val database: Database) {
 
         val rs = QueryBuilder
         .select(
-          SelectResult.expression(Meta.id).as("hotelId"))
+          SelectResult.expression(Meta.id).`as`("hotelId"))
           .from(DataSource.database(database))
 
           // end::query-syntax-id[]


### PR DESCRIPTION
The as function requires it to be escaped using ` ` - in the code example there are four times I found the as function without escaping, which means the code won't work for customers that are trying to use this code.  The proper syntax should be:

sudo code follows:
```kotlin
db?.let { database ->
  val query = QueryBuilder
    .select(SelectResult.all())
    .from(DataSource.database(database).`as`("item"))
    .where(Expression.property("type").equalTo(Expression.string("project")))
}
```