### PR TITLE
Doc 12410 319 maint release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
                 stage("Validate C") {
                     agent { label 's61113u16 (litecore)' }
                     steps {
-                        sh 'jenkins/c_build.sh 3.1.0'
+                        sh 'jenkins/c_build.sh 3.1.9'
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
                 stage("Validate C#") {
                     agent { label 's61113u16 (litecore)' }
                     steps {
-                        sh 'jenkins/dotnet_build.sh'
+                        sh 'jenkins/dotnet_build.sh 3.1.9'
                     }
                 }
                 stage("Validate C") {

--- a/antora.yml
+++ b/antora.yml
@@ -22,12 +22,12 @@ asciidoc:
     release: '3.1'
     major: 3
     minor: 1
-    maintenance-ios: 7
-    maintenance-c: 7
-    maintenance-android: 8
-    maintenance-java: 7
-    maintenance-net: 7
-    base: 7 # generic maintenance base, may no longer apply when versions deviate, change to version-maint-mobilesdk later rather than using base
+    maintenance-ios: 9
+    maintenance-c: 9
+    maintenance-android: 9
+    maintenance-java: 9
+    maintenance-net: 9
+    base: 9 # generic maintenance base, may no longer apply when versions deviate, change to version-maint-mobilesdk later rather than using base
     page-toclevels: 2@
     # releasetag:
     # show_edition:

--- a/jenkins/dotnet_build.sh
+++ b/jenkins/dotnet_build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash -e
 
+cbl_version=${1:-3.1.0}
+
+cbl_build=$(curl -s "http://proget.build.couchbase.com:8080/api/get_version?product=couchbase-lite-net&version=$cbl_version&ee=true" | jq .BuildNumber)
+
 pushd modules/csharp/examples/code_snippets
-dotnet add package --prerelease couchbase.lite.enterprise
+dotnet add package couchbase.lite.enterprise -v $cbl_version-b$(printf "%04d" $cbl_build)
 dotnet restore
 dotnet build --no-restore -c Release

--- a/modules/ROOT/pages/_partials/commons/common-database.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-database.adoc
@@ -136,6 +136,21 @@ endif::is-c[]
 include::{root-partials}block_tabbed_code_example.adoc[]
 :param-tags!:
 
+== Database Full Sync
+
+Database Full Sync will prevent the loss of transactional data due to an unexpected system crash or loss of power.
+This feature is not enabled by default and must be manually set in your database configuration.
+
+
+CAUTION: Database Full Sync is a safe method to preserve data loss but will incur a significant degredation of performance.
+
+.Enable Database Full Sync
+[#ex-dbfullsync]
+:param-tags: database-fullsync
+include::{root-partials}block_tabbed_code_example.adoc[]
+:param-tags!:
+
+NOTE: It is not possible to change the configuration of a Database after instantiating the Database with the configuration by updating its `DatabaseConfiguration` property.
 
 == Database Encryption
 

--- a/modules/ROOT/pages/cbl-whatsnew.adoc
+++ b/modules/ROOT/pages/cbl-whatsnew.adoc
@@ -17,7 +17,6 @@ NOTE: Couchbase Lite 3.0 introduces some breaking changes. +
 If you are upgrading from 2.x, please refer to the appropriate upgrade page -- see: <<lbl-upgrade>>
 Users should be able to upgrade to 3.1.x from 3.0.x without manual intervention.
 
-
 == Release 3.1.0 (April 2023)
 
 // tag::scopes-and-collections[]

--- a/modules/android/examples/codesnippet_collection.java
+++ b/modules/android/examples/codesnippet_collection.java
@@ -641,8 +641,8 @@ public class Examples {
     }
 
      public void databaseFullSyncExample() throws CouchbaseLiteException {
-        // tag::database-fullsync[]
         DatabaseConfiguration config = new DatabaseConfiguration();
+        // tag::database-fullsync[]
         config.setFullSync(true);
         // end::database-fullsync[]
     }

--- a/modules/android/examples/codesnippet_collection.java
+++ b/modules/android/examples/codesnippet_collection.java
@@ -632,12 +632,19 @@ public class Examples {
         config.setDirectory(customDir);
         Database database = new Database(DB_NAME, config);
         // end::new-database[]
-
+        
         // tag::close-database[]
         database.close();
         // end::close-database[]
 
         database.delete();
+    }
+
+     public void databaseFullSyncExample() throws CouchbaseLiteException {
+        // tag::database-fullsync[]
+        DatabaseConfiguration config = new DatabaseConfiguration();
+        config.setFullSync(true);
+        // end::database-fullsync[]
     }
 
     public void databaseEncryptionExample() throws CouchbaseLiteException {

--- a/modules/android/examples/codesnippet_collection.kt
+++ b/modules/android/examples/codesnippet_collection.kt
@@ -120,16 +120,16 @@ class BasicExamples(private val context: Context) {
         database.delete()
     }
 
-    // ### Database FullSync
+    // ### Database FullSync tag needs reinserting
     fun DatabaseFullSyncExample() {
-        // tag::database-fullsync[]
+       
         val database = Database(
             "my-db",
             DatabaseConfigurationFactory.newConfig(
                 fullSync = true
             )
         ) 
-        // end::database-fullsync[]
+        
         
     }
 

--- a/modules/android/examples/codesnippet_collection.kt
+++ b/modules/android/examples/codesnippet_collection.kt
@@ -120,6 +120,22 @@ class BasicExamples(private val context: Context) {
         database.delete()
     }
 
+    // ### Database FullSync
+    fun DatabaseFullSyncExample() {
+        // tag::database-fullsync[]
+        val database = Database(
+            "my-db",
+            DatabaseConfigurationFactory.newConfig(
+                fullSync = true
+            )
+        ) 
+        // end::database-fullsync[]
+        
+        config.setFullSync()
+        
+    }
+
+
     // ### Database Encryption
     fun databaseEncryptionExample() {
         // tag::database-encryption[]

--- a/modules/android/examples/codesnippet_collection.kt
+++ b/modules/android/examples/codesnippet_collection.kt
@@ -131,8 +131,6 @@ class BasicExamples(private val context: Context) {
         ) 
         // end::database-fullsync[]
         
-        config.setFullSync()
-        
     }
 
 

--- a/modules/android/pages/releasenotes.adoc
+++ b/modules/android/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_android.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-android-release-note.3.1.9.adoc[]
+
 include::partial$release-notes/couchbase-mobile-android-release-note.3.1.8.adoc[]
 
 include::partial$release-notes/couchbase-mobile-android-release-note.3.1.7.adoc[]

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.8.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.8.adoc
@@ -11,8 +11,6 @@ None for this release
 
 * https://issues.couchbase.com/browse/CBL-5723[CBL-5723 -- Ensured replicator syncs do not restart from the beginning when using prebuilt databases synced from Sync Gateway]
 
-None for this release
-
 === Deprecations
 
 None for this release

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.9.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.9.adoc
@@ -1,0 +1,26 @@
+[#maint-3-1-9]
+== 3.1.9 -- August 2024
+
+Version 3.1.9 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBL-6009[CBL-6009 -- You can now enable full sync in the database]
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5841[CBL-5841 -- Fixed Java FLSliceResult memory leak]
+
+* https://issues.couchbase.com/browse/CBL-5846[CBL-5846 -- Fixed dates in Parameters cannot be encoded]
+
+* https://issues.couchbase.com/browse/CBL-6124[CBL-6124 -- Fixed call to c4stream_write with critical array may cause crash]
+
+* https://issues.couchbase.com/browse/CBL-5791[CBL-5791 -- Fixed Socket was not called to close after receiving WebSocket PING Timeout]
+
+* https://issues.couchbase.com/browse/CBL-5978[CBL-5978 -- LiteCore now holds the names of its log domains]
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]

--- a/modules/c/examples/code_snippets/main.c
+++ b/modules/c/examples/code_snippets/main.c
@@ -463,6 +463,14 @@ static void close_database() {
     // end::close-database[]
 }
 
+static void database_fullsync() {
+   // tag::database-fullsync[] 
+   CBLDatabaseConfiguration config = CBLDatabaseConfiguration_Default();
+   // this enables full sync
+   config.fullSync = true; 
+   // end::database-fullsync[]
+}
+
 static void create_collection() {
     CBLDatabase *db = kDatabase;
     // tag::scopes-manage-create-collection[]

--- a/modules/c/examples/code_snippets/main.c
+++ b/modules/c/examples/code_snippets/main.c
@@ -464,8 +464,8 @@ static void close_database() {
 }
 
 static void database_fullsync() {
-   // tag::database-fullsync[] 
    CBLDatabaseConfiguration config = CBLDatabaseConfiguration_Default();
+   // tag::database-fullsync[] 
    // this enables full sync
    config.fullSync = true; 
    // end::database-fullsync[]

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -24,6 +24,7 @@ include::{root-partials}_show_get_started_topic_group.adoc[]
  
 .Downloads are available for the following versions:
 ****
+<<release-3-1-9>>
 <<release-3-1-7>>
 <<release-3-1-6>>
 <<release-3-1-3>>
@@ -33,6 +34,11 @@ include::{root-partials}_show_get_started_topic_group.adoc[]
 ****
 
 // This block will always represent the major release version
+:param-version: 3.1.9
+:param-version-hyphenated: 3-1-9
+include::partial$downloadslist.adoc[]
+:param-version!:
+
 :param-version: 3.1.7
 :param-version-hyphenated: 3-1-7
 include::partial$downloadslist.adoc[]

--- a/modules/c/pages/releasenotes.adoc
+++ b/modules/c/pages/releasenotes.adoc
@@ -13,6 +13,8 @@ include::partial$_set_page_context_for_c.adoc[]
 include::{root-partials}_show_page_header_block.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-c-release-note.3.1.9.adoc[]
+
 include::partial$release-notes/couchbase-mobile-c-release-note.3.1.7.adoc[]
 
 include::partial$release-notes/couchbase-mobile-c-release-note.3.1.6.adoc[]

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.9.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.9.adoc
@@ -1,0 +1,20 @@
+[#maint-3-1-9]
+== 3.1.9 -- August 2024
+
+Version 3.1.9 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBL-6009[CBL-6009 -- You can now enable full sync in the database]
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5791[CBL-5791 -- Fixed Socket was not called to close after receiving WebSocket PING Timeout]
+
+* https://issues.couchbase.com/browse/CBL-5978[CBL-5978 -- LiteCore now holds the names of its log domains]
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]

--- a/modules/csharp/examples/code_snippets/Program.cs
+++ b/modules/csharp/examples/code_snippets/Program.cs
@@ -449,6 +449,15 @@ namespace api_walkthrough
             // end::close-database[]
         }
 
+        private static void DatabaseFullsync()
+        {
+           // tag::database-fullsync[] 
+          var config = new DatabaseConfiguration();
+          // this enables fullsync
+          config.FullSync = false;
+           // end::database-fullsync[]
+        }
+
         private static void CreateCollection() 
         {
             // tag::scopes-manage-create-collection[]

--- a/modules/csharp/examples/code_snippets/Program.cs
+++ b/modules/csharp/examples/code_snippets/Program.cs
@@ -452,9 +452,8 @@ namespace api_walkthrough
         private static void DatabaseFullsync()
         {
            // tag::database-fullsync[] 
-          var config = new DatabaseConfiguration();
-          // this enables fullsync
-          config.FullSync = false;
+           // this enables fullsync
+           config.FullSync = true;
            // end::database-fullsync[]
         }
 

--- a/modules/csharp/examples/code_snippets/Program.cs
+++ b/modules/csharp/examples/code_snippets/Program.cs
@@ -451,6 +451,7 @@ namespace api_walkthrough
 
         private static void DatabaseFullsync()
         {
+           var config = new DatabaseConfiguration(); 
            // tag::database-fullsync[] 
            // this enables fullsync
            config.FullSync = true;

--- a/modules/csharp/pages/releasenotes.adoc
+++ b/modules/csharp/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_csharp.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-csharp-release-note.3.1.9.adoc[]
+
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.1.7.adoc[]
 
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.1.6.adoc[]

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.9.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.9.adoc
@@ -1,0 +1,27 @@
+[#maint-3-1-9]
+== 3.1.9 -- August 2024
+
+Version 3.1.9 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBL-6009[CBL-6009 -- You can now enable full sync in the database]
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5790[CBL-5790 -- Fixed FLSliceResult leaked when exception thrown in Collection.Save()]
+
+* https://issues.couchbase.com/browse/CBL-6118[CBL-6118 -- Fixed UWP package has incorrect reference to LiteCore]
+
+* https://issues.couchbase.com/browse/CBL-6128[CBL-6128 -- Fixed Queries using incorrect lock]
+---
+
+* https://issues.couchbase.com/browse/CBL-5791[CBL-5791 -- Fixed Socket was not called to close after receiving WebSocket PING Timeout]
+
+* https://issues.couchbase.com/browse/CBL-5978[CBL-5978 -- LiteCore now holds the names of its log domains]
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]

--- a/modules/java/examples/codesnippet_collection.java
+++ b/modules/java/examples/codesnippet_collection.java
@@ -617,6 +617,13 @@ public class Examples {
         database.delete();
     }
 
+     public void DatabaseFullSyncExample() throws CouchbaseLiteException {
+        // tag::database-fullsync[]
+        DatabaseConfiguration config = new DatabaseConfiguration();
+        config.setFullSync(true);
+        // end::database-fullsync[]
+    }
+
     public void databaseEncryptionExample() throws CouchbaseLiteException {
         // tag::database-encryption[]
         DatabaseConfiguration config = new DatabaseConfiguration();

--- a/modules/java/examples/codesnippet_collection.java
+++ b/modules/java/examples/codesnippet_collection.java
@@ -618,8 +618,8 @@ public class Examples {
     }
 
      public void DatabaseFullSyncExample() throws CouchbaseLiteException {
-        // tag::database-fullsync[]
         DatabaseConfiguration config = new DatabaseConfiguration();
+        // tag::database-fullsync[]
         config.setFullSync(true);
         // end::database-fullsync[]
     }

--- a/modules/java/pages/releasenotes.adoc
+++ b/modules/java/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_java.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-java-release-note.3.1.9.adoc[]
+
 include::partial$release-notes/couchbase-mobile-java-release-note.3.1.7.adoc[]
 
 include::partial$release-notes/couchbase-mobile-java-release-note.3.1.6.adoc[]

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.9.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.9.adoc
@@ -1,0 +1,26 @@
+[#maint-3-1-9]
+== 3.1.9 -- August 2024
+
+Version 3.1.9 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBL-6009[CBL-6009 -- You can now enable full sync in the database]
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5841[CBL-5841 -- Fixed Java FLSliceResult memory leak]
+
+* https://issues.couchbase.com/browse/CBL-5846[CBL-5846 -- Fixed dates in Parameters cannot be encoded]
+
+* https://issues.couchbase.com/browse/CBL-6124[CBL-6124 -- Fixed call to c4stream_write with critical array may cause crash]
+
+* https://issues.couchbase.com/browse/CBL-5791[CBL-5791 -- Fixed Socket was not called to close after receiving WebSocket PING Timeout]
+
+* https://issues.couchbase.com/browse/CBL-5978[CBL-5978 -- LiteCore now holds the names of its log domains]
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]

--- a/modules/objc/examples/code_snippets/SampleCodeTest.m
+++ b/modules/objc/examples/code_snippets/SampleCodeTest.m
@@ -213,10 +213,6 @@
     // tag::database-encryption[]
     CBLDatabaseConfiguration *config = [[CBLDatabaseConfiguration alloc] init];
     config.encryptionKey = [[CBLEncryptionKey alloc] initWithPassword:@"secretpassword"];
-    // tag::database-fullsync[]
-    config.fullSync = true;
-    // end::database-fullsync[]
-
     NSError *error;
     self.database = [[CBLDatabase alloc] initWithName:@"my-database" config:config error:&error];
     if (!self.database) {

--- a/modules/objc/examples/code_snippets/SampleCodeTest.m
+++ b/modules/objc/examples/code_snippets/SampleCodeTest.m
@@ -188,8 +188,8 @@
 }
 
 - (void) dontTestDatabaseFullSync {
-  // tag::database-fullsync[]
   CBLDatabaseConfiguration* config = [[CBLDatabaseConfiguration alloc] init];
+  // tag::database-fullsync[]
   config.fullSync = true;
   // end::database-fullsync[]
 }

--- a/modules/objc/examples/code_snippets/SampleCodeTest.m
+++ b/modules/objc/examples/code_snippets/SampleCodeTest.m
@@ -187,6 +187,14 @@
     // end::close-database[]
 }
 
+- (void) dontTestDatabaseFullSync {
+  // tag::database-fullsync[]
+  CBLDatabaseConfiguration* config = [[CBLDatabaseConfiguration alloc] init];
+  config.fullSync = true;
+  // end::database-fullsync[]
+}
+
+
 - (void) dontTestLogging {
     // tag::logging[]
 
@@ -205,6 +213,9 @@
     // tag::database-encryption[]
     CBLDatabaseConfiguration *config = [[CBLDatabaseConfiguration alloc] init];
     config.encryptionKey = [[CBLEncryptionKey alloc] initWithPassword:@"secretpassword"];
+    // tag::database-fullsync[]
+    config.fullSync = true;
+    // end::database-fullsync[]
 
     NSError *error;
     self.database = [[CBLDatabase alloc] initWithName:@"my-database" config:config error:&error];

--- a/modules/objc/pages/releasenotes.adoc
+++ b/modules/objc/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_objc.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.9.adoc[]
+
 include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.7.adoc[]
 
 include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.6.adoc[]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.9.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.9.adoc
@@ -1,0 +1,28 @@
+[#maint-3-1-9]
+== 3.1.9 -- August 2024
+
+Version 3.1.9 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBL-6009[CBL-6009 -- You can now enable full sync in the database]
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5221[CBL-5221 -- Fixed MutableDocument not usable before creating a database instance]
+
+* https://issues.couchbase.com/browse/CBL-5329[CBL-5329 -- Fixed Replicatpr's ListenerToken.remove() not removing the listener]
+
+* https://issues.couchbase.com/browse/CBL-6023[CBL-6023 -- Fixed Live Query could become nil before is stopped]
+
+* https://issues.couchbase.com/browse/CBL-6024[CBL-6024 -- Fixed Swift MutableDocument's collection is not set when a new document is saved]
+
+* https://issues.couchbase.com/browse/CBL-5791[CBL-5791 -- Fixed Socket was not called to close after receiving WebSocket PING Timeout]
+
+* https://issues.couchbase.com/browse/CBL-5978[CBL-5978 -- LiteCore now holds the names of its log domains]
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]

--- a/modules/swift/examples/code_snippets/SampleCodeTest.swift
+++ b/modules/swift/examples/code_snippets/SampleCodeTest.swift
@@ -61,8 +61,8 @@ class SampleCodeTest {
     }
 
     func dontTestDatabaseFullSync() throws {
-        // tag::database-fullsync[]
         var config = DatabaseConfiguration()
+        // tag::database-fullsync[]
         // This enables full sync
         config.fullSync = true
         // end::database-fullsync[]

--- a/modules/swift/examples/code_snippets/SampleCodeTest.swift
+++ b/modules/swift/examples/code_snippets/SampleCodeTest.swift
@@ -60,6 +60,16 @@ class SampleCodeTest {
         // end::close-database[]
     }
 
+    func dontTestDatabaseFullSync() throws {
+        // tag::database-fullsync[]
+        var config = DatabaseConfiguration()
+        // This enables full sync
+        config.fullSync = true
+        // end::database-fullsync[]
+    }
+
+    
+
     // helper
     func isValidCredentials(_ u: String, password: String) -> Bool { return true }
     func isValidCertificates(_ certs: [SecCertificate]) -> Bool { return true }

--- a/modules/swift/pages/releasenotes.adoc
+++ b/modules/swift/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_swift.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.9.adoc[]
+
 include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.7.adoc[]
 
 include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.6.adoc[]

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.9.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.9.adoc
@@ -1,0 +1,28 @@
+[#maint-3-1-9]
+== 3.1.9 -- August 2024
+
+Version 3.1.9 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBL-6009[CBL-6009 -- You can now enable full sync in the database]
+
+=== Issues and Resolutions
+
+* https://issues.couchbase.com/browse/CBL-5221[CBL-5221 -- Fixed MutableDocument not usable before creating a database instance]
+
+* https://issues.couchbase.com/browse/CBL-5329[CBL-5329 -- Fixed Replicatpr's ListenerToken.remove() not removing the listener]
+
+* https://issues.couchbase.com/browse/CBL-6023[CBL-6023 -- Fixed Live Query could become nil before is stopped]
+
+* https://issues.couchbase.com/browse/CBL-6024[CBL-6024 -- Fixed Swift MutableDocument's collection is not set when a new document is saved]
+
+* https://issues.couchbase.com/browse/CBL-5791[CBL-5791 -- Fixed Socket was not called to close after receiving WebSocket PING Timeout]
+
+* https://issues.couchbase.com/browse/CBL-5978[CBL-5978 -- LiteCore now holds the names of its log domains]
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]


### PR DESCRIPTION
Documentation for 3.1.9 maintenance release.

Includes:

- Database Fullsync API update docs (In database common)
- Snippets required for above feature
- Standard release items (Update antora.yaml Release notes, update to gs-downloads for C)