### PR TITLE
Doc 12113 fix download link

### DIFF
--- a/modules/android/pages/gs-prereqs.adoc
+++ b/modules/android/pages/gs-prereqs.adoc
@@ -15,7 +15,7 @@ include::{root-partials}_show_page_header_block.adoc[]
 // DO NOT EDIT
 // :ziputils: ROOT:example$/java-android/app/src/main/java/com/couchbase/code_snippets/ZipUtils.java
 
-.Supported Versions
+== Supported Versions
 
 The operating systems listed below refer to "Certified" versions of Android.
 We do not test against, nor guarantee support for, uncertified Android versions such as versions built from source.
@@ -48,7 +48,7 @@ include::{root-partials}deprecationNotice.adoc[]
 |22
 |===
 
-.Supported Versions for Vector Search 3.2.0 Beta
+== Supported Versions for Vector Search 3.2.0 Beta
 
 IMPORTANT: The beta version of the Vector Search extension library does not support 32-bit architectures.
 

--- a/modules/objc/pages/gs-install.adoc
+++ b/modules/objc/pages/gs-install.adoc
@@ -109,7 +109,7 @@ Direct Download::
 +
 --
 
-. Download the binaries from here -- {downloads-mobile--xref}.
+. Download the binaries from here -- https://packages.couchbase.com/releases/couchbase-lite-vector-search/{vs-version-maintenance}/couchbase-lite-vector-search_xcframework_{vs-version-maintenance}.zip[binary download link.]
 
 . Unpack the download zip file into your XCode project location.
 

--- a/modules/swift/pages/gs-install.adoc
+++ b/modules/swift/pages/gs-install.adoc
@@ -73,7 +73,7 @@ Direct Download::
 +
 --
 
-. Download the binaries from here -- {downloads-mobile--xref}.
+. Download the binaries from here -- https://packages.couchbase.com/releases/couchbase-lite-vector-search/{vs-version-maintenance}/couchbase-lite-vector-search_xcframework_{vs-version-maintenance}.zip[binary download link.]
 
 . Unpack the download zip file into your XCode project location.
 


### PR DESCRIPTION
Fix for the following ticket: https://issues.couchbase.com/browse/DOC-12113

Fixed swift direct download instructions link pointing to CB downloads page which... points to our install docs again.

After some testing across other Vector Search pages, also found the bug in the Obj-C docs and applied the same fix.

Binary is for an iOS download so Swift and Obj-C use the same link.

Fly by fix to Android prereqs docs to fix formatting in which the vector search extension prereqs were unclear due to being added to important admonition instead of separated from it.