### PR TITLE
DOC-11862: add ios deprecations

### DIFF
--- a/modules/ROOT/pages/_partials/supported-versions.adoc
+++ b/modules/ROOT/pages/_partials/supported-versions.adoc
@@ -224,6 +224,10 @@ h|Operating System|Version|Deprecation Release
 | 10.12.6 (High Sierra)
 | 3.0.0
 
+|iOS
+| iOS 10, iOS 11
+| 3.1.0
+
 |===
 
 == Removed Versions

--- a/modules/ROOT/pages/_partials/supported-versions.adoc
+++ b/modules/ROOT/pages/_partials/supported-versions.adoc
@@ -205,10 +205,10 @@ The following table identifies the <<supported-os-versions,supported platforms>>
 |Platform |Minimum OS version
 
 |iOS
-|10.0
+|10.0 - deprecated at 3.1.0
 
 |macOS
-| 10.14 (Mojave)
+| 10.14 (Mojave) - deprecated at 3.1.0
 |===
 
 NOTE: Couchbase Lite for {param-title} provides native support for both Mac Catalyst and M1.

--- a/modules/ROOT/pages/_partials/supported-versions.adoc
+++ b/modules/ROOT/pages/_partials/supported-versions.adoc
@@ -216,13 +216,17 @@ NOTE: Couchbase Lite for {param-title} provides native support for both Mac Cata
 
 == Deprecated Versions
 
-[#deprecated, cols="^1,^1,^1"]
+[#deprecated, cols="^1,^4,^1"]
 |===
 h|Operating System|Version|Deprecation Release
 
 |macOS
 | 10.12.6 (High Sierra)
 | 3.0.0
+
+|macOS
+| 10.14 (Mojave), 10.15 (Catalina), 11 (Big Sur)
+| 3.1.0
 
 |iOS
 | iOS 10, iOS 11


### PR DESCRIPTION
This is a fix for: https://issues.couchbase.com/browse/DOC-11862

Description: Acceptance Criteria
Mark iOS 10 and 11 as deprecated in the 3.1.0 release on CBL Swift and Objective C, e.g. https://docs.couchbase.com/couchbase-lite/current/swift/supported-os.html#deprecated-versions

Screenshot of fix applied to Obj-C. (Also on Swift)
![Screenshot 2024-02-15 at 13 44 18](https://github.com/couchbase/docs-couchbase-lite/assets/45071242/811d6946-a1f4-4f77-8706-dbef107a6955)

