### PR TITLE
DOC-12513: Fix android install instructions for vector search

### DIFF
--- a/modules/android/pages/gs-install.adoc
+++ b/modules/android/pages/gs-install.adoc
@@ -41,8 +41,9 @@ Kotlin - Enterprise::
 `implementation 'com.couchbase.lite:couchbase-lite-android-ee-ktx:{version-maintenance-android}'`
 . Add the following _maven_ repo to your repositories (in `build.gradle` or `settings.gradle` as required +
 `https://mobile.maven.couchbase.com/maven2/dev/`
-. If you want to use Vector Search, add the Couchbase Lite Vector Search dependency for architectures other than `x86_64`: `com.couchbase.lite:couchbase-lite-java-vector-search-arm64-{vs-version-maintenance}`
-.. For `x86_64` architectures: `com.couchbase.lite:couchbase-lite-android-vector-search-x86_64-{vs-version-maintenance}`
+.. If you want to use Vector Search, add the Couchbase Lite Vector Search dependency for architectures other than `x86_64`: `com.couchbase.lite:couchbase-lite-java-vector-search-arm64-{vs-version-maintenance}`
+... For `x86_64` architectures: `com.couchbase.lite:couchbase-lite-android-vector-search-x86_64-{vs-version-maintenance}`
+.. You must then use `CouchbaseLite.enableVectorSearch();` to enable the vector search extension.
 . Build the project and it will pull Couchbase Lite down.
 --
 
@@ -64,8 +65,8 @@ Java - Enterprise::
 `implementation 'com.couchbase.lite:couchbase-lite-android-ee:{version-maintenance-android}'`
 . Add the following _maven_ repo to your repositories (in `build.gradle` or `settings.gradle` as required +
 `https://mobile.maven.couchbase.com/maven2/dev/`
-. If you want to use Vector Search, add the Couchbase Lite Vector Search dependency for architectures other than `x86_64`: `com.couchbase.lite:couchbase-lite-java-vector-search-arm64-{vs-version-maintenance}`
-.. For `x86_64` architectures: `com.couchbase.lite:couchbase-lite-android-vector-search-x86_64-{vs-version-maintenance}`
+.. If you want to use Vector Search, add the Couchbase Lite Vector Search dependency for architectures other than `x86_64`: `com.couchbase.lite:couchbase-lite-java-vector-search-arm64-{vs-version-maintenance}`
+... For `x86_64` architectures: `com.couchbase.lite:couchbase-lite-android-vector-search-x86_64-{vs-version-maintenance}`
 .. You must then use `CouchbaseLite.enableVectorSearch();` to enable the vector search extension.
 . Build the project and it will pull Couchbase Lite down.
 --
@@ -271,6 +272,13 @@ dependencies {
 }
 ----
 
+. To activate the extension, the snippet below is required: 
++
+[source,java, subs="attributes+"]
+----
+include::java:example$snippets/common/main/java/com/couchbase/codesnippets/VectorSearchExamples.java[tags=vs-setup-packaging]
+----
+
 == Java - Step-by-step Install
 
 More detailed instructions on getting up and running with Couchbase Lite for Android (Java).
@@ -455,6 +463,12 @@ dependencies {
 
 //   ... other section content as required by user
 }
+----
+. To activate the extension, the snippet below is required: 
++
+[source,java, subs="attributes+"]
+----
+include::java:example$snippets/common/main/java/com/couchbase/codesnippets/VectorSearchExamples.java[tags=vs-setup-packaging]
 ----
 
 include::{root-partials}block-related-content-start.adoc[]

--- a/modules/android/pages/gs-install.adoc
+++ b/modules/android/pages/gs-install.adoc
@@ -258,8 +258,9 @@ dependencies {
 //   ... other section content as required by user
 }
 ----
-
++
 .. For x86_64 architectures:
++
 [source,kotlin, subs="attributes+"]
 ----
 dependencies {
@@ -273,7 +274,6 @@ dependencies {
 ----
 
 . To activate the extension, the snippet below is required: 
-+
 [source,java, subs="attributes+"]
 ----
 include::java:example$snippets/common/main/java/com/couchbase/codesnippets/VectorSearchExamples.java[tags=vs-setup-packaging]
@@ -464,6 +464,7 @@ dependencies {
 //   ... other section content as required by user
 }
 ----
++
 . To activate the extension, the snippet below is required: 
 +
 [source,java, subs="attributes+"]


### PR DESCRIPTION
This PR fixes the missing android install instructions (The vector search activation), now that we have the missing snippet. 

Important to note is that the Kotlin snippet is the same as the Java one as Kotlin is able to parse certain Java functionality by design. (Had to look this up!)