### PR TITLE
[BACKPORT] DOC-12292: Now navigates straight to page

### DIFF
--- a/modules/c/nav-c.adoc
+++ b/modules/c/nav-c.adoc
@@ -33,7 +33,7 @@
 
   * xref:c:conflict.adoc[Handling Data Conflicts]
 
-  * https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-c}/couchbase-lite-c/[API{nbsp}References]
+  * https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-c}/couchbase-lite-c/C/html/modules.html[API{nbsp}References]
 
   * Product Notes
     ** xref:c:releasenotes.adoc[Release Notes]


### PR DESCRIPTION
This is a PR tweak for the API reference URL. 
Backport of: https://github.com/couchbase/docs-couchbase-lite/pull/874

Using 3.1 as an example, when you click the API references link in the nav you are sent to a blank page with generic links:
https://docs.couchbase.com/mobile/3.1.7/couchbase-lite-c/

The actual references page is here: https://docs.couchbase.com/mobile/3.1.7/couchbase-lite-c/C/html/modules.html

So we're just skipping the middle step.