### PR TITLE
DOC-11614: Explain scope creation and dropping

### DIFF
--- a/modules/ROOT/pages/_partials/commons/common-scopes-collections-manage.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-scopes-collections-manage.adoc
@@ -61,6 +61,8 @@ NOTE: Scope and collection names are case sensitive.
 include::{root-partials}block_tabbed_code_example.adoc[]
 :param-tags!:
 
+NOTE: You cannot create an empty user-defined scope. 
+Scopes are an entity that contains collections, they are implicity created when a collection with documents associated to the provided scope is created.
 
 == Index a Collection
 
@@ -77,6 +79,8 @@ include::{root-partials}block_tabbed_code_example.adoc[]
 include::{root-partials}block_tabbed_code_example.adoc[]
 :param-tags!:
 
+NOTE: You cannot drop a user-defined scope.
+User-defined scopes are dropped when the collections associated with them contain no documents.
 
 == List Scopes and Collections
 

--- a/modules/ROOT/pages/_partials/commons/common-scopes-collections-manage.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-scopes-collections-manage.adoc
@@ -61,8 +61,17 @@ NOTE: Scope and collection names are case sensitive.
 include::{root-partials}block_tabbed_code_example.adoc[]
 :param-tags!:
 
+In the example above, you can see that `db.createCollection()` can take two parameters. 
+The first is the scope assigned to the created collection, if this parameter is omitted then a collection of the given name will be assigned to the `_default` scope. In this case, creating a collection called `Verlaine`.
+
+The second parameter is the name of the collection you want to create, in this case `Verlaine`.
+In the second section of the example you can see `db.createCollection("Television", "Verlaine")`. 
+This creates the collection `Verlaine` and then checks to see if the scope `Television` exists.
+If the scope `Television` exists, the collection `Verlaine` is assigned to the scope `Television`. If not, a new scope, `Television` is created and then the collection `Verlaine` is assigned to it.
+
 NOTE: You cannot create an empty user-defined scope. 
-Scopes are an entity that contains collections, they are implicity created when a collection with documents associated to the provided scope is created.
+A scope is implicitly created in the `db.createCollection()` method.
+
 
 == Index a Collection
 
@@ -79,7 +88,7 @@ include::{root-partials}block_tabbed_code_example.adoc[]
 include::{root-partials}block_tabbed_code_example.adoc[]
 :param-tags!:
 
-NOTE: You cannot drop a user-defined scope.
+NOTE: There is no need to drop a user-defined scope.
 User-defined scopes are dropped when the collections associated with them contain no documents.
 
 == List Scopes and Collections


### PR DESCRIPTION
-- ***WIP*** --

This PR shall hopefully contain the first iteration of a mobile refactor for a small section of the mobile docs codebase. The content of the change should stay the same.

[https://issues.couchbase.com/browse/DOC-11614](url)

This change addresses the following customer feedback:

"Here are the specific issues I'd like to highlight:

Creating a Scope: The documentation lacks clear and detailed instructions on how to create a scope programmatically using the Couchbase Lite Java SDK. As a developer, I have been unable to find any code examples or explanations in the documentation that guide me through this process.

Deleting a Scope: Similarly, there is a lack of information on how to safely delete a scope using the Couchbase Lite Java SDK while ensuring data integrity. Deleting scopes is a critical operation, and it is important to have clear documentation and examples to follow."

Scopes are more of a conceptual container and by design cannot be explicitly created or dropped. They exist to serve and organise collections. I have included the explanation in note blocks by the relevant topics to draw attention to this.

