### PR TITLE
Doc 12022 spm instructions fix

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -12,11 +12,10 @@ nav:
 - modules/javascript/nav-javascript.adoc
 - modules/objc/nav-objc.adoc
 - modules/swift/nav-swift.adoc
-# - modules/ROOT/nav-javascript.adoc
 asciidoc:
   attributes:
-    prerelease: Beta 1
-    page-status: Beta 1
+    prerelease: Beta
+    page-status: Beta
     release: '3.2'
     major: 3
     minor: 2
@@ -26,4 +25,13 @@ asciidoc:
     maintenance-java: 0
     maintenance-net: 0
     base: 0
+
+    # Used for Vector Search Extension. 
+    vs-major: 1
+    vs-minor: 0
+    vs-maintenance-ios: 0
+    vs-maintenance-c: 0
+    vs-maintenance-android: 0
+    vs-maintenance-java: 0
+    vs-maintenance-net: 0
     page-toclevels: 2@

--- a/antora.yml
+++ b/antora.yml
@@ -16,7 +16,9 @@ asciidoc:
   attributes:
     prerelease: Beta
     page-status: Beta
+    previous-release: 3.1.6 
     release: '3.2'
+    releasetag: beta.1
     major: 3
     minor: 2
     maintenance-ios: 0

--- a/modules/ROOT/pages/_partials/_define_component_attributes.adoc
+++ b/modules/ROOT/pages/_partials/_define_component_attributes.adoc
@@ -11,9 +11,8 @@ ifdef::is_diag[_define_component_attributes.adoc]
 
 // Basic version for Vector Search
 :vs-version: {vs-major}.{vs-minor}
-// Base three digit version including optional tag
-:releasetag: beta.1
-:tag: {empty}
+
+// Base three digit version including optional release tag
 ifdef::releasetag[:tag: -{releasetag}]
 :version-full: {major}.{minor}.{base}{tag}
 :version-full-hyphenated: {major}-{minor}-{base}{tag}

--- a/modules/ROOT/pages/_partials/_define_component_attributes.adoc
+++ b/modules/ROOT/pages/_partials/_define_component_attributes.adoc
@@ -8,7 +8,11 @@ ifdef::is_diag[_define_component_attributes.adoc]
 
 // Basic version
 :version: {major}.{minor}
+
+// Basic version for Vector Search
+:vs-version: {vs-major}.{vs-minor}
 // Base three digit version including optional tag
+:releasetag: beta.1
 :tag: {empty}
 ifdef::releasetag[:tag: -{releasetag}]
 :version-full: {major}.{minor}.{base}{tag}
@@ -18,11 +22,20 @@ ifdef::releasetag[:tag: -{releasetag}]
 // version-maintenance is the full version including maintenance release number.
 // Note that the maintenance release is set at module level in the `_define_module_attributes.adoc` file
 // here at component level it is always same as version-full
-:version-maintenance-android: {major}.{minor}.{maintenance-android}
-:version-maintenance-c: {major}.{minor}.{maintenance-c}
-:version-maintenance-net: {major}.{minor}.{maintenance-net}
-:version-maintenance-java: {major}.{minor}.{maintenance-java}
-:version-maintenance-ios: {major}.{minor}.{maintenance-ios}
+:version-maintenance-android: {major}.{minor}.{maintenance-android}{tag}
+:version-maintenance-c: {major}.{minor}.{maintenance-c}{tag}
+:version-maintenance-net: {major}.{minor}.{maintenance-net}{tag}
+:version-maintenance-java: {major}.{minor}.{maintenance-java}{tag}
+:version-maintenance-ios: {major}.{minor}.{maintenance-ios}{tag}
+
+// vs-version-maintenance is the full version including maintenance release number of VECTOR SEARCH EXTENSION.
+// Note that the maintenance release is set at module level in the `_define_module_attributes.adoc` file
+// here at component level it is always same as version-full
+:vs-version-maintenance-android: {vs-major}.{vs-minor}.{vs-maintenance-android}
+:vs-version-maintenance-c: {vs-major}.{vs-minor}.{vs-maintenance-c}
+:vs-version-maintenance-net: {vs-major}.{vs-minor}.{vs-maintenance-net}
+:vs-version-maintenance-java: {vs-major}.{vs-minor}.{vs-maintenance-java}
+:vs-version-maintenance-ios: {vs-major}.{vs-minor}.{vs-maintenance-ios}
 
 // CAO versions used
 :version_cao: 2.0

--- a/modules/android/nav-android.adoc
+++ b/modules/android/nav-android.adoc
@@ -1,4 +1,4 @@
-:tag: -beta.1
+:tag:
 ifdef::releasetag[:tag: -{releasetag}]
 
 .xref:android:quickstart.adoc[Android]

--- a/modules/android/nav-android.adoc
+++ b/modules/android/nav-android.adoc
@@ -1,5 +1,4 @@
-:tag:
-ifdef::releasetag[:tag: -{releasetag}]
+include::partial$_set_page_context_for_android.adoc[]
 
 .xref:android:quickstart.adoc[Android]
   * Start Here!
@@ -45,8 +44,8 @@ ifdef::releasetag[:tag: -{releasetag}]
   *** xref:android:p2psync-custom.adoc[Integrate Custom Listener]
 
   * xref:android:conflict.adoc[Handling Data Conflicts]
-  * https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-android}{tag}/couchbase-lite-android/[API References]
-  * https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-android}{tag}/couchbase-lite-android-ktx[Kotlin Extensions]
+  * https://docs.couchbase.com/mobile/{version-maintenance-android}/couchbase-lite-android/[API References]
+  * https://docs.couchbase.com/mobile/{version-maintenance-android}/couchbase-lite-android-ktx[Kotlin Extensions]
 
   * xref:android:upgrade.adoc[Upgrade]
 

--- a/modules/android/pages/_partials/_define_module_attributes.adoc
+++ b/modules/android/pages/_partials/_define_module_attributes.adoc
@@ -6,6 +6,12 @@
 // SET full maintennce version number
 :version-maintenance: {version}.{maintenance-android}{tag}
 :version-maintenance-hyphenated: {major}-{minor}-{maintenance-android}{tag}
+
+// VECTOR SEARCH attributes
+:vs-version-maintenance: {vs-version}.{vs-maintenance-android}{tag}
+:vs-version-maintenance-hyphenated: {vs-major}-{vs-minor}-{vs-maintenance-android}{tag}
+//
+
 // BEGIN::module page attributes
 :module: {param-module}
 :packageNm: couchbase-lite-{module}

--- a/modules/android/pages/gs-install.adoc
+++ b/modules/android/pages/gs-install.adoc
@@ -28,7 +28,7 @@ Installation instructions are included in the step-by-step install guides for bo
 
 .Couchbase Lite Quick Steps
 ****
-For experienced developers, this is all you need to add _Couchbase Lite for {param-title} {version-maintenance-android} Beta to your application projects.
+For experienced developers, this is all you need to add _Couchbase Lite for {param-title} {version-maintenance-android} to your application projects.
 
 [{tabs}]
 =====
@@ -38,7 +38,7 @@ Kotlin - Enterprise::
 --
 . Create a Kotlin Android app project in Android Studio
 . Add Couchbase Lite as a dependency in your app-level `build.gradle` +
-`implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}-beta.1'`
+`implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}'`
 . Add the following _maven_ repo to your repositories (in `build.gradle` or `settings.gradle` as required +
 `https://mobile.maven.couchbase.com/maven2/dev/`
 . Build the project and it will pull Couchbase Lite down.
@@ -49,7 +49,7 @@ Kotlin - Community::
 --
 . Create a Kotlin Android app project in Android Studio
 . Add Couchbase Lite as a dependency in your app-level `build.gradle` +
-`implementation 'com.couchbase.lite:couchbase-lite-android-ktx:{version-maintenance-android}-beta.1'`
+`implementation 'com.couchbase.lite:couchbase-lite-android-ktx:{version-maintenance-android}'`
 . Check you have `mavenCentral()` in `repositories` (or in `settings.gradle`)
 . Build the project and it will pull Couchbase Lite down.
 --
@@ -59,7 +59,7 @@ Java - Enterprise::
 --
 . Create a Java Android app project in Android Studio
 . Add Couchbase Lite as a dependency in your app-level `build.gradle` +
-`implementation 'com.couchbase.lite:couchbase-lite-android-ee:{version-maintenance-android}-beta.1'`
+`implementation 'com.couchbase.lite:couchbase-lite-android-ee:{version-maintenance-android}'`
 . Add the following _maven_ repo to your repositories (in `build.gradle` or `settings.gradle` as required +
 `https://mobile.maven.couchbase.com/maven2/dev/`
 . Build the project and it will pull Couchbase Lite down.
@@ -70,7 +70,7 @@ Java - Community::
 --
 . Create a Java Android app project in Android Studio
 . Add Couchbase Lite as a dependency in your app-level `build.gradle` +
-`implementation 'com.couchbase.lite:couchbase-lite-android:{version-maintenance-android}-beta.1'`
+`implementation 'com.couchbase.lite:couchbase-lite-android:{version-maintenance-android}'`
 . Check you have `mavenCentral()` in `repositories` (or in `settings.gradle`)
 . Build the project and it will pull Couchbase Lite down.
 --
@@ -136,7 +136,7 @@ repositories {
 ----
 dependencies {
 
-  implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}-beta.1'
+  implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}'
 
 //   ... other section content as required by user
 }
@@ -198,10 +198,10 @@ repositories {
 ----
 dependencies {
 
-  implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}-beta.1'
+  implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}'
 
   // All standard 64-bit ARM architectures
-  implementation 'com.couchbase.lite:couchbase-lite-android-vector-search-arm64-1.0.0-beta.1'
+  implementation 'com.couchbase.lite:couchbase-lite-android-vector-search-arm64-{vs-version-maintenance}'
 
 //   ... other section content as required by user
 }
@@ -213,9 +213,9 @@ dependencies {
 ----
 dependencies {
 
-  implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}-beta.1'
+  implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}'
 
-  implementation 'com.couchbase.lite:couchbase-lite-android-vector-search-x86_64-1.0.0-beta.1'
+  implementation 'com.couchbase.lite:couchbase-lite-android-vector-search-x86_64-{vs-version-maintenance}'
 
 //   ... other section content as required by user
 }
@@ -259,7 +259,7 @@ repositories {
 ----
 dependencies {
 
-  implementation "com.couchbase.lite:couchbase-lite-android-ktx:{version-maintenance-android}-beta.1"
+  implementation "com.couchbase.lite:couchbase-lite-android-ktx:{version-maintenance-android}"
 
 //   ... other section content as required by user
 }
@@ -325,7 +325,7 @@ repositories {
 ----
 dependencies {
 
-  implementation 'com.couchbase.lite:couchbase-lite-android-ee:{version-maintenance-android}-beta.1'
+  implementation 'com.couchbase.lite:couchbase-lite-android-ee:{version-maintenance-android}'
 
 //   ... other section content as required by user
 }
@@ -387,10 +387,10 @@ repositories {
 ----
 dependencies {
 
-  implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}-beta.1'
+  implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}'
 
   // All standard 64-bit ARM architectures
-  implementation 'com.couchbase.lite:couchbase-lite-android-vector-search-arm64-1.0.0-beta.1'
+  implementation 'com.couchbase.lite:couchbase-lite-android-vector-search-arm64-{vs-version-maintenance}'
 
 //   ... other section content as required by user
 }
@@ -402,9 +402,9 @@ dependencies {
 ----
 dependencies {
 
-  implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}-beta.1'
+  implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}'
 
-  implementation 'com.couchbase.lite:couchbase-lite-android-vector-search-x86_64-1.0.0-beta.1'
+  implementation 'com.couchbase.lite:couchbase-lite-android-vector-search-x86_64-1.0.0-{vs-version-maintenance}'
 
 //   ... other section content as required by user
 }
@@ -452,7 +452,7 @@ repositories {
 [source,groovy, subs="attributes+"]
 ----
 dependencies {
-  implementation 'com.couchbase.lite:couchbase-lite-android:{version-maintenance-android}-beta.1'
+  implementation 'com.couchbase.lite:couchbase-lite-android:{version-maintenance-android}'
 //   ... other section content as required by user
 }
 ----

--- a/modules/android/pages/gs-prereqs.adoc
+++ b/modules/android/pages/gs-prereqs.adoc
@@ -58,11 +58,11 @@ IMPORTANT: The beta version of the Vector Search extension library does not supp
 
 |Android
 |arm64-v8a
-|22
+|23
 
 |Android
 |x86_64
-|22
+|23
 |===
 
 include::{root-partials}block-related-content-start.adoc[]

--- a/modules/c/nav-c.adoc
+++ b/modules/c/nav-c.adoc
@@ -33,7 +33,9 @@
 
   * xref:c:conflict.adoc[Handling Data Conflicts]
 
-  * https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-c}/couchbase-lite-c/[API{nbsp}References]
+ // TODO change to {major}.{minor}.{maintenance-c}{tag} once beta version of 3.2 for C released
+ 
+  * https://docs.couchbase.com/mobile/{previous-release}/couchbase-lite-c/C/html/modules.html[API{nbsp}References]
 
   * Product Notes
     ** xref:c:releasenotes.adoc[Release Notes]

--- a/modules/csharp/nav-csharp.adoc
+++ b/modules/csharp/nav-csharp.adoc
@@ -36,7 +36,9 @@
 
   * xref:csharp:conflict.adoc[Handling Data Conflicts]
 
-  * https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}/couchbase-lite-net/index.html[API{nbsp}References]
+ // TODO change to {major}.{minor}.{maintenance-c}{tag} once beta version of 3.2 for .Net released
+ 
+  * https://docs.couchbase.com/mobile/{previous-release}/couchbase-lite-net/index.html[API{nbsp}References]
 
   * xref:csharp:upgrade.adoc[Upgrade]
 

--- a/modules/java/nav-java.adoc
+++ b/modules/java/nav-java.adoc
@@ -37,7 +37,9 @@
 
   * xref:java:conflict.adoc[Handling Data Conflicts]
 
-  * https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-java}/couchbase-lite-java/[API{nbsp}References]
+ // TODO change to {major}.{minor}.{maintenance-c}{tag} once beta version of 3.2 for Java Desktop released
+ 
+  * https://docs.couchbase.com/mobile/{previous-release}/couchbase-lite-java/[API{nbsp}References]
 
   * xref:java:upgrade.adoc[Upgrade]
 

--- a/modules/objc/nav-objc.adoc
+++ b/modules/objc/nav-objc.adoc
@@ -1,5 +1,4 @@
-:tag:
-ifdef::releasetag[:tag: -{releasetag}]
+include::partial$_set_page_context_for_objc.adoc[]
 
 .xref:objc:quickstart.adoc[Objective-C]
   * Start Here!
@@ -44,7 +43,7 @@ ifdef::releasetag[:tag: -{releasetag}]
 
   * xref:objc:conflict.adoc[Handling Data Conflicts]
 
-  * https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{tag}/couchbase-lite-objc/index.html[API{nbsp}References]
+  * https://docs.couchbase.com/mobile/{version-maintenance-ios}/couchbase-lite-objc/index.html[API{nbsp}References]
 
   * xref:objc:upgrade.adoc[Upgrade]
 

--- a/modules/objc/nav-objc.adoc
+++ b/modules/objc/nav-objc.adoc
@@ -1,4 +1,4 @@
-:tag: -beta.1
+:tag:
 ifdef::releasetag[:tag: -{releasetag}]
 
 .xref:objc:quickstart.adoc[Objective-C]

--- a/modules/objc/pages/_partials/_define_module_attributes.adoc
+++ b/modules/objc/pages/_partials/_define_module_attributes.adoc
@@ -20,6 +20,11 @@
 :version-maintenance-hyphenated: {major}-{minor}-{maintenance-ios}{tag}
 //
 
+// VECTOR SEARCH attributes
+:vs-version-maintenance: {vs-version}.{vs-maintenance-ios}{tag}
+:vs-version-maintenance-hyphenated: {vs-major}-{vs-minor}-{vs-maintenance-ios}{tag}
+//
+
 
 
 // BEGIN - Set attributes pointing to API references for this module

--- a/modules/objc/pages/gs-install.adoc
+++ b/modules/objc/pages/gs-install.adoc
@@ -17,7 +17,7 @@ include::{root-partials}_show_page_header_block.adoc[]
 
 == Get Started
 
-Create or open an existing _Xcode_ project and install _Couchbase Lite {version-full}_ using one of the <<lbl-install-tabs>> methods shown.
+Create or open an existing _Xcode_ project and install _Couchbase Lite {version-full} using one of the <<lbl-install-tabs>> methods shown.
 
 Enterprise users can also download the Couchbase Lite Vector Search extension library.
 
@@ -70,7 +70,7 @@ NOTE: The minimum required version of Cocoapods is *1.15*
 ----
 target '<your target name>' do
   use_frameworks!
-  pod 'CouchbaseLite', '{version-full}-beta.1'
+  pod 'CouchbaseLite', '{version-full}'
 end
 ----
 +
@@ -79,7 +79,7 @@ end
 ----
 target '<your target name>' do
   use_frameworks!
-  pod 'CouchbaseLite-Enterprise', '{version-full}-beta.1'
+  pod 'CouchbaseLite-Enterprise', '{version-full}'
 end
 ----
 
@@ -135,7 +135,7 @@ NOTE: The minimum required Cocoapods  version is *1.15*
 ----
 target 'Example' do
   use_frameworks!
-  pod 'CouchbaseLiteVectorSearch', '1.0.0-beta.1' // <.>
+  pod 'CouchbaseLiteVectorSearch', '{vs-version-maintenance}' // <.>
 end
 ----
 

--- a/modules/swift/nav-swift.adoc
+++ b/modules/swift/nav-swift.adoc
@@ -1,5 +1,4 @@
-:tag:
-ifdef::releasetag[:tag: -{releasetag}]
+include::partial$_set_page_context_for_swift.adoc[]
 
 .xref:swift:quickstart.adoc[Swift]
   * Start Here!
@@ -43,7 +42,7 @@ ifdef::releasetag[:tag: -{releasetag}]
 
   * xref:swift:conflict.adoc[Handling Data Conflicts]
 
-  * https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{tag}/couchbase-lite-swift/index.html[API{nbsp}References]
+  * https://docs.couchbase.com/mobile/{version-maintenance-ios}/couchbase-lite-swift/index.html[API{nbsp}References]
 
   * xref:swift:upgrade.adoc[Upgrade]
 

--- a/modules/swift/nav-swift.adoc
+++ b/modules/swift/nav-swift.adoc
@@ -1,5 +1,4 @@
-:tag: -beta.1
-ifdef::releasetag[:tag: -{releasetag}]
+include::swift:pages/partial$_set_page_context_for_swift.adoc[]
 
 .xref:swift:quickstart.adoc[Swift]
   * Start Here!

--- a/modules/swift/nav-swift.adoc
+++ b/modules/swift/nav-swift.adoc
@@ -1,4 +1,5 @@
-include::swift:pages/partial$_set_page_context_for_swift.adoc[]
+:tag:
+ifdef::releasetag[:tag: -{releasetag}]
 
 .xref:swift:quickstart.adoc[Swift]
   * Start Here!

--- a/modules/swift/pages/_partials/_define_module_attributes.adoc
+++ b/modules/swift/pages/_partials/_define_module_attributes.adoc
@@ -16,6 +16,10 @@
 //
 :version-maintenance: {version}.{maintenance-ios}{tag}
 :version-maintenance-hyphenated: {major}-{minor}-{maintenance-ios}{tag}
+
+// VECTOR SEARCH attributes
+:vs-version-maintenance: {vs-version}.{vs-maintenance-ios}{tag}
+:vs-version-maintenance-hyphenated: {vs-major}-{vs-minor}-{vs-maintenance-ios}{tag}
 //
 
 

--- a/modules/swift/pages/_partials/gs-install-tab-cocoapods.adoc
+++ b/modules/swift/pages/_partials/gs-install-tab-cocoapods.adoc
@@ -10,7 +10,7 @@ NOTE: The minimum required Cocoapods  version is *1.15*
 ----
 target 'Example' do
   use_frameworks!
-  pod 'CouchbaseLite-Swift', '{version-maintenance}-beta.1' // <.>
+  pod 'CouchbaseLite-Swift', '{version-maintenance}' // <.>
 end
 ----
 +
@@ -22,7 +22,7 @@ end
 ----
 target 'Example' do
   use_frameworks!
-  pod 'CouchbaseLite-Swift-Enterprise', '{version-maintenance}-beta.1' // <.>
+  pod 'CouchbaseLite-Swift-Enterprise', '{version-maintenance}' // <.>
 end
 ----
 

--- a/modules/swift/pages/_partials/gs-install-tab-spm.adoc
+++ b/modules/swift/pages/_partials/gs-install-tab-spm.adoc
@@ -21,7 +21,7 @@ Here we will add the `CouchbaseLiteSwift` dependency to your Parent Swift packag
 dependencies: [
   .package(name: "CouchbaseLiteSwift",
     url: "insert Couchbase Lite URL", // <.>
-    from: "{version-maintenance}-beta.1"), // <.>
+    from: "{version-maintenance}"), // <.>
   ],
 ----
 

--- a/modules/swift/pages/gs-install.adoc
+++ b/modules/swift/pages/gs-install.adoc
@@ -99,7 +99,7 @@ NOTE: The minimum required Cocoapods  version is *1.15*
 ----
 target 'Example' do
   use_frameworks!
-  pod 'CouchbaseLiteVectorSearch', '1.0.0-beta.1' // <.>
+  pod 'CouchbaseLiteVectorSearch', '{vs-version-maintenance}' // <.>
 end
 ----
 
@@ -138,7 +138,7 @@ Here we will add the `CouchbaseLiteVectorSearch` package as a dependency to your
 dependencies: [
   .package(name: "CouchbaseLiteVectorSearch",
     url: "https://github.com/couchbase/couchbase-lite-vector-search-spm.git", 
-    from: "1.0.0-beta.1"), 
+    from: "{vs-version-maintenance}"), 
   ],
 ----
 
@@ -178,11 +178,11 @@ image::spm-2.png[]
 
 . In the _Choose Package Repository_ dialog: +
 *Enter* the appropriate Couchbase Lite URL, btn:[Next] to continue +
-For Vector Search Beta-1: https://github.com/couchbase/couchbase-lite-vector-search-spm.git
+For Vector Search: https://github.com/couchbase/couchbase-lite-vector-search-spm.git
 +
 image::spm-3.png[]
 
-. *Enter* the required *_Version_* (1.0.0-beta.1) and btn:[Next] to continue
+. *Enter* the required *_Version_* ({vs-version-maintenance}) and btn:[Next] to continue
 +
 image::spm-4.png[]
 


### PR DESCRIPTION
Fixed SPM instructions referencing incorrect version (3.1.6 instead of 3.2.0-beta.1)

Caused by incorrect attribute values used.

Expanded scope on the logic that now the attribute was fixed it should be applied to the pages and modules that required it.
Also did some fly-bys

-  Updated minimum API version on android to 23
-  Changed 'Beta 1' text to just 'Beta' as decision was made to change it on docs site rather than beta 1,2,3 as there is no need to have separate pages for the versions.
-  Added attributes for vector search for all sdks to remove hardcoded version for that too as this will be useful for subsequent vector search releases and was needed anyway.
- Changed hardcoded tag attribute in swift, android and objc navs to an include of the relevant module component 
-  Added a previous-version attribute to antora.yml so we don't get a 403 on api reference docs for mobile sdks yet to have a 3.2.0 beta release

