### PR TITLE
DOC-11248: Adds SHA files to windows downloads

### DIFF
--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -138,7 +138,7 @@ Community Edition::
 
 .1+| Windows
 | {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64.zip[couchbase-lite-c-community-{our-version}-windows-x86_64.zip]
-| {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64.zip.sha256[couchbase-lite-c-comminity-{our-version}-windows-x86_64.zip.sha256]
+| {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64.zip.sha256[couchbase-lite-c-community-{our-version}-windows-x86_64.zip.sha256]
 | {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip[couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip]
 
 |===

--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -123,7 +123,7 @@ Enterprise Edition::
 
 .1+| Windows
 | {source_url}couchbase-lite-c-enterprise-{our-version}-windows-x86_64.zip[couchbase-lite-c-enterprise-{our-version}-windows-x86_64.zip]
-| {empty}
+| {source_url}couchbase-lite-c-enterprise-{our-version}-windows-x86_64.zip.sha256[couchbase-lite-c-enterprise-{our-version}-windows-x86_64.zip.sha256]
 | {source_url}couchbase-lite-c-enterprise-{our-version}-windows-x86_64-symbols.zip[couchbase-lite-c-enterprise-{our-version}-windows-x86_64-symbols.zip]
 
 |===
@@ -138,7 +138,7 @@ Community Edition::
 
 .1+| Windows
 | {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64.zip[couchbase-lite-c-community-{our-version}-windows-x86_64.zip]
-| {empty}
+| {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64.zip.sha256[couchbase-lite-c-comminity-{our-version}-windows-x86_64.zip.sha256]
 | {source_url}couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip[couchbase-lite-c-community-{our-version}-windows-x86_64-symbols.zip]
 
 |===


### PR DESCRIPTION
Adds SHA files to Windows section (3.0.12) as per feedback from @djpongh 

Supersedes https://github.com/couchbase/docs-couchbase-lite/pull/812 

 [DOC-11248](https://issues.couchbase.com/browse/DOC-11248)