### PR TITLE
Doc 11322  Recategorise rel-notes

### DIFF
--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.1.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.1.adoc
@@ -13,10 +13,6 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 * https://issues.couchbase.com/browse/CBL-4665[CBL-4665 - Better error message when getCollections returns error]
 
-* https://issues.couchbase.com/browse/CBL-4631[CBL-4631 - Update iOS target version to 11.0]
-
-* https://issues.couchbase.com/browse/CBL-4625[CBL-4625 - Set macOS target version to 10.14]
-
 * https://issues.couchbase.com/browse/CBL-4414[CBL-4414 - Enhance checkpoint resolution algorithm when local and remote checkpoint are mismatched]
 
 === Issues and Resolutions

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.1.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.1.adoc
@@ -3,10 +3,6 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
-=== Scopes and Collections
-
-include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
-
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4622[CBL-4622 - Remove extraneous logging]
@@ -32,4 +28,3 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 * https://issues.couchbase.com/browse/CBL-4535[CBL-4535 - Error when saving documents with LiteCore error 17: must be called during a transaction]
 
 * https://issues.couchbase.com/browse/CBL-4445[CBL-4445 - Replicator is stuck in busy state when there is an error thrown while applying delta to create full fleece doc]
-

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.1.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.1.adoc
@@ -3,6 +3,8 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4622[CBL-4622 - Remove extraneous logging]

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.1.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.1.adoc
@@ -33,10 +33,3 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 * https://issues.couchbase.com/browse/CBL-4445[CBL-4445 - Replicator is stuck in busy state when there is an error thrown while applying delta to create full fleece doc]
 
-=== Known Issues
-
-None for this release
-
-=== Deprecations 
-
-None for this release

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.1.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.1.adoc
@@ -9,17 +9,9 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 === Enhancements
 
-* https://issues.couchbase.com/browse/CBL-4630[CBL-4630 - Update iOS target version to 11.0]
-
 * https://issues.couchbase.com/browse/CBL-4574[CBL-4574 - Generate API Doc]
 
-* https://issues.couchbase.com/browse/CBL-4488[CBL-4488 - Build release framework without bitcode enabled]
-
 * https://issues.couchbase.com/browse/CBL-4665[CBL-4665 - Better error message when getCollections returns error]
-
-* https://issues.couchbase.com/browse/CBL-4631[CBL-4631 - Update iOS target version to 11.0]
-
-* https://issues.couchbase.com/browse/CBL-4625[CBL-4625 - Set macOS target version to 10.14]
 
 * https://issues.couchbase.com/browse/CBL-4414[CBL-4414 - Enhance checkpoint resolution algorithm when local and remote checkpoint are mismatched]
 

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.1.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.1.adoc
@@ -25,7 +25,7 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 === Known Issues
 
-None for this releaseß
+None for this release
 
 === Deprecations 
 

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.1.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.1.adoc
@@ -3,10 +3,6 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
-=== Scopes and Collections
-
-include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
-
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4574[CBL-4574 - Generate API Doc]

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.1.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.1.adoc
@@ -3,6 +3,8 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4574[CBL-4574 - Generate API Doc]

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.1.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.1.adoc
@@ -23,10 +23,3 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 * https://issues.couchbase.com/browse/CBL-4445[CBL-4445 - Replicator is stuck in busy state when there is an error thrown while applying delta to create full fleece doc]
 
-=== Known Issues
-
-None for this release
-
-=== Deprecations 
-
-None for this release

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.1.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.1.adoc
@@ -9,17 +9,11 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 === Enhancements
 
-* https://issues.couchbase.com/browse/CBL-4633[CBL-4633 - Update iOS target version to 11.0]
-
 * https://issues.couchbase.com/browse/CBL-4577[CBL-4577 - Make IReachability interface public]
 
 * https://issues.couchbase.com/browse/CBL-4505[CBL-4505 - Make Reachability interface public]
 
 * https://issues.couchbase.com/browse/CBL-4665[CBL-4665 - Better error message when getCollections returns error]
-
-* https://issues.couchbase.com/browse/CBL-4631[CBL-4631 - Update iOS target version to 11.0]
-
-* https://issues.couchbase.com/browse/CBL-4625[CBL-4625 - Set macOS target version to 10.14]
 
 * https://issues.couchbase.com/browse/CBL-4414[CBL-4414 - Enhance checkpoint resolution algorithm when local and remote checkpoint are mismatched]
 
@@ -39,7 +33,3 @@ None for this release
 
 None for this release
 
-
-=== Removed
-
-None for this release

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.1.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.1.adoc
@@ -25,11 +25,4 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 * https://issues.couchbase.com/browse/CBL-4445[CBL-4445 - Replicator is stuck in busy state when there is an error thrown while applying delta to create full fleece doc]
 
-=== Known Issues
-
-None for this release
-
-=== Deprecations 
-
-None for this release
 

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.1.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.1.adoc
@@ -3,10 +3,6 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
-=== Scopes and Collections
-
-include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
-
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4577[CBL-4577 - Make IReachability interface public]
@@ -20,8 +16,6 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 === Issues and Resolutions
 
 * https://issues.couchbase.com/browse/CBL-4623[CBL-4623 - Use FTS match() in the WHERE clause of LEFT OUTER JOINS Not Returning Correct Result]
-
-* https://issues.couchbase.com/browse/CBL-4535[CBL-4535 - Error when saving documents with LiteCore error 17: must be called during a transaction]
 
 * https://issues.couchbase.com/browse/CBL-4445[CBL-4445 - Replicator is stuck in busy state when there is an error thrown while applying delta to create full fleece doc]
 

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.1.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.1.adoc
@@ -3,6 +3,8 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4577[CBL-4577 - Make IReachability interface public]

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.1.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.1.adoc
@@ -29,10 +29,3 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 * https://issues.couchbase.com/browse/CBL-4445[CBL-4445 - Replicator is stuck in busy state when there is an error thrown while applying delta to create full fleece doc]
 
-=== Known Issues
-
-None for this release
-
-=== Deprecations 
-
-None for this release

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.1.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.1.adoc
@@ -3,10 +3,6 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
-=== Scopes and Collections
-
-include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
-
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4622[CBL-4622 - Remove extraneous logging]

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.1.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.1.adoc
@@ -13,10 +13,6 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 * https://issues.couchbase.com/browse/CBL-4665[CBL-4665 - Better error message when getCollections returns error]
 
-* https://issues.couchbase.com/browse/CBL-4631[CBL-4631 - Update iOS target version to 11.0]
-
-* https://issues.couchbase.com/browse/CBL-4625[CBL-4625 - Set macOS target version to 10.14]
-
 * https://issues.couchbase.com/browse/CBL-4414[CBL-4414 - Enhance checkpoint resolution algorithm when local and remote checkpoint are mismatched]
 
 === Issues and Resolutions
@@ -31,10 +27,7 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 * https://issues.couchbase.com/browse/CBL-4623[CBL-4623 - Use FTS match() in the WHERE clause of LEFT OUTER JOINS Not Returning Correct Result]
 
-* https://issues.couchbase.com/browse/CBL-4535[CBL-4535 - Error when saving documents with LiteCore error 17: must be called during a transaction]
-
 * https://issues.couchbase.com/browse/CBL-4445[CBL-4445 - Replicator is stuck in busy state when there is an error thrown while applying delta to create full fleece doc]
-
 
 === Known Issues
 

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.1.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.1.adoc
@@ -3,6 +3,8 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4622[CBL-4622 - Remove extraneous logging]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.1.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.1.adoc
@@ -23,6 +23,12 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 * https://issues.couchbase.com/browse/CBL-4414[CBL-4414 - Enhance checkpoint resolution algorithm when local and remote checkpoint are mismatched]
 
+* https://issues.couchbase.com/browse/CBL-4630[CBL-4630 - Update iOS target version to 11.0]
+
+* https://issues.couchbase.com/browse/CBL-4488[CBL-4488 - Build release framework without bitcode enabled]
+
+* https://issues.couchbase.com/browse/CBL-4633[CBL-4633 - Update iOS target version to 11.0]
+
 === Issues and Resolutions
 
 * https://issues.couchbase.com/browse/CBL-4581[CBL-4581 - MutableDocument contains(key: String) returns wrong result]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.1.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.1.adoc
@@ -3,6 +3,8 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4627[CBL-4627 - Update iOS target version to 11.0]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.1.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.1.adoc
@@ -3,10 +3,6 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
-=== Scopes and Collections
-
-include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
-
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4627[CBL-4627 - Update iOS target version to 11.0]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.1.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.1.adoc
@@ -46,11 +46,3 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 * https://issues.couchbase.com/browse/CBL-4535[CBL-4535 - Error when saving documents with LiteCore error 17: must be called during a transaction]
 
 * https://issues.couchbase.com/browse/CBL-4445[CBL-4445 - Replicator is stuck in busy state when there is an error thrown while applying delta to create full fleece doc]
-
-=== Known Issues
-
-None for this release
-
-=== Deprecations 
-
-None for this release

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.1.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.1.adoc
@@ -23,6 +23,12 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 * https://issues.couchbase.com/browse/CBL-4414[CBL-4414 - Enhance checkpoint resolution algorithm when local and remote checkpoint are mismatched]
 
+* https://issues.couchbase.com/browse/CBL-4630[CBL-4630 - Update iOS target version to 11.0]
+
+* https://issues.couchbase.com/browse/CBL-4488[CBL-4488 - Build release framework without bitcode enabled]
+
+* https://issues.couchbase.com/browse/CBL-4633[CBL-4633 - Update iOS target version to 11.0]
+
 === Issues and Resolutions
 
 * https://issues.couchbase.com/browse/CBL-4581[CBL-4581 - MutableDocument contains(key: String) returns wrong result]

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.1.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.1.adoc
@@ -47,11 +47,3 @@ include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
 
 * https://issues.couchbase.com/browse/CBL-4445[CBL-4445 - Replicator is stuck in busy state when there is an error thrown while applying delta to create full fleece doc]
 
-
-=== Known Issues
-
-None for this release
-
-=== Deprecations 
-
-None for this release

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.1.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.1.adoc
@@ -3,6 +3,8 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4627[CBL-4627 - Update iOS target version to 11.0]

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.1.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.1.adoc
@@ -3,10 +3,6 @@
 
 Version 3.1.1 for {param-title} delivers the following features and enhancements:
 
-=== Scopes and Collections
-
-include::ROOT:cbl-whatsnew.adoc[tag=scopes-and-collections]
-
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBL-4627[CBL-4627 - Update iOS target version to 11.0]


### PR DESCRIPTION
- Re-categorizes rel-notes as the Jira tickets were not accurate 
- Removes un-needed Headings 
- Removes whats new - S&C includes 
- Adds whats new S&C - xrefs via notes

Jira: [DOC-11322](https://issues.couchbase.com/browse/DOC-11322)