### PR TITLE
CBL-3974: [swift] variable names are made consistent

### DIFF
--- a/modules/swift/examples/code_snippets/SampleCodeTest.swift
+++ b/modules/swift/examples/code_snippets/SampleCodeTest.swift
@@ -141,7 +141,7 @@ class SampleCodeTest {
         guard let collection = try self.database.defaultCollection() else {
             fatalError("For sample code snippet, collection should be present!")
         }
-        // tag::ne[]
+        // tag::initializer[]
         let doc = MutableDocument()
             .setString("task", forKey: "type")
             .setString("todo", forKey: "owner")

--- a/modules/swift/examples/code_snippets/SampleCodeTest.swift
+++ b/modules/swift/examples/code_snippets/SampleCodeTest.swift
@@ -141,12 +141,12 @@ class SampleCodeTest {
         guard let collection = try self.database.defaultCollection() else {
             fatalError("For sample code snippet, collection should be present!")
         }
-        // tag::initializer[]
-        let newTask = MutableDocument()
+        // tag::ne[]
+        let doc = MutableDocument()
             .setString("task", forKey: "type")
             .setString("todo", forKey: "owner")
             .setDate(Date(), forKey: "createdAt")
-        try collection.save(document: newTask)
+        try collection.save(document: doc)
         // end::initializer[]
     }
 
@@ -156,35 +156,37 @@ class SampleCodeTest {
         }
         
         // tag::update-document[]
-        guard let document = try collection.document(id: "xyz") else { return }
-        let mutableDocument = document.toMutable()
+        guard let doc = try collection.document(id: "xyz") else { return }
+        let mutableDocument = doc.toMutable()
         mutableDocument.setString("apples", forKey: "name")
         try collection.save(document: mutableDocument)
         // end::update-document[]
     }
 
-    func dontTestTypedAcessors() throws {
-        let newTask = MutableDocument()
-
+    func dontTestDateGetter() throws {
         // tag::date-getter[]
-        newTask.setValue(Date(), forKey: "createdAt")
-        let date = newTask.date(forKey: "createdAt")
+        let mutableDoc = MutableDocument(id: "xyz")
+        mutableDoc.setValue(Date(), forKey: "createdAt")
+        
+        guard let doc = try collection.document(id: "xyz") else { return }
+        let date = doc.date(forKey: "createdAt")
         // end::date-getter[]
-
-        // tag::to-dictionary[]
-        print(newTask.toDictionary())
-
-        // end::to-dictionary[]
-
-        // tag::to-json[]
-        print(newTask.toJSON())
-
-        // end::to-json[]
-
         print("\(date!)")
     }
 
-
+    func dontTestToDictionary() throws {
+        // tag::to-dictionary[]
+        guard let doc = try collection.document(id: "xyz") else { return }
+        print(doc.toDictionary())
+        // end::to-dictionary[]
+    }
+    
+    func dontTestToJSON() throws {
+        // tag::to-json[]
+        guard let doc = try collection.document(id: "xyz") else { return }
+        print(doc.toJSON())
+        // end::to-json[]
+    }
 
     func dontTestBatchOperations() throws {
         guard let collection = try self.database.defaultCollection() else {
@@ -215,9 +217,10 @@ class SampleCodeTest {
         }
         
         // tag::document-listener[]
+        weak var wCollection = collection
         let token = collection.addDocumentChangeListener(id: "user.john") { (change) in
-            if let document = try? self.collection.document(id: change.documentID) {
-                print("Status :: \(document?.string(forKey: "verified_account") ?? "--")")
+            if let doc = try? wCollection?.document(id: change.documentID) {
+                print("Status :: \(doc?.string(forKey: "verified_account") ?? "--")")
             }
         }
         // end::document-listener[]
@@ -2865,10 +2868,10 @@ public class Supporting_Datatypes
 
         // tag::datatype_dictionary[]
         // NOTE: No error handling, for brevity (see getting started)
-        guard let document = try collection.document(id:"doc1") else { return }
+        guard let doc = try collection.document(id:"doc1") else { return }
 
         // Getting a dictionary from the document's properties
-        guard let dict = document.dictionary(forKey: "address") else { return }
+        guard let dict = doc.dictionary(forKey: "address") else { return }
 
         // Access a value with a key from the dictionary
         guard let street = dict.string(forKey: "street") else { return }
@@ -2879,10 +2882,10 @@ public class Supporting_Datatypes
         }
 
         // Create a mutable copy
-        let mutable_dict = dict.toMutable()
+        let mutableDict = dict.toMutable()
         // end::datatype_dictionary[]
         
-        print("street \(street) dict \(mutable_dict)")
+        print("street \(street) dict \(mutableDict)")
     }
 
     func datatype_mutable_dictionary() throws {
@@ -2894,14 +2897,14 @@ public class Supporting_Datatypes
 
         // tag::datatype_mutable_dictionary[]
         // Create a new mutable dictionary and populate some keys/values
-        let mutable_dict = MutableDictionaryObject()
-        mutable_dict.setString("1 Main st.", forKey: "street")
-        mutable_dict.setString("San Francisco", forKey: "city")
+        let mutableDict = MutableDictionaryObject()
+        mutableDict.setString("1 Main st.", forKey: "street")
+        mutableDict.setString("San Francisco", forKey: "city")
 
         // Add the dictionary to a document's properties and save the document
-        let mutable_doc = MutableDocument(id: "doc1")
-        mutable_doc.setDictionary(mutable_dict, forKey: "address")
-        try! collection.save(document:mutable_doc)
+        let mutableDoc = MutableDocument(id: "doc1")
+        mutableDoc.setDictionary(mutableDict, forKey: "address")
+        try! collection.save(document:mutableDoc)
 
         // end::datatype_mutable_dictionary[]
     }
@@ -2915,10 +2918,10 @@ public class Supporting_Datatypes
         var phone = "--"
 
         // tag::datatype_array[]
-        guard let document = try collection.document(id:"doc1") else { return }
+        guard let doc = try collection.document(id:"doc1") else { return }
 
         // Getting a phones array from the document's properties
-        guard let array = document.array(forKey: "phones") else { return }
+        guard let array = doc.array(forKey: "phones") else { return }
 
         // Access an array element by index
         if array.count >= 0, let val = array.string(at: 0) {
@@ -2931,10 +2934,10 @@ public class Supporting_Datatypes
         }
 
         // Create a mutable copy
-        let mutable_array = array.toMutable()
+        let mutableArray = array.toMutable()
         // end::datatype_array[]
         
-        print("phone is \(phone). mutable array is \(mutable_array)")
+        print("phone is \(phone). mutable array is \(mutableArray)")
 
     }
 
@@ -2946,14 +2949,14 @@ public class Supporting_Datatypes
 
         // tag::datatype_mutable_array[]
         // Create a new mutable array and populate data into the array
-        var mutable_array = MutableArrayObject()
-        mutable_array.addString("650-000-0000")
-        mutable_array.addString("650-000-0001")
+        var mutableArray = MutableArrayObject()
+        mutableArray.addString("650-000-0000")
+        mutableArray.addString("650-000-0001")
 
             // Set the array to document's properties and save the document
-        let mutable_doc = MutableDocument(id: "doc1")
-        mutable_doc.setArray(mutable_array, forKey:"phones")
-        try collection.save(document:mutable_doc)
+        let mutableDoc = MutableDocument(id: "doc1")
+        mutableDoc.setArray(mutableArray, forKey:"phones")
+        try collection.save(document:mutableDoc)
         // end::datatype_mutable_array[]
     }
 


### PR DESCRIPTION
```datatype_usage_createdb		-> 
datatype_usage_createdoc	-> exists
datatype_usage_mutdict		-> exists
datatype_usage_mutarray		-> exists
datatype_usage_populate		-> exists 

datatype_usage_persist		-> collection.save() already updated. 
datatype_usage_closedb		-> exists

date-getter			-> updated doc instead of task
datatype_dictionary		-> collection.document() already updated, doc instead of document. 
datatype_mutable_dictionary	-> mutable_dict -> mutableDict, mutable_doc -> mutableDoc, iOS standards, collection.save() already updated. 
datatype_array			-> mutable_array -> mutableArray, document -> doc
datatype_mutable_array		-> collection.save() already updated, 

initializer			-> collection.save() already updated, newTask -> doc
update-document			-> document->doc, collection.save()

to-dictionary;to-json		-> get document from collection and printed the functions

batch				-> collection save already done. 
document-listener		-> updated with weak collection, collection.addDocumentChangeListener already done. 

document-expiration		-> collection.setDocExpiry, Datasource.collection() already done. 

tojson-array			-> Get doc from collection already done. Save not necessary, since it for demo toJSON. 
tojson-blob			-> same as above 
tojson-dictionary		-> same as above 
tojson-document			-> same as above

query-get-all			-> no change required.
query-access-json		-> exists

Note: mutableDict in case of iOS(objc, swift) code standards, and not 'mutable_dict'