### PR TITLE
3.2 beta tweak (no prerelease flag)

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,7 @@
 name: couchbase-lite
 version: '3.2'
-prerelease: Beta 1
+display_version: '3.2 Beta 1'
+# prerelease: Beta 1 # this setting affects the `current` naming
 title: Couchbase Lite
 start_page: ROOT:index.adoc
 nav:
@@ -15,6 +16,7 @@ nav:
 # - modules/ROOT/nav-javascript.adoc
 asciidoc:
   attributes:
+    # these settings affect the page-status "badge" on each page
     prerelease: Beta 1
     page-status: Beta 1
     release: '3.2'


### PR DESCRIPTION
If applied, this tweak would:

* make "3.2 Beta 1" the default version for mobile
* make it the "current" version
* this means there will be NO "You are viewing docs for a prerelease version" banner
* However, the "Beta 1" orange Page Status badge will show on each docs article page as before.