### PR TITLE
DOC-12315: Cut missing version

### DIFF
--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -24,7 +24,6 @@ include::{root-partials}_show_get_started_topic_group.adoc[]
  
 .Downloads are available for the following versions:
 ****
-<<release-3-1-8>>
 <<release-3-1-7>>
 <<release-3-1-6>>
 <<release-3-1-3>>
@@ -34,11 +33,6 @@ include::{root-partials}_show_get_started_topic_group.adoc[]
 ****
 
 // This block will always represent the major release version
-:param-version: 3.1.8
-:param-version-hyphenated: 3-1-8
-include::partial$downloadslist.adoc[]
-:param-version!:
-
 :param-version: 3.1.7
 :param-version-hyphenated: 3-1-7
 include::partial$downloadslist.adoc[]


### PR DESCRIPTION
Removing 3.1.8 from C-downloads. Version 3.1.8 was an Android only release.