### PR TITLE
Doc 12354 fix beta versioning

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -18,7 +18,7 @@ asciidoc:
     page-status: Beta
     previous-release: 3.1.6
     release: '3.2'
-    releasetag: beta.3
+    releasetag: beta.2
     major: 3
     minor: 2
     maintenance-ios: 0

--- a/modules/ROOT/pages/_partials/_define_component_attributes.adoc
+++ b/modules/ROOT/pages/_partials/_define_component_attributes.adoc
@@ -14,6 +14,7 @@ ifdef::is_diag[_define_component_attributes.adoc]
 
 // Base three digit version including optional release tag
 ifdef::releasetag[:tag: -{releasetag}]
+:tag-c: -beta.3
 :version-full: {major}.{minor}.{base}{tag}
 :version-full-hyphenated: {major}-{minor}-{base}{tag}
 :version-full-untagged: {major}.{minor}.{base}
@@ -22,7 +23,7 @@ ifdef::releasetag[:tag: -{releasetag}]
 // Note that the maintenance release is set at module level in the `_define_module_attributes.adoc` file
 // here at component level it is always same as version-full
 :version-maintenance-android: {major}.{minor}.{maintenance-android}{tag}
-:version-maintenance-c: {major}.{minor}.{maintenance-c}{tag}
+:version-maintenance-c: {major}.{minor}.{maintenance-c}{tag-c}
 :version-maintenance-net: {major}.{minor}.{maintenance-net}{tag}
 :version-maintenance-java: {major}.{minor}.{maintenance-java}{tag}
 :version-maintenance-ios: {major}.{minor}.{maintenance-ios}{tag}
@@ -337,7 +338,7 @@ ifdef::is-beta[:url-api-references-pfx: {url-api-references-beta}]
 :snippets-content--android-kotlin: {lang-mod-android}:example$codesnippet_collection.kt
 :snippets-content--android-java: {lang-mod-android}:example$codesnippet_collection.java
 :snippets-content--java: {lang-mod-java}:example$codesnippet_collection.java
-:snippets-content--c: {lang-mod-c}:{snippets-pfx}main.c
+:snippets-content--c: {lang-mod-c}:{snippets-pfx}main.cpp
 :snippets-content--csharp: {lang-mod-csharp}:{snippets-pfx}Program.cs
 :snippets-content--objc: {lang-mod-objc}:{snippets-pfx}SampleCodeTest.m
 :snippets-content--swift: {lang-mod-swift}:{snippets-pfx}SampleCodeTest.swift

--- a/modules/ROOT/pages/_partials/commons/common-quickstart-skeleton.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-quickstart-skeleton.adoc
@@ -32,9 +32,12 @@ ifdef::is-c[]
 endif::is-c[]
 * xref:{param-module}:gs-install.adoc[Install]
 * xref:{param-module}:gs-build.adoc[Build]
-ifndef::is-android[* {url-api-references}[Browse API References ...]]
+ifndef::is-android[]
+* {url-api-references}[Browse API References ...]
+endif::is-android[]
 ifdef::is-android[]
-* Browse API References ...
+
+.Browse API References
 ** https://docs.couchbase.com/mobile/{version-maintenance-android}/couchbase-lite-android[API References]
 ** https://docs.couchbase.com/mobile/{version-maintenance-android}/couchbase-lite-android-ktx[Kotlin Extensions]
 endif::is-android[]

--- a/modules/c/pages/_partials/_define_module_attributes.adoc
+++ b/modules/c/pages/_partials/_define_module_attributes.adoc
@@ -13,6 +13,7 @@
 //
 // CBL-C Maintenance release number
 //
+:tag: -beta.3
 :version-maintenance: {version}.{maintenance-c}{tag}
 :version-maintenance-hyphenated: {major}-{minor}-{maintenance-c}{tag}
 //

--- a/modules/c/pages/gs-install.adoc
+++ b/modules/c/pages/gs-install.adoc
@@ -52,7 +52,7 @@ endif::is-beta[]
 == Download
 
 
-_Couchbase Lite for C {version-full}_ is available for all supported platforms -- see: <<lbl-platforms>>.
+Couchbase Lite for C {version-maintenance} is available for all supported platforms -- see: <<lbl-platforms>>.
 
 You can obtain the downloads here:
 

--- a/modules/objc/pages/gs-install.adoc
+++ b/modules/objc/pages/gs-install.adoc
@@ -35,7 +35,7 @@ Couchbase Lite is distributed as an xcframework, to support this:
 [#lbl-install-tabs]
 === Install Couchbase Lite
 
-IMPORTANT: There is no Carthage support for the 3.2.0 Beta-1 of Couchbase Lite.
+IMPORTANT: There is no Carthage support for the 3.2.0 Beta version of Couchbase Lite.
 
 [{tabs}]
 ====


### PR DESCRIPTION
This is a fix for the following ticket: https://issues.couchbase.com/browse/DOC-12354

Description: All platforms other than C return a 403 error when trying to access -beta.3 API references pages. They all seem to work for -beta.2. Not sure if this is intended behaviour to have different versions.

This has also broken some links that directly point to API reference pages based on version.

Example: https://docs.couchbase.com/couchbase-lite/current/csharp/database.html#close-database

The issue also resulted in download binaries being incorrect and multiple links being broken across all platforms. 
Additional fly-by fixes:
-- Copy editing
-- Changing file extension of c examples to .cpp to fix c platform examples not being included.

