### PR TITLE
DOC-11908: changes to page to reflect ionic app going opensource

### DIFF
--- a/modules/javascript/pages/ionic.adoc
+++ b/modules/javascript/pages/ionic.adoc
@@ -1,6 +1,6 @@
 = Ionic
 :page-partials:
-:page-edition: Enterprise
+:page-edition: 
 :page-toclevels: 2@
 :description: Using Couchbase Lite with Javascript Ionic applications
 
@@ -10,28 +10,43 @@ include::partial$_set_page_context_for_javascript.adoc[]
 :param-related: xref:cordova.adoc[] | xref:react.adoc[]
 include::{root-partials}_show_page_header_block.adoc[]
 
+.Support Changes
+[IMPORTANT]
+
+--
+* The Ionic bridging-layer plugin is now open source and community supported.
+* The Couchbase Lite Native API functionality, which contains storage and sync functionality, shall be fully supported as normal for Enterprise customers. 
+--
 
 == Introduction
 
 
 // tag::summary[]
-Ionic's Couchbase Lite integration is tailor-made for web developers, making it easy to build secure, high-performance, offline-enabled apps.
+Ionic's Couchbase Lite integration is an opensource solution for web developers, enabling easy to build secure, high-performance, offline-enabled apps.
 
 // end::summary[]
-This premier integration supports apps built for iOS, Android, and native Windows.
+This integration supports apps built for iOS, Android, and native Windows.
 
-.Community-Edition-Only
 [NOTE]
 --
-Users of Community Edition can instead build their own native plugin on top of Couchbase Lite's native API for iOS and Android.
+Users can build their own native plugin on top of Couchbase Lite's native API for iOS and Android.
 Ionic recommends use of
-https://capacitorjs.com/docs/plugins[Capacitor]
-, which can be used independent of the application's UI layer, to access native functionality from within Ionic apps.
+https://capacitorjs.com/docs/plugins[Capacitor], which can be used independent of the application's UI layer, to access native functionality from within Ionic apps.
 --
 
+== Opensource Plugin
+
+There are several benefits to be drawn from the opensource Ionic integration with Couchbase Lite:
+
+. It is free to use.
+. You have the flexibility to customise the plugin to your needs.
+. You have more control over the functionality of the plugin and how it interacts with your applications.
+. You can contribute to and engage with a community of developers who also make use of the plugin.
+
+You can also create your own plugin based on this by cloning the repository here[] and creating a private repo.
+Alternatively, you can build your own native application on top of https://capacitorjs.com/docs/plugins[Capacitor].
 
 == Accessing Couchbase Lite
-
 
 Using a robust JavaScript API, you can access the entirety of Couchbase Lite's functionality with no native experience required.
 
@@ -39,7 +54,6 @@ As a starting point, you should follow the hotel search tutorial. +
 The tutorial shows how to build an app that allows users to search and bookmark hotels.
 It uses data loaded from a Couchbase Lite database -- see the tutorial at
 https://ionic.io/docs/couchbase-lite/tutorials/hotel-search
-
 
 .Resources
 ****
@@ -57,6 +71,7 @@ Download::
 Reach out to _Ionic_ sales to get access, either from the
 https://ionic.io/docs/couchbase-lite[docs page] or this
 https://ionic.io/integrations/couchbase-lite[landing page]
+*[Insert link to plugin repo here]*
 
 ****
 

--- a/modules/javascript/pages/ionic.adoc
+++ b/modules/javascript/pages/ionic.adoc
@@ -14,8 +14,8 @@ include::{root-partials}_show_page_header_block.adoc[]
 [IMPORTANT]
 
 --
-* The Ionic bridging-layer plugin is now open source and community supported.
-* The Couchbase Lite Native API functionality, which contains storage and sync functionality, shall be fully supported as normal for Enterprise customers. 
+* The Ionic plugin is now open source and community supported.
+* The Couchbase Lite API, which contains storage and sync functionality, is fully supported as normal for Enterprise customers. 
 --
 
 == Introduction

--- a/modules/javascript/pages/ionic.adoc
+++ b/modules/javascript/pages/ionic.adoc
@@ -22,7 +22,7 @@ include::{root-partials}_show_page_header_block.adoc[]
 
 
 // tag::summary[]
-Ionic's Couchbase Lite integration is an opensource solution for web developers, enabling easy to build secure, high-performance, offline-enabled apps.
+Ionic's Couchbase Lite integration is an open source solution for web developers, enabling easy to build secure, high-performance, offline-enabled apps.
 
 // end::summary[]
 This integration supports apps built for iOS, Android, and native Windows.
@@ -34,9 +34,9 @@ Ionic recommends use of
 https://capacitorjs.com/docs/plugins[Capacitor], which can be used independent of the application's UI layer, to access native functionality from within Ionic apps.
 --
 
-== Opensource Plugin
+== Open source Plugin
 
-There are several benefits to be drawn from the opensource Ionic integration with Couchbase Lite:
+There are several benefits to be drawn from the open source Ionic integration with Couchbase Lite:
 
 . It is free to use.
 . You have the flexibility to customise the plugin to your needs.


### PR DESCRIPTION
This is a fix for the tickets: https://issues.couchbase.com/browse/DOC-11908
https://issues.couchbase.com/browse/DOC-11911

Communicate to users that the CBL Ionic Plugin is no longer supported by Ionic and that it is open sourced. For more context -> https://docs.google.com/document/d/10D_4vNx3bYN9JTHtsK0c1XvBVIfiSyYCAdp9KRbUtvw/edit?usp=sharing 

Aim is to reflect change to open source provision and emphasise benefits of open source nature rather than discourage customer usage.