### PR TITLE
DOC-11159: Adds note about non-couchbase support

### DIFF
--- a/modules/javascript/pages/cordova.adoc
+++ b/modules/javascript/pages/cordova.adoc
@@ -9,11 +9,7 @@ include::partial$_set_page_context_for_javascript.adoc[]
 :param-related: xref:ionic.adoc[] | xref:react.adoc[]
 include::{root-partials}_show_page_header_block.adoc[]
 
-
-.Enterprise-only
-[NOTE]
-Ionic supports both https://capacitorjs.com/docs/plugins[Capacitor] and Cordova, with Ionic recommending use of Capacitor.
-
+NOTE: Couchbase Lite for Cordova is a community-driven project without official support from Couchbase.
 
 == Introduction
 
@@ -29,6 +25,10 @@ To use Couchbase Lite as an embedded database within your Cordova-based app, you
 
 https://cordova.apache.org/docs/en/10.x/guide/hybrid/plugins/index.html[Cordova Native Plugins]
 allow web-based apps running in a Cordova webview to access native platform functionality through a Javascript interface.
+
+.Enterprise-only
+[NOTE]
+Ionic supports both https://capacitorjs.com/docs/plugins[Capacitor] and Cordova, with Ionic recommending use of Capacitor.
 
 To use Couchbase Lite within your Cordova apps, you should implement a Cordova native plugin, which exports the Couchbase Lite Android and iOS APIs to Javascript.
 It is typical to start with exporting the minimal subset of APIs that your app needs and extend as needed.

--- a/modules/javascript/pages/react.adoc
+++ b/modules/javascript/pages/react.adoc
@@ -16,6 +16,7 @@ include::{root-partials}_show_page_header_block.adoc[]
 
 :ref_implementation: https://github.com/couchbaselabs/couchbase-lite-react-native-module/
 
+NOTE: Couchbase Lite for React Native is a community-driven project without official support from Couchbase.
 
 // == Introduction
 


### PR DESCRIPTION
- adds note: Couchbase Lite for Cordova is a community-driven project without official support from Couchbase.
- adds note: Couchbase Lite for React Native is a community-driven project without official support from Couchbase.