### PR TITLE
DOC-11488: Remove logging info long out of support

### DIFF
--- a/modules/ROOT/pages/_partials/commons/common-logging.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-logging.adoc
@@ -247,22 +247,6 @@ $ .\cbl-log.exe logcat LOGFILE <OUTPUT_PATH>
 ====
 =====
 
-[#pre-2x5-logging]
-=== Logging functionality prior to Release 2.5
-
-.Deprecation
-[NOTE]
-include::{root-partials}block-deprecations.adoc[tag=logging25]
-
-The log messages are split into different domains (`LogDomains`) which can be tuned to different log levels.
-
-.Enable verbose logging on a domain
-:param-tags: logging
-:param-leader: The following example enables `verbose` logging for the `replicator` and `query` domains.
-include::{root-partials}block_tabbed_code_example.adoc[]
-:param-tags!:
-:param-leader!:
-
 // Begin - Output related content unless this inclusion is used as part of an encompassing page
 ifdef::param-fullpage[]
 include::{root-partials}block-related-content-query.adoc[]


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-11488

This fixes the ticket above. 

Description below: 
2.5 is long out of support so the deprecated techniques listed at the bottom of this page are no longer relevant.