### PR TITLE
Doc 11211: Updates download page for c

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -23,7 +23,7 @@ asciidoc:
     major: 3
     minor: 0
     maintenance-ios: 2
-    maintenance-c: 2
+    maintenance-c: 12
     maintenance-android: 2
     maintenance-java: 2
     maintenance-net: 2

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -36,11 +36,20 @@ include::{root-partials}_show_get_started_topic_group.adoc[]
  
 .Downloads are available for the following versions:
 ****
+<<release-3-0-12>> |
 <<release-3-0-11>> |
 <<release-3-0-10>> | 
 <<release-3-0-2>>  |
 <<release-3-0-0>>
 ****
+
+:param-version-hyphenated: 3-0-12
+:param-version: 3.0.12
+:is-fullpage:
+include::partial$downloadslist.adoc[]
+:is-fullpage!:
+:param-version!:
+:param-version-hyphenated!:
 
 :param-version-hyphenated: 3-0-11
 :param-version: 3.0.11


### PR DESCRIPTION
Updates the downloads page under the release/3.0 with downloads for 3.0.12

https://docs.couchbase.com/couchbase-lite/3.0/c/gs-downloads.html

[[FEWD-8800](https://issues.couchbase.com/browse/FEWD-8800)](https://issues.couchbase.com/browse/FEWD-8800)

