### PR TITLE
Doc 12181 3.1.7 relnotes

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -22,12 +22,12 @@ asciidoc:
     release: '3.1'
     major: 3
     minor: 1
-    maintenance-ios: 6
-    maintenance-c: 6
-    maintenance-android: 6
-    maintenance-java: 6
-    maintenance-net: 6
-    base: 6 # generic maintenance base, may no longer apply when versions deviate, change to version-maint-mobilesdk later rather than using base
+    maintenance-ios: 7
+    maintenance-c: 7
+    maintenance-android: 7
+    maintenance-java: 7
+    maintenance-net: 7
+    base: 7 # generic maintenance base, may no longer apply when versions deviate, change to version-maint-mobilesdk later rather than using base
     page-toclevels: 2@
     # releasetag:
     # show_edition:

--- a/modules/android/pages/releasenotes.adoc
+++ b/modules/android/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_android.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-android-release-note.3.1.7.adoc[]
+
 include::partial$release-notes/couchbase-mobile-android-release-note.3.1.6.adoc[]
 
 include::partial$release-notes/couchbase-mobile-android-release-note.3.1.3.adoc[]

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.7.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.7.adoc
@@ -1,0 +1,37 @@
+[#maint-3-1-7]
+== 3.1.7 -- May 2024
+
+Version 3.1.7 for {param-title} delivers the following features and enhancements:
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBL-5645[CBL-5645 -- Allow to close the socket while connecting to the remote server]
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5521[CBL-5521 -- Fixed N1QL Parser has exponential slowdown for redundant parentheses]
+
+* https://issues.couchbase.com/browse/CBL-5569[CBL-5569 -- Fixed Text Log Files do not have date included in the log timestamp]
+
+* https://issues.couchbase.com/browse/CBL-5631[CBL-5631 -- Fixed pthread_mutex_lock called on a destroyed mutex]
+
+* https://issues.couchbase.com/browse/CBL-5642[CBL-5642 -- Fixed Null dereference crash in gotHTTPResponse]
+
+* https://issues.couchbase.com/browse/CBL-5652[CBL-5652 -- Fixed HELIUM: toJSON should throw unchecked exception]
+
+* https://issues.couchbase.com/browse/CBL-5653[CBL-5653 -- Fixed HELIUM: Client Task executor should not fail on RejectedExecution]
+
+* https://issues.couchbase.com/browse/CBL-5655[CBL-5655 -- Fixed HELIUM: Native crash in objects derived from ResultSet]
+
+* https://issues.couchbase.com/browse/CBL-5657[CBL-5657 -- Fixed HELIUM: NativeC4QueryObserver.free should disable the listener before freeing it]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -24,6 +24,7 @@ include::{root-partials}_show_get_started_topic_group.adoc[]
  
 .Downloads are available for the following versions:
 ****
+<<release-3-1-7>>
 <<release-3-1-6>>
 <<release-3-1-3>>
 <<release-3-1-1>>
@@ -32,6 +33,11 @@ include::{root-partials}_show_get_started_topic_group.adoc[]
 ****
 
 // This block will always represent the major release version
+:param-version: 3.1.7
+:param-version-hyphenated: 3-1-7
+include::partial$downloadslist.adoc[]
+:param-version!:
+
 :param-version: 3.1.6
 :param-version-hyphenated: 3-1-6
 include::partial$downloadslist.adoc[]

--- a/modules/c/pages/releasenotes.adoc
+++ b/modules/c/pages/releasenotes.adoc
@@ -13,7 +13,12 @@ include::partial$_set_page_context_for_c.adoc[]
 include::{root-partials}_show_page_header_block.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-c-release-note.3.1.7.adoc[]
+
 include::partial$release-notes/couchbase-mobile-c-release-note.3.1.6.adoc[]
+
 include::partial$release-notes/couchbase-mobile-c-release-note.3.1.3.adoc[]
+
 include::partial$release-notes/couchbase-mobile-c-release-note.3.1.1.adoc[]
+
 include::partial$release-notes/couchbase-mobile-c-release-note.3.1.0.adoc[]

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.6.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.6.adoc
@@ -1,4 +1,4 @@
-[#maint-3-1-3]
+[#maint-3-1-6]
 == 3.1.6 -- March 2024
 
 Version 3.1.6 for {param-title} delivers the following features and enhancements:

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.7.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.7.adoc
@@ -1,0 +1,33 @@
+[#maint-3-1-7]
+== 3.1.7 -- May 2024
+
+Version 3.1.7 for {param-title} delivers the following features and enhancements:
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5521[CBL-5521 -- Fixed N1QL Parser has exponential slowdown for redundant parentheses]
+
+* https://issues.couchbase.com/browse/CBL-5569[CBL-5569 -- Fixed Text Log Files do not have date included in the log timestamp]
+
+* https://issues.couchbase.com/browse/CBL-5606[CBL-5606 -- Fixed save document could be blocked when using database change listener]
+
+* https://issues.couchbase.com/browse/CBL-5631[CBL-5631 -- Fixed pthread_mutex_lock called on a destroyed mutex]
+
+* https://issues.couchbase.com/browse/CBL-5642[CBL-5642 -- Fixed Null dereference crash in gotHTTPResponse]
+
+* https://issues.couchbase.com/browse/CBL-5661[CBL-5661 -- Fixed invalidated context may be used in query observer callback]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release

--- a/modules/csharp/pages/releasenotes.adoc
+++ b/modules/csharp/pages/releasenotes.adoc
@@ -9,8 +9,12 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_csharp.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-csharp-release-note.3.1.7.adoc[]
+
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.1.6.adoc[]
+
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.1.3.adoc[]
 
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.1.1.adoc[]
+
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.1.0.adoc[]

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.7.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.7.adoc
@@ -1,0 +1,30 @@
+[#maint-3-1-7]
+== 3.1.7 -- May 2024
+
+Version 3.1.7 for {param-title} delivers the following features and enhancements:
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5521[CBL-5521 -- Fixed N1QL Parser has exponential slowdown for redundant parentheses]
+* https://issues.couchbase.com/browse/CBL-5569[CBL-5569 -- Fixed Text Log Files do not have date included in the log timestamp]
+
+* https://issues.couchbase.com/browse/CBL-5631[CBL-5631 -- Fixed pthread_mutex_lock called on a destroyed mutex]
+
+* https://issues.couchbase.com/browse/CBL-5642[CBL-5642 -- Fixed Null dereference crash in gotHTTPResponse]
+
+* https://issues.couchbase.com/browse/CBL-5649[CBL-5649 -- Fixed Context object for LiveQuerier never freed]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+* https://issues.couchbase.com/browse/CBL-5305[CBL-5305 -- Version specific RIDs are deprecated]

--- a/modules/java/pages/releasenotes.adoc
+++ b/modules/java/pages/releasenotes.adoc
@@ -9,9 +9,13 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_java.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-java-release-note.3.1.7.adoc[]
+
 include::partial$release-notes/couchbase-mobile-java-release-note.3.1.6.adoc[]
+
 include::partial$release-notes/couchbase-mobile-java-release-note.3.1.3.adoc[]
 
 include::partial$release-notes/couchbase-mobile-java-release-note.3.1.1.adoc[]
+
 include::partial$release-notes/couchbase-mobile-java-release-note.3.1.0.adoc[]
 

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.7.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.7.adoc
@@ -1,0 +1,37 @@
+[#maint-3-1-7]
+== 3.1.7 -- May 2024
+
+Version 3.1.7 for {param-title} delivers the following features and enhancements:
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBL-5645[CBL-5645 -- Allow to close the socket while connecting to the remote server]
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5521[CBL-5521 -- Fixed N1QL Parser has exponential slowdown for redundant parentheses]
+
+* https://issues.couchbase.com/browse/CBL-5569[CBL-5569 -- Fixed Text Log Files do not have date included in the log timestamp]
+
+* https://issues.couchbase.com/browse/CBL-5631[CBL-5631 -- Fixed pthread_mutex_lock called on a destroyed mutex]
+
+* https://issues.couchbase.com/browse/CBL-5642[CBL-5642 -- Fixed Null dereference crash in gotHTTPResponse]
+
+* https://issues.couchbase.com/browse/CBL-5652[CBL-5652 -- Fixed HELIUM: toJSON should throw unchecked exception]
+
+* https://issues.couchbase.com/browse/CBL-5653[CBL-5653 -- Fixed HELIUM: Client Task executor should not fail on RejectedExecution]
+
+* https://issues.couchbase.com/browse/CBL-5655[CBL-5655 -- Fixed HELIUM: Native crash in objects derived from ResultSet]
+
+* https://issues.couchbase.com/browse/CBL-5657[CBL-5657 -- Fixed HELIUM: NativeC4QueryObserver.free should disable the listener before freeing it]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release

--- a/modules/objc/pages/releasenotes.adoc
+++ b/modules/objc/pages/releasenotes.adoc
@@ -9,10 +9,15 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_objc.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.7.adoc[]
+
 include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.6.adoc[]
+
 include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.4.adoc[]
+
 include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.3.adoc[]
 
 include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.1.adoc[]
+
 include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.0.adoc[]
 

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.7.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.7.adoc
@@ -1,0 +1,33 @@
+[#maint-3-1-7]
+== 3.1.7 -- May 2024
+
+Version 3.1.7 for {param-title} delivers the following features and enhancements:
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBL-5458[CBL-5458 -- Added missing Objective-C symbols in the exp file]
+
+* https://issues.couchbase.com/browse/CBL-5544[CBL-5544 -- Added missing required keys to Privacy Manifest file]
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5521[CBL-5521 -- Fixed N1QL Parser has exponential slowdown for redundant parentheses]
+
+* https://issues.couchbase.com/browse/CBL-5569[CBL-5569 -- Fixed Text Log Files do not have date included in the log timestamp]
+
+* https://issues.couchbase.com/browse/CBL-5631[CBL-5631 -- Fixed pthread_mutex_lock called on a destroyed mutex]
+
+* https://issues.couchbase.com/browse/CBL-5642[CBL-5642 -- Fixed Null dereference crash in gotHTTPResponse]
+
+* https://issues.couchbase.com/browse/CBL-5659[CBL-5659 -- Fixed invalidated context may be used in query observer callback]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release

--- a/modules/swift/pages/releasenotes.adoc
+++ b/modules/swift/pages/releasenotes.adoc
@@ -9,8 +9,14 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_swift.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.7.adoc[]
+
 include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.6.adoc[]
+
 include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.4.adoc[]
+
 include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.3.adoc[]
+
 include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.1.adoc[]
+
 include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.0.adoc[]

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.7.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.7.adoc
@@ -1,0 +1,33 @@
+[#maint-3-1-7]
+== 3.1.7 -- May 2024
+
+Version 3.1.7 for {param-title} delivers the following features and enhancements:
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]
+
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBL-5458[CBL-5458 -- Added missing Objective-C symbols in the exp file]
+
+* https://issues.couchbase.com/browse/CBL-5544[CBL-5544 -- Added missing required keys to Privacy Manifest file]
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5521[CBL-5521 -- Fixed N1QL Parser has exponential slowdown for redundant parentheses]
+
+* https://issues.couchbase.com/browse/CBL-5569[CBL-5569 -- Fixed Text Log Files do not have date included in the log timestamp]
+
+* https://issues.couchbase.com/browse/CBL-5631[CBL-5631 -- Fixed pthread_mutex_lock called on a destroyed mutex]
+
+* https://issues.couchbase.com/browse/CBL-5642[CBL-5642 -- Fixed Null dereference crash in gotHTTPResponse]
+
+* https://issues.couchbase.com/browse/CBL-5659[CBL-5659 -- Fixed invalidated context may be used in query observer callback]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release


### PR DESCRIPTION
Release notes for 3.1.7 maintenance release.
Also includes a quick fix to a label in c release notes pointing to the wrong version.
Antora.yml updated so version attributes now say 3.1.7 instead of 3.1.6 for 3.1 docs.