### PR TITLE
Doc 12259 quick fixes

### DIFF
--- a/modules/ROOT/pages/cbl-whatsnew.adoc
+++ b/modules/ROOT/pages/cbl-whatsnew.adoc
@@ -35,6 +35,7 @@ A beta version of Vector Search is now available on Couchbase Lite for the C pla
 Read more at: 
 
 * xref:c:vector-search.adoc[Vector Search - C]
+** xref:gs-downloads.adoc#vs-release-1-0-0-beta.3[Downloads Page]
 ** xref:c:gs-install.adoc[Installation Instructions]
 ** xref:c:working-with-vector-search.adoc[Use Vector Search]
 

--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -64,7 +64,7 @@ page, for how to get the software using a package manager.
 Ensure you select the correct package for your application's compiler and architecture.
 endif::is-fullpage[]
 
-[#release-{our-version-hyphenated}]
+[id=release-{our-version-hyphenated}]
 == Couchbase Lite Release {our-version}
 
 .Available platforms are:
@@ -75,7 +75,7 @@ endif::is-fullpage[]
 <<ubuntu-{our-version-hyphenated}>>  |
 ****
 
-[#macos-{our-version-hyphenated}]
+[id=macos-{our-version-hyphenated}]
 === MacOS
 
 [#tbl-downloads-{our-version}]
@@ -117,7 +117,7 @@ Community Edition::
 
 =====
 
-[#windows-{our-version-hyphenated}]
+[id=windows-{our-version-hyphenated}]
 === Windows
 
 [#tbl-downloads-{our-version}]
@@ -159,7 +159,7 @@ Community Edition::
 
 =====
 
-[#debian-{our-version-hyphenated}]
+[id=debian-{our-version-hyphenated}]
 === Debian
 
 [#tbl-downloads-{our-version}]
@@ -359,7 +359,7 @@ Community Edition::
 =====
 
 
-[#ubuntu-{our-version-hyphenated}]
+[id=ubuntu-{our-version-hyphenated}]
 === Ubuntu
 
 [#tbl-downloads-{our-version}]
@@ -524,7 +524,7 @@ Community Edition::
 
 =====
 
-[#raspbian-{our-version-hyphenated}]
+[id=raspbian-{our-version-hyphenated}]
 === Raspbian
 
 Please use the <<debian-{our-version-hyphenated},Debian `.deb` download>> choosing the appropriate version (`debian9` or `debian10`) and architecture.

--- a/modules/c/pages/gs-install.adoc
+++ b/modules/c/pages/gs-install.adoc
@@ -85,7 +85,7 @@ For Android and iOS the symbols are incorporated in the standard release package
 
 You can obtain the download for the Vector Search extension here:
 
-* _Vector Search Extension_ -- link:https://www.couchbase.com/downloads/?family=couchbase-lite#LiteExtensions[Couchbase Lite Extensions]
+* _Vector Search Extension_ -- xref:gs-downloads.adoc#vs-release-1-0-0-beta.3[Download Vector Search]
 
 [IMPORTANT]
 --
@@ -246,7 +246,7 @@ sudo apt install ./{release-dir-dev-ee}
 
 === Install Vector Search for Linux
 
-Before you can use Vector Search, you must link:https://www.couchbase.com/downloads/?family=couchbase-lite#LiteExtensions[download and install the Vector Search library] to the location in your project where the library can be accessed and loaded at run time.
+Before you can use Vector Search, you must xref:gs-downloads.adoc#vs-release-1-0-0-beta.3[download and install the Vector Search library] to the location in your project where the library can be accessed and loaded at run time.
 The Vector Search extension for the C platform ships with supported prebuilt libraries containing the required dependencies.
 
 You need to set the `LD_LIBRARIES_PATH` to the extension location instead of installing the libraries yourself.
@@ -286,7 +286,7 @@ It is up to you to determine where best to place it so it is available during ex
 
 To use the Vector Search extension:
 
-. Download and extract the link:https://www.couchbase.com/downloads/?family=couchbase-lite#LiteExtensions[Vector Search extension].
+. Download and extract the xref:gs-downloads.adoc#vs-release-1-0-0-beta.3[Vector Search extension].
 . Put the library in your development environment.
 
 In the code, before opening the database and using the vector search extension, you must call the CBL_SetExtensionPath function shown below to set the path to the installed location of the vector search library.
@@ -335,7 +335,7 @@ Then, within the dialog:
 
 IMPORTANT: Couchbase does not support homebrew for 3.2.0 beta-3 installation of Couchbase Lite or Vector Search. 
 
-Before you can use Vector Search, you must link:https://www.couchbase.com/downloads/?family=couchbase-lite#LiteExtensions[download and install the Vector Search library] to the location in your project where the library can be accessed and loaded at run time.
+Before you can use Vector Search, you must xref:gs-downloads.adoc#vs-release-1-0-0-beta.3[download and install the Vector Search library] to the location in your project where the library can be accessed and loaded at run time.
 The Vector Search extension for the C platform ships with supported prebuilt libraries containing the required dependencies.
 
 In the code, before opening the database and using the vector search extension, you must call the CBL_SetExtensionPath function shown below to set the path to the installed location of the vector search library.
@@ -366,7 +366,7 @@ If you encounter a build error -- Include of non-modular header inside framework
 
 === Install Vector Search for iOS
 
-. Download and extract the link:https://www.couchbase.com/downloads/?family=couchbase-lite#LiteExtensions[Vector Search extension] into your XCode project location.
+. Download and extract the xref:gs-downloads.adoc#vs-release-1-0-0-beta.3[Vector Search extension] into your XCode project location.
 . Select your target settings in XCode and drag *CouchbaseLiteVectorSearch.xcframework* from your Finder to the *Frameworks, Libraries, and Embedded Content* section.
 . Import the xcframework and start using it in your project.
 
@@ -437,7 +437,7 @@ Once the install is finished, you can build and run this skeleton app.
 
 To use Vector Search in your Android applications, follow the steps below:
 
-. Download and extract the link:https://www.couchbase.com/downloads/?family=couchbase-lite#LiteExtensions[Vector Search extension] into your project location.
+. Download and extract the xref:gs-downloads.adoc#vs-release-1-0-0-beta.3[Vector Search extension] into your project location.
 . The package must be installed to the location in your project where the library can be accessed and loaded while the executable is running.
 .. The Vector Search download for CBL-C only contains the Vector Search libraries needed to include in your app.
 .. Steps to include the prebuilt native library can be found link:https://developer.android.com/studio/projects/gradle-external-native-builds[here].


### PR DESCRIPTION
Quick fixes due to incorrect link pathing and overrides breaking some links due to '.3' 

Summary
-- Correct pathing
-- Fix broken links due to overrides
-- add downloads to what's new