### PR TITLE
Doc 12498 vs extension act fix and platform support

### DIFF
--- a/modules/ROOT/pages/_partials/supported-versions.adoc
+++ b/modules/ROOT/pages/_partials/supported-versions.adoc
@@ -85,7 +85,9 @@ Please plan to migrate your apps to use an appropriate alternative version.
 |===
 .>| Version | x64 | ARM 64
 
-| OSX 10.14 (Mojave) a|  image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| MacOS 14 (Sonoma) a|  image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| MacOS 12 (Ventura) a|  image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| MacOS 12 (Monterey) a|  image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
 |===
 
@@ -97,14 +99,40 @@ Please plan to migrate your apps to use an appropriate alternative version.
 |===
 .>| Distro	| Version .>| x64 .>| ARM 32 .>| ARM 64
 
-.2+| Debian
+.4+| Debian
 | 9 | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
-| 10 | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| 10 (Buster) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
 | Raspberry Pi OS | 10	|  	| image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | Raspbian | 9	|  | image:ROOT:yes.png[] |
 
-| Ubuntu | 20.04	| image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+.2+| Ubuntu 
+| 20.04 LTS	| image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| 22.04 LTS	| image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+
+|===
+
+=== Embedded Linux
+
+[cols="^1,^1,^1,^1^,^1,^1",options="header"]
+//  frame=none]
+|===
+.>| Distro	| Version .>| x64 .>| ARM 32 .>| ARM 64
+
+.4+| Debian
+| 9 | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| 10 (Buster) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+
+| Raspberry Pi OS | 10	|  	| image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| Raspbian | 9	|  | image:ROOT:yes.png[] |
+
+.2+| Ubuntu 
+| 20.04 LTS	| image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| 22.04 LTS	| image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
 |===
 
@@ -116,7 +144,6 @@ Please plan to migrate your apps to use an appropriate alternative version.
 .>|| Version | x64
 
 | Desktop | 10+ | image:ROOT:yes.png[]
-// | WinUI | 10.0.19041+ | image:ROOT:yes.png[]
 
 |===
 
@@ -213,7 +240,7 @@ The following table identifies the <<supported-os-versions,supported platforms>>
 |Platform |Minimum OS version
 
 |iOS
-|12.0 - deprecated at 3.2.0
+|12.0+
 
 |macOS
 | 12 (Monterey)
@@ -244,17 +271,26 @@ h|Operating System|Version|Deprecation Release
 ^.>|Removed
 ^.>|Deprecation Release
 
-| macOS
+.2+| iOS
+
+| iOS 10
+| 3.1.1
+| 3.1.0
+
+| iOS 11
+| 3.2.0
+| 3.1.1
+
+.3+| macOS
+
 | macOS 11
 | 3.2.0
 | 3.1.0
 
-| macOS
 | OSX 10.15
 | 3.2.0
 | 3.1.0
 
-| macOS
 | OSX 10.14
 | 3.2.0
 | 3.1.0
@@ -262,7 +298,6 @@ h|Operating System|Version|Deprecation Release
 |===
 // end::objc[]
 // end::swift[]
-
 
 // tag::java[]
 == Officially Supported Versions
@@ -275,8 +310,10 @@ The targeted OS versions are given in  <<supported-os-versions>>
 Support for the following will be deprecated in this release and will be removed in a future release:
 
 * macOS 11 - Big Sur
+* Apple OS X v10.15(Catalina)
 * RedHat - 8
 * Microsoft Server - 2019
+* Microsoft Windows 2016 (64 bit)
 
 Please plan to migrate your apps to use an appropriate alternative version.
 --
@@ -304,8 +341,14 @@ Please plan to migrate your apps to use an appropriate alternative version.
 | 20.04 LTS
 | Desktop & Web Service/Servlet (Tomcat)
 
-|Debian
-|GNU/Linux 10 +
+3+|Debian
+|GNU/Linux 10 (Buster) +
+|Desktop & Web Service/Servlet (Tomcat)
++
+|GNU/Linux 11 (Bullseye) +
+|Desktop & Web Service/Servlet (Tomcat)
++
+|GNU/Linux 12 (Bookworm) +
 |Desktop & Web Service/Servlet (Tomcat)
 
 |Microsoft Server

--- a/modules/android/pages/gs-install.adoc
+++ b/modules/android/pages/gs-install.adoc
@@ -66,6 +66,7 @@ Java - Enterprise::
 `https://mobile.maven.couchbase.com/maven2/dev/`
 . If you want to use Vector Search, add the Couchbase Lite Vector Search dependency for architectures other than `x86_64`: `com.couchbase.lite:couchbase-lite-java-vector-search-arm64-{vs-version-maintenance}`
 .. For `x86_64` architectures: `com.couchbase.lite:couchbase-lite-android-vector-search-x86_64-{vs-version-maintenance}`
+.. You must then use `CouchbaseLite.enableVectorSearch();` to enable the vector search extension.
 . Build the project and it will pull Couchbase Lite down.
 --
 

--- a/modules/java/pages/gs-install.adoc
+++ b/modules/java/pages/gs-install.adoc
@@ -46,6 +46,7 @@ Include the following in your Gradle `build.gradle` or Maven `pom.xml` file, as 
 `couchbase-lite-java-ee:{version-full}`
 
 . If you want to use Vector Search, add the Couchbase Lite Vector Search dependency: `couchbase-lite-java-vector-search`
+. You must then use `CouchbaseLite.enableVectorSearch();` to enable the vector search extension.
 --
 
 Community Edition::
@@ -219,6 +220,12 @@ repositories {
 //   ... other section content as required by user
     }
 
+----
+
+.Activating the Extension
+[source,java, subs="attributes+"]
+----
+include::java:example$snippets/common/main/java/com/couchbase/codesnippets/VectorSearchExamples.java[tags=vs-setup-packaging]
 ----
 --
 


### PR DESCRIPTION
This PR adds extension activation for Java and Java-Android.

It also aims to fix and fully update platform support for CBL 3.2. See ticket: https://issues.couchbase.com/browse/CM-1178

Preview Link: https://preview.docs-test.couchbase.com/platformsupport/couchbase-lite/current/index.html

Pages changed:

- Install - Android and Java
- Supported Platforms - All Platforms