### PR TITLE
Fix crash bug: premature release of ResultSet

### DIFF
--- a/modules/java/examples/GetStartedWS/src/main/java/com/couchbase/gettingstarted/DBManager.java
+++ b/modules/java/examples/GetStartedWS/src/main/java/com/couchbase/gettingstarted/DBManager.java
@@ -2,6 +2,8 @@ package com.couchbase.gettingstarted;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Map;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -101,11 +103,15 @@ public class DBManager {
 
     // <.>
     // Create a query to fetch documents with language == Kotlin.
-    public List<Result> queryDocs(Collection collection) throws CouchbaseLiteException {
+    public List<Map<String, Object>> queryDocs(Collection collection) throws CouchbaseLiteException {
         Query query = QueryBuilder.select(SelectResult.all())
             .from(DataSource.collection(collection))
             .where(Expression.property("language").equalTo(Expression.string("Kotlin")));
-        try (ResultSet rs = query.execute()) { return rs.allResults(); }
+        List<Map<String, Object>> results = new ArrayList<>();
+        try (ResultSet rs = query.execute()) {
+            for (Result result: rs) { results.add(result.toMap()); }
+        }
+        return results;
     }
 
     // <.>

--- a/modules/java/examples/GetStartedWS/src/main/java/com/couchbase/gettingstarted/GettingStartedServlet.java
+++ b/modules/java/examples/GetStartedWS/src/main/java/com/couchbase/gettingstarted/GettingStartedServlet.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -78,7 +79,7 @@ public class GettingStartedServlet extends HttpServlet {
                 logToResponse("Learning :: " + doc.getString("language"));
             }
             mgr.updateDoc(coll, id);
-            List<Result> results = mgr.queryDocs(coll);
+            List<Map<String, Object>> results = mgr.queryDocs(coll);
             numRows = results.size();
             logToResponse("Number of rows :: " + numRows);
 

--- a/modules/java/examples/codesnippet_collection.java
+++ b/modules/java/examples/codesnippet_collection.java
@@ -243,7 +243,6 @@ package com.couchbase.codesnippets;
 
 import java.io.File;
 
-import kotlin.jvm.internal.Intrinsics;
 import org.jetbrains.annotations.NotNull;
 
 import com.couchbase.lite.Array;
@@ -268,13 +267,10 @@ public class BasicExamples {
         public void datatypeUsage() throws CouchbaseLiteException {
             // tag::datatype_usage[]
             // tag::datatype_usage_createdb[]
-            // Initialize the Couchbase Lite system
-            CouchbaseLite.init();
-
             // Get the database (and create it if it doesn’t exist).
             DatabaseConfiguration config = new DatabaseConfiguration();
             config.setDirectory(this.rootDir.getAbsolutePath());
-            Database database = new Database("getting-started", config)
+            Database database = new Database("getting-started", config);
             try (Collection collection = database.getCollection("myCollection")) {
                 if (collection == null) { throw new IllegalStateException("collection not found"); }
 
@@ -334,6 +330,14 @@ public class BasicExamples {
             // end::datatype_usage_closedb[]
 
             // end::datatype_usage[]
+        }
+
+        public void useExplicitType(Collection collection, Document someDoc) throws CouchbaseLiteException {
+            // tag::fleece-data-encoding[]
+            Document doc = collection.getDocument(someDoc.getId());
+            // force longVal to be type Long, even if it could be represented as an int.
+            long longVal = doc.getLong("test");
+            // end::fleece-data-encoding[]
         }
 
         public void datatypeDictionary(@NotNull Collection collection) throws CouchbaseLiteException {
@@ -2428,20 +2432,22 @@ public class QueryExamples {
         }
     }
 
-    public List<Result> docsOnlyQuerySyntaxN1QL(Database thisDb) throws CouchbaseLiteException {
+    public List<Map<String, Object>> docsOnlyQuerySyntaxN1QL(Database thisDb) throws CouchbaseLiteException {
         // For Documentation -- N1QL Query using parameters
         // tag::query-syntax-n1ql[]
         //  Declared elsewhere: Database thisDb
         Query thisQuery =
             thisDb.createQuery(
                 "SELECT META().id AS thisId FROM _ WHERE type = \"hotel\""); // <.>
+        List<Map<String, Object>> results = new ArrayList<>();
         try (ResultSet rs = thisQuery.execute()) {
-            return rs.allResults();
+            for (Result result: rs) { results.add(result.toMap()); }
         }
+        return results;
         // end::query-syntax-n1ql[]
     }
 
-    public List<Result> docsonlyQuerySyntaxN1QLParams(Database thisDb) throws CouchbaseLiteException {
+    public List<Map<String, Object>> docsonlyQuerySyntaxN1QLParams(Database thisDb) throws CouchbaseLiteException {
         // For Documentation -- N1QL Query using parameters
         // tag::query-syntax-n1ql-params[]
         //  Declared elsewhere: Database thisDb
@@ -2453,9 +2459,11 @@ public class QueryExamples {
         thisQuery.setParameters(
             new Parameters().setString("type", "hotel")); // <.>
 
+        List<Map<String, Object>> results = new ArrayList<>();
         try (ResultSet rs = thisQuery.execute()) {
-            return rs.allResults();
+            for (Result result: rs) { results.add(result.toMap()); }
         }
+        return results;
         // end::query-syntax-n1ql-params[]
     }
 }

--- a/modules/java/examples/snippets/common/main/java/com/couchbase/codesnippets/QueryExamples.java
+++ b/modules/java/examples/snippets/common/main/java/com/couchbase/codesnippets/QueryExamples.java
@@ -644,20 +644,22 @@ public class QueryExamples {
         }
     }
 
-    public List<Result> docsOnlyQuerySyntaxN1QL(Database thisDb) throws CouchbaseLiteException {
+    public List<Map<String, Object>> docsOnlyQuerySyntaxN1QL(Database thisDb) throws CouchbaseLiteException {
         // For Documentation -- N1QL Query using parameters
         // tag::query-syntax-n1ql[]
         //  Declared elsewhere: Database thisDb
         Query thisQuery =
             thisDb.createQuery(
                 "SELECT META().id AS thisId FROM _ WHERE type = \"hotel\""); // <.>
+        List<Map<String, Object>> results = new ArrayList<>();
         try (ResultSet rs = thisQuery.execute()) {
-            return rs.allResults();
+            for (Result result: rs) { results.add(result.toMap()); }
         }
+        return results;
         // end::query-syntax-n1ql[]
     }
 
-    public List<Result> docsonlyQuerySyntaxN1QLParams(Database thisDb) throws CouchbaseLiteException {
+    public List<Map<String, Object>> docsonlyQuerySyntaxN1QLParams(Database thisDb) throws CouchbaseLiteException {
         // For Documentation -- N1QL Query using parameters
         // tag::query-syntax-n1ql-params[]
         //  Declared elsewhere: Database thisDb
@@ -669,9 +671,11 @@ public class QueryExamples {
         thisQuery.setParameters(
             new Parameters().setString("type", "hotel")); // <.>
 
+        List<Map<String, Object>> results = new ArrayList<>();
         try (ResultSet rs = thisQuery.execute()) {
-            return rs.allResults();
+            for (Result result: rs) { results.add(result.toMap()); }
         }
+        return results;
         // end::query-syntax-n1ql-params[]
     }
 }


### PR DESCRIPTION
This is a pretty serious bug.
All the way back to 3.0 closing a ResultSet and then accessing a Result that it contains, will cause a native SEGV crash.