### PR TITLE
update documentation on indexing

### DIFF
--- a/modules/android/examples/codesnippet_collection.kt
+++ b/modules/android/examples/codesnippet_collection.kt
@@ -2326,7 +2326,7 @@ class QueryExamples(private val database: Database) {
         // tag::query-index[]
         database.createIndex(
           "TypeNameIndex",
-          ValueIndexConfigurationFactory.create(expressions = ["type","name"])
+          ValueIndexConfigurationFactory.create(expressions = arrayOf("type","name"))
         )
 
         // end::query-index[]

--- a/modules/android/examples/codesnippet_collection.kt
+++ b/modules/android/examples/codesnippet_collection.kt
@@ -2326,7 +2326,7 @@ class QueryExamples(private val database: Database) {
         // tag::query-index[]
         database.createIndex(
           "TypeNameIndex",
-          ValueIndexConfigurationFactory.create(expressions = arrayOf("type","name"))
+          ValueIndexConfigurationFactory.create("type","name")
         )
 
         // end::query-index[]


### PR DESCRIPTION
The example on ValueIndexConfigurationFactory for creating indexes with Kotlin shows the incorrect way to create an array.  The proper syntax is to use the arrayOf function and pass in the values.