### PR TITLE
DOC-11240: Add links to windows downloads 3.0.12

### DIFF
--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -122,7 +122,7 @@ Enterprise Edition::
 | Platform | Download | SHA | Debug Symbols
 
 .1+| Windows
-| {empty}
+| {source_url}couchbase-lite-c-enterprise-{our-version}-windows-x86_64.zip[couchbase-lite-c-enterprise-{our-version}-windows-x86_64.zip]
 | {empty}
 | {source_url}couchbase-lite-c-enterprise-{our-version}-windows-x86_64-symbols.zip[couchbase-lite-c-enterprise-{our-version}-windows-x86_64-symbols.zip]
 
@@ -137,7 +137,7 @@ Community Edition::
 | Platform | Download | SHA | Debug Symbols
 
 .1+| Windows
-| {empty}
+| {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip[couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip]
 | {empty}
 | {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip[couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip]
 

--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -137,7 +137,7 @@ Community Edition::
 | Platform | Download | SHA | Debug Symbols
 
 .1+| Windows
-| {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip[couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip]
+| {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64.zip[couchbase-lite-c-community-{our-version}-windows-x86_64.zip]
 | {empty}
 | {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip[couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip]
 


### PR DESCRIPTION
Added link to Windows download for Couchbase-lite C downloads

SHA link not added as per https://github.com/couchbase/docs-couchbase-lite/pull/809

Ticket: [DOC-11240](https://issues.couchbase.com/browse/DOC-11240)