### PR TITLE
DOC-12631 temporary fix replication.adoc code samples

### DIFF
--- a/modules/csharp/pages/replication.adoc
+++ b/modules/csharp/pages/replication.adoc
@@ -4,12 +4,1576 @@ ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:
 :description: Couchbase Lite for C# -- Synchronizing data changes between local and remote databases using Sync Gateway
+:underscore: _
 
-include::partial$_set_page_context_for_csharp.adoc[]
+[abstract]
+--
+Description -- _{description}_ +
+Related Content -- xref:csharp:conflict.adoc[Handling Data Conflicts] | xref:csharp:dbreplica.adoc[Intra-Device] | <<csharp:replication:::p2psync-websocket.adoc,Peer-to-Peer>>
+--
+// DO NOT DELETE
 
-:url-repl-cfg: {url-api-references}/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html[`ReplicatorConfiguration`]
-// END::Local page attributes
 
-include::{root-commons}sgw-replication.adoc[subs="macros,attributes"]
+.Code Snippets
+[NOTE]
+All code examples are indicative only.
+They demonstrate the basic concepts and approaches to using a feature.
+Use them as inspiration and adapt these examples to best practice when developing applications for your platform.
 
-// END: inclusion-page - common-database.adoc[]
+
+
+[discrete#csharp:replication:::introduction]
+== Introduction
+
+
+Couchbase Lite for C#.Net provides API support for secure, bi-directional, synchronization of data changes between mobile applications and a central server database.
+It does so by using a _replicator_ to interact with Sync Gateway.
+
+The _replicator_ is designed to manage replication of documents and-or document changes between a source and a target database.
+For example, between a local Couchbase Lite database and remote Sync Gateway database, which is ultimately mapped to a bucket in a Couchbase Server instance in the cloud or on a server.
+
+This page shows sample code and configuration examples covering the implementation of a replication using Sync Gateway.
+
+Your application runs a replicator (also referred to here as a client), which  will initiate connection with a Sync Gateway (also referred to here as a server) and participate in the replication of database changes to bring both local and remote databases into sync.
+
+Subsequent sections provide additional details and examples for the main configuration options.
+
+[discrete#csharp:replication:::replication-concepts]
+== Replication Concepts
+
+Couchbase Lite allows for one database for each application running on the mobile device.
+This database can contain one or more scopes.
+Each scope can contain one or more collections.
+
+To learn about Scopes and Collections, see xref:csharp:database.adoc[]
+
+You can set up a replication scheme across these data levels:
+
+Database:: The `_default` collection is synced.
+
+Collection:: A specific collection or a set of collections is synced.
+
+As part of the syncing setup, the Gateway has to map the Couchbase Lite database to the database being synced on Capella.
+
+
+
+
+
+[discrete#csharp:replication:::replication-protocol]
+== Replication Protocol
+
+[discrete#csharp:replication:::scheme]
+=== Scheme
+
+Couchbase Mobile uses a replication protocol based on WebSockets for replication.
+To use this protocol the replication URL should specify WebSockets as the URL scheme (see the <<csharp:replication:::lbl-cfg-tgt>> section below).
+
+Incompatibilities::
+Couchbase Lite's replication protocol is *incompatible* with CouchDB-based databases.
+And since Couchbase Lite 2.x+ only supports the new protocol, you will need to run a version of Sync Gateway that supports it -- see: xref:csharp:compatibility.adoc[Compatibility].
+
+Legacy Compatibility::
+Clients using Couchbase Lite 1.x can continue to use `http` as the URL scheme.
+Sync Gateway 2.x+ will automatically use:
+* The 1.x replication protocol when a Couchbase Lite 1.x client connects through `\http://localhost:4984/db`
+* The 2.0 replication protocol when a Couchbase Lite 2.0 client connects through `ws://localhost:4984/db`.
+
+You can find further information in our blog: https://blog.couchbase.com/data-replication-couchbase-mobile/[Introducing the Data Replication Protocol].
+
+[discrete#csharp:replication:::lbl-repl-ord]
+=== Ordering
+
+To optimize for speed, the replication protocol doesn't guarantee that documents will be received in a particular order.
+So we don't recommend to rely on that when using the replication or database change listeners for example.
+
+
+[discrete#csharp:replication:::scopes-and-collections]
+== Scopes and Collections
+
+Scopes and Collections allow you to organize your documents in Couchbase Lite.
+
+When syncing, you can configure the collections to be synced.
+
+The collections specified in the Couchbase Lite replicator setup must exist (both scope and collection name must be identical) on the Sync Gateway side, otherwise starting the Couchbase Lite replicator will result in an error.
+
+During replication:
+
+. If Sync Gateway config (or server) is updated to remove a collection that is being synced, the client replicator will be offline and will be stopped after the first retry. An error will be reported.
+
+. If Sync Gateway config is updated to add a collection to a scope that is being synchronized, the replication will ignore the collection. The added collection will not automatically sync until the Couchbase Lite replicator's configuration is updated.
+
+[discrete#csharp:replication:::default-collection]
+=== Default Collection
+
+When upgrading Couchbase Lite to 3.1, the existing documents in the database will be automatically migrated to the default collection.
+
+For backward compatibility with the code prior to 3.1, when you set up the replicator with the database, the default collection will be set up to sync with the default collection on Sync Gateway.
+
+.Sync Couchbase Lite database with the default collection on Sync Gateway
+image:ROOT:cbl-replication-scopes-collections-1.png[Sync Couchbase Lite database with the default collection on Sync Gateway,500,,align="left"]
+
+
+.Sync Couchbase Lite default collection with default collection on Sync Gateway
+image:ROOT:cbl-replication-scopes-collections-2.png[Sync Couchbase Lite default collection with default collection on Sync Gateway,500,,align="left"]
+
+
+[discrete#csharp:replication:::user-defined-collections]
+=== User-Defined Collections
+
+The user-defined collections specified in the Couchbase Lite replicator setup must exist (and be identical) on the Sync Gateway side to sync.
+
+.Syncing scope with user-defined collections.
+image:ROOT:cbl-replication-scopes-collections-3.png["Syncing scope with user-defined collections.",500,,align="left"]
+
+.Syncing scope with user-defined collections. Couchbase Lite has more collections than the Sync Gateway configuration (with collection filters)
+image:ROOT:cbl-replication-scopes-collections-4.png["Syncing scope with user-defined collections. Couchbase Lite has more collections than the Sync Gateway configuration (with collection filters)",500,,align="left"]
+
+
+// tag::replicator-config-sample[]
+[discrete#csharp:replication:::configuration-summary]
+== Configuration Summary
+
+
+You should configure and initialize a replicator for each Couchbase Lite database instance you want to sync.
+<<csharp:replication:::ex-simple-repl>> shows the configuration and initialization process.
+
+NOTE: You need Couchbase Lite 3.1+ and Sync Gateway 3.1+ to use `custom` Scopes and Collections. +
+If you’re using Capella App Services or Sync Gateway releases that are older than version 3.1, you won’t be able to access `custom` Scopes and Collections.
+To use Couchbase Lite 3.1+ with these older versions, you can use the `default` Collection as a backup option.
+
+Click the *GitHub* tab in the code examples for further details.
+
+// Example 1
+[#ex-simple-repl]
+.Replication configuration and initialization
+[#csharp:replication:::ex-simple-repl]
+====
+// include ::csharp:example$code_snippets/Program.cs[tags="p2p-act-rep-func", indent=0]
+// Show Main Snippet
+[source, C#]
+----
+// . . . preceding code. for example . . .
+private static ListenerToken _thisListenerToken;
+var Database thisDB;
+// . . . other code . . .
+// initialize the replicator configuration
+
+var thisUrl = new URLEndpoint("wss://listener.com:4984/otherDB"); <1> 
+var config = new ReplicatorConfiguration(thisDB, thisUrl);
+
+
+// Set replicator type
+thisConfig.ReplicatorType = ReplicatorType.PushAndPull;
+
+// Set autopurge option
+// here we override its default
+thisConfig.EnableAutoPurge = false; <2>
+
+// Configure Sync Mode
+thisConfig.Continuous = true; // default value
+
+// Configure Server Security -- only accept self-signed certs
+thisConfig.AcceptOnlySelfSignedServerCertificate = true; <3>
+
+// Configure Client Security <4>
+// Configure basic auth using user credentials
+thisConfig.Authenticator = new BasicAuthenticator("Our Username", "Our Password");
+
+/* Optionally set a conflict resolver call back */ <5>
+// Use built-in resolver
+thisConfig.ConflictResolver = new LocalWinConflictResolver();  //
+
+// optionally use custom resolver
+thisConfig.ConflictResolver = new ConflictResolver(
+  (conflict) => {
+    /* define resolver function */
+  }
+); //
+
+// Initialize and start a replicator
+// Initialize replicator with configuration data
+var thisReplicator = new Replicator(thisConfig); <6>
+
+//Optionally add a change listener <7>
+_thisListenerToken =
+  thisReplicator.AddChangeListener((sender, args) =>
+    {
+      if (args.Status.Activity == ReplicatorActivityLevel.Stopped) {
+          Console.WriteLine("Replication stopped");
+      }
+    });
+
+// Start replicator
+thisReplicator.Start(); <8>
+----
+====
+
+
+*Notes on Example*
+
+<.> get endpoint for target DB
+<.> Use the https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html[ReplicatorConfiguration] class's constructor -- https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration__ctor_Couchbase_Lite_Database_Couchbase_Lite_Sync_IEndpoint[ReplicatorConfiguration(Database database, IEndpoint target)] -- to initialize the replicator configuration with the local database -- see also: <<csharp:replication:::lbl-cfg-tgt>>
+<.> The default is to auto-purge documents that this user no longer has access to -- see: <<csharp:replication:::anchor-auto-purge-on-revoke>>.
+Here we over-ride this behavior by setting its flag false.
+
+<.> Configure how the client will authenticate the server.
+Here we say connect only to servers presenting a self-signed certificate.
+By default, clients accept only servers presenting certificates that can be verified using the OS bundled Root CA Certificates -- see: <<csharp:replication:::lbl-svr-auth>>.
+<.> Configure the client-authentication credentials (if required).
+These are the credential the client will present to pass:q,a[sync{nbsp}gateway] if requested to do so. +
+Here we configure to provide _Basic Authentication_ credentials.
+Other options are available -- see: <<csharp:replication:::lbl-client-auth>>.
+
+<.> Configure how the replication should handle conflict resolution -- see: xref:csharp:conflict.adoc[Handling Data Conflicts] topic for mor on conflict resolution.
+
+<.> Initialize the replicator using your configuration -- see: <<csharp:replication:::lbl-init-repl>>.
+
+<.> Optionally, register an observer, which will notify you of changes to the replication status -- see: <<csharp:replication:::lbl-repl-mon>>
+
+<.> Start the replicator  -- see: <<csharp:replication:::lbl-repl-start>>.
+
+
+[discrete#csharp:replication:::lbl-cfg-repl]
+== Configure
+
+
+In this section::
++
+--
+<<csharp:replication:::lbl-cfg-tgt>>
+|  <<csharp:replication:::lbl-cfg-sync>>
+|  <<csharp:replication:::lbl-cfg-keep-alive>>
+|  <<csharp:replication:::lbl-user-auth>>
+|  <<csharp:replication:::lbl-svr-auth>>
+|  <<csharp:replication:::lbl-client-auth>>
+|  <<csharp:replication:::lbl-repl-evnts>>
+|  <<csharp:replication:::lbl-repl-hdrs>>
+|  <<csharp:replication:::lbl-repl-ckpt>>
+|  <<csharp:replication:::lbl-repl-fltrs>>
+|  <<csharp:replication:::lbl-repl-chan>>
+|  <<csharp:replication:::anchor-auto-purge-on-revoke>>
+|  <<csharp:replication:::lbl-repl-delta>>
+--
+
+[discrete#csharp:replication:::lbl-cfg-tgt]
+=== Configure Target
+
+Use the
+Initialize and define the replication configuration with local and remote database locations using the https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html[ReplicatorConfiguration] object.
+
+The constructor provides:
+
+* the name of the local database to be sync'd
+* the server's URL (including the port number and the name of the remote database to sync with)
++
+--
+It is expected that the app will identify the IP address and URL and append the remote database name to the URL endpoint, producing for example: `wss://10.0.2.2:4984/travel-sample`
+
+The URL scheme for web socket URLs uses `ws:` (non-TLS) or `wss:` (SSL/TLS) prefixes.
+--
+
+// Example 2
+.Add Target to Configuration
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="sgw-act-rep-initialize", indent=0]
+[source, C#]
+----
+// initialize the replicator configuration
+
+var url = new URLEndpoint(new Uri("wss://10.0.2.2:4984/anotherDB")); // <.>
+var replConfig = new ReplicatorConfiguration(url);
+// Add collections to the config now
+----
+
+
+
+
+// close example block
+
+====
+
+// Tidy-up atttibutes created
+// END -- block_show_snippet.doc
+<.> Note use of the scheme prefix (`wss://`
+to ensure TLS encryption -- strongly recommended in production -- or `ws://`)
+// END -- inclusion -- common-sgw-replication-cfg-tgt.adoc
+
+
+[#lbl-network-interface]
+
+
+[discrete#csharp:replication:::lbl-cfg-sync]
+=== Sync Mode
+
+
+Here we define the direction and type of replication we want to initiate.
+
+We use `https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html[ReplicatorConfiguration]` class's https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_ReplicatorType[ReplicatorType] and
+`https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_Continuous[Continuous]` parameters, to tell the replicator:
+
+* The type (or direction) of the replication:
+`*pushAndPull*`; `pull`; `push`
+
+* The replication mode, that is either of:
+
+** Continuous -- remaining active indefinitely to replicate changed documents (`continuous=true`).
+
+** Ad-hoc -- a one-shot replication of changed documents (`continuous=false`).
+
+// Example 3
+[#ex-repl-sync]
+.Configure replicator type and mode
+
+[#csharp:replication:::ex-repl-sync]
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="p2p-act-rep-config-type;p2p-act-rep-config-cont", indent=0]
+[source, C#]
+----
+// Set replicator type
+thisConfig.ReplicatorType = ReplicatorType.PushAndPull;
+
+// Configure Sync Mode
+thisConfig.Continuous = true; // default value
+----
+====
+
+[TIP]
+--
+Unless there is a solid use-case not to, always initiate a single `PUSH_AND_PULL` replication rather than identical separate `PUSH` and `PULL` replications.
+
+This prevents the replications generating the same checkpoint `docID` resulting in multiple conflicts.
+--
+
+[discrete#csharp:replication:::lbl-cfg-keep-alive]
+=== Retry Configuration
+
+
+Couchbase Lite for C#.Net's replication retry logic assures a resilient connection.
+
+The replicator minimizes the chance and impact of dropped connections by maintaining a heartbeat; essentially pinging the Sync Gateway at a configurable interval to ensure the connection remains alive.
+
+In the event it detects a transient error, the replicator will attempt to reconnect, stopping only when the connection is re-established, or the number of retries exceeds the retry limit (9 times for a single-shot replication and unlimited for a continuous replication).
+
+On each retry the interval between attempts is increased exponentially (exponential backoff) up to the maximum wait time limit (5 minutes).
+
+The REST API provides configurable control over this replication retry logic using a set of configiurable properties -- see: <<csharp:replication:::tbl-repl-retry>>.
+
+.Replication Retry Configuration Properties
+[#csharp:replication:::tbl-repl-retry,cols="2,3,5"]
+|===
+
+h|Property
+h|Use cases
+h|Description
+
+|https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_Heartbeat[Heartbeat()]
+a|* Reduce to detect connection errors sooner
+* Align to load-balancer or proxy `keep-alive` interval -- see Sync Gateway's topic xref:sync-gateway::load-balancer.adoc#websocket-connection[Load Balancer - Keep Alive]
+a|The interval (in seconds) between the heartbeat pulses.
+
+Default: The replicator pings the Sync Gateway every 300 seconds.
+
+|https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_MaxAttempts[MaxAttempts()]
+|Change this to limit or extend the number of retry attempts.
+a| The maximum number of retry attempts
+
+* Set to zero (0) to use default values
+* Set to zero (1) to prevent any retry attempt
+* The retry attempt count is reset when the replicator is able to connect and replicate
+* Default values are:
+** Single-shot replication = 9;
+** Continuous replication = maximum integer value
+* Negative values generate a Couchbase exception `InvalidArgumentException`
+
+|https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_MaxAttemptWaitTime[MaxAttemptWaitTime()]
+|Change this to adjust the interval between retries.
+a|The maximum interval between retry attempts
+
+While you can configure the *maximum permitted* wait time,  the replicator's exponential backoff algorithm calculates each individual interval which is not configurable.
+
+* Default value: 300 seconds (5 minutes)
+* Zero sets the maximum interval between retries to the default of 300 seconds
+* 300 sets the maximum interval between retries to the default of 300 seconds
+* A negative value generates a Couchbase exception, `InvalidArgumentException`
+
+|===
+
+When necessary you can adjust any or all of those configurable values -- see: <<csharp:replication:::ex-repl-retry>> for how to do this.
+
+.Configuring Replication Retries
+[#ex-repl-retry]
+
+[#csharp:replication:::ex-repl-retry]
+====
+
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="replication-retry-config", indent=0]
+
+[source, C#]
+----
+            var url = new Uri("ws://localhost:4984/mydatabase");
+            var target = new URLEndpoint(url);
+
+            var config = new ReplicatorConfiguration(target);
+
+            //  other config as required . . .
+
+            config.Heartbeat = TimeSpan.FromSeconds(120); //  <.>
+            config.MaxAttempts = 20; //  <.>
+            config.MaxAttemptsWaitTime = TimeSpan.FromSeconds(600); //  <.>
+
+            //  other config as required . . .
+
+            var replicator = new Replicator(config);
+
+----
+
+
+
+
+// close example block
+
+====
+
+// Tidy-up atttibutes created
+// END -- block_show_snippet.doc
+<.> Here we use https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_Heartbeat[Heartbeat()] to set the required interval (in seconds) between the heartbeat pulses
+<.> Here we use https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_MaxAttempts[MaxAttempts()] to set the required number of retry attempts
+<.> Here we use https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_MaxAttemptWaitTime[MaxAttemptWaitTime()] to set the required interval between retry attempts.
+
+// END -- inclusion -- common-sgw-replication-cfg-retryadoc
+
+[discrete#csharp:replication:::lbl-user-auth]
+=== User Authorization
+
+// include::ROOT:partial$authorization.adoc[]
+
+By default, Sync Gateway does not enable user authorization.
+This makes it easier to get up and running with synchronization.
+
+You can enable authorization in the pass:q,a[sync{nbsp}gateway] configuration file, as shown in <<csharp:replication:::example-enable-authorization>>.
+
+.Enable Authorization
+[#csharp:replication:::example-enable-authorization]
+====
+[source,json]
+----
+{
+  "databases": {
+    "mydatabase": {
+      "users": {
+        "GUEST": {"disabled": true}
+      }
+    }
+  }
+}
+----
+====
+
+To authorize with Sync Gateway, an associated user must first be created.
+Sync Gateway users can be created through the
+xref:sync-gateway:ROOT:refer/rest-api-admin.adoc#/user/post\__db___user_[`+POST /{tkn-db}/_user+`]
+endpoint on the Admin REST API.
+
+
+
+[discrete#csharp:replication:::lbl-svr-auth]
+=== Server Authentication
+
+Define the credentials your app (the client) is expecting to receive from the Sync Gateway (the server) in order to ensure it is prepared to continue with the sync.
+
+
+Note that the client cannot authenticate the server if TLS is turned off.
+When TLS is enabled (Sync Gateway's default) the client _must_ authenticate the server.
+If the server cannot provide acceptable credentials then the connection will fail.
+
+Use `https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html[ReplicatorConfiguration]` properties https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_AcceptOnlySelfSignedServerCertificate[AcceptOnlySelfSignedServerCertificate] and https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_PinnedServerCertificate[PinnedServerCertificate], to tell the replicator how to verify server-supplied TLS server certificates.
+
+* If there is a pinned certificate, nothing else matters, the server cert must *exactly* match the pinned certificate.
+* If there are no pinned certs and https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_AcceptOnlySelfSignedServerCertificate[AcceptOnlySelfSignedServerCertificate] is `true` then any self-signed certificate is accepted.  Certificates that are not self signed are rejected, no matter who signed them.
+* If there are no pinned certificates and https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_AcceptOnlySelfSignedServerCertificate[AcceptOnlySelfSignedServerCertificate] is `false` (default), the client validates the server’s certificates against the system CA certificates.  The server must supply a chain of certificates whose root is signed by one of the certificates in the system CA bundle.
+
+// Example 4
+.Set Server TLS security
+====
+[tabs]
+======
+
+CA Cert::
++
+--
+Set the client to expect and accept only CA attested certificates.
+
+[source, C#]
+----
+// Configure Server Security -- only accept CA certs
+thisConfig.AcceptOnlySelfSignedServerCertificate = false;  <1>
+----
+<.> This is the default.
+Only certificate chains with roots signed by a trusted CA are allowed.
+Self signed certificates are not allowed.
+--
+
+
+Self Signed Cert::
++
+--
+Set the client to expect and accept only self-signed certificates
+
+[source, C#]
+----
+// Configure Server Security -- only accept self-signed certs
+thisConfig.AcceptOnlySelfSignedServerCertificate = true; <1>
+----
+<.> Set this to `true` to accept any self signed cert.
+Any certificates that are not self-signed are rejected.
+--
+
+
+Pinned Certificate::
++
+--
+Set the client to expect and accept only a pinned certificate.
+
+[source, C#]
+----
+// Only CA Certs accepted
+thisConfig.AcceptOnlySelfSignedServerCertificate =
+  false; <1>
+
+var thisCert =
+  new X509Certificate2(caData);  <2>
+
+thisConfig.PinnedServerCertificate =
+  thisCert; <3>
+----
+--
+
+======
+
+
+====
+
+This all assumes that you have configured the Sync Gateway to provide the appropriate SSL certificates, and have included the appropriate certificate in your app bundle -- for more on this see: <<csharp:replication:::lbl-cert-pinning>>.
+
+
+
+[discrete#csharp:replication:::lbl-client-auth]
+=== Client Authentication
+
+There are two ways to authenticate from a Couchbase Lite client: <<csharp:replication:::basic-authentication>> or <<csharp:replication:::session-authentication>>.
+
+[discrete#csharp:replication:::basic-authentication]
+==== Basic Authentication
+
+You can provide a user name and password to the basic authenticator class method.
+Under the hood, the replicator will send the credentials in the first request to retrieve a `SyncGatewaySession` cookie and use it for all subsequent requests during the replication.
+This is the recommended way of using basic authentication.
+<<csharp:replication:::ex-base-auth>> shows how to initiate a one-shot replication as the user *username* with the password *password*.
+
+.Basic Authentication
+[#ex-base-auth]
+
+[#csharp:replication:::ex-base-auth]
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="basic-authentication", indent=0]
+[source, C#]
+----
+var url = new Uri("ws://localhost:4984/mydatabase");
+var target = new URLEndpoint(url);
+var config = new ReplicatorConfiguration(target);
+config.AddCollection(collection);
+config.Authenticator = new BasicAuthenticator("john", "pass");
+
+var replicator = new Replicator(config);
+replicator.Start();
+----
+====
+
+[discrete#csharp:replication:::session-authentication]
+==== Session Authentication
+
+Session authentication is another way to authenticate with Sync Gateway.
+
+A user session must first be created through the
+xref:sync-gateway:ROOT:refer/rest-api-public.adoc#/session/post\__db___session[`+POST /{tkn-db}/_session+`]
+endpoint on the Public REST API.
+
+The HTTP response contains a session ID which can then be used to authenticate as the user it was created for.
+
+See <<csharp:replication:::ex-session-auth>>, which shows how to initiate a one-shot replication with the session ID returned from the `+POST /{tkn-db}/_session+` endpoint.
+
+.Session Authentication
+[#ex-session-auth]
+
+[#csharp:replication:::ex-session-auth]
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="session-authentication", indent=0]
+
+[source, C#]
+----
+var url = new Uri("ws://localhost:4984/mydatabase");
+var target = new URLEndpoint(url);
+var config = new ReplicatorConfiguration(target);
+config.AddCollection(collection);
+config.Authenticator = new SessionAuthenticator("904ac010862f37c8dd99015a33ab5a3565fd8447");
+
+var replicator = new Replicator(config);
+replicator.Start();
+----
+====
+
+[discrete#csharp:replication:::lbl-repl-hdrs]
+=== Custom Headers
+
+Custom headers can be set on the configuration object.
+The replicator will then include those headers in every request.
+
+This feature is useful in passing additional credentials, perhaps when an authentication or authorization step is being done by a proxy server (between Couchbase Lite and Sync Gateway) -- see <<csharp:replication:::ex-cust-hdr>>.
+
+.Setting custom headers
+[#ex-cust-hdr]
+
+
+[#csharp:replication:::ex-cust-hdr]
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="replication-custom-header", indent=0]
+
+[source, C#]
+----
+var config = new ReplicatorConfiguration(target)
+{
+    Headers = new Dictionary<string, string>
+    {
+        ["CustomHeaderName"] = "Value"
+    }
+};
+----
+
+====
+
+[discrete#csharp:replication:::lbl-repl-fltrs]
+=== Replication Filters
+
+Replication Filters allow you to have quick control over the documents stored as the result of a push and/or pull replication.
+
+[discrete#csharp:replication:::push-filter]
+==== Push Filter
+
+The push filter allows an app to push a subset of a database to the server.
+This can be very useful.
+For instance, high-priority documents could be pushed first, or documents in a "draft" state could be skipped.
+
+.Push Filter
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="replication-push-filter", indent=0]
+
+[source, C#]
+----
+var url = new Uri("ws://localhost:4984/mydatabase");
+var target = new URLEndpoint(url);
+
+var config = new ReplicatorConfiguration(target);
+config.AddCollection(collection, new CollectionConfiguration()
+{
+    PushFilter = (document, flags) => // <1>
+    {
+        if (flags.HasFlag(DocumentFlags.Deleted)) {
+            return false;
+        }
+
+        return true;
+    }
+});
+
+// Dispose() later
+var replicator = new Replicator(config);
+replicator.Start();
+----
+
+<1> The callback should follow the semantics of a https://en.wikipedia.org/wiki/Pure_function[pure function^].
+Otherwise, long running functions would slow down the replicator considerably.
+Furthermore, your callback should not make assumptions about what thread it is being called on.
+
+[discrete#csharp:replication:::pull-filter]
+==== Pull Filter
+
+The pull filter gives an app the ability to validate documents being pulled, and skip ones that fail.
+This is an important security mechanism in a peer-to-peer topology with peers that are not fully trusted.
+
+NOTE: Pull replication filters are not a substitute for channels.
+Sync Gateway
+xref:sync-gateway::data-routing.adoc[channels]
+are designed to be scalable (documents are filtered on the server) whereas a pull replication filter is applied to a document once it has been downloaded.
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="replication-pull-filter", indent=0]
+
+[source, C#]
+----
+var url = new Uri("ws://localhost:4984/mydatabase");
+var target = new URLEndpoint(url);
+
+var config = new ReplicatorConfiguration(target);
+config.AddCollection(collection, new CollectionConfiguration()
+{
+    PullFilter = (document, flags) => // <1>
+    {
+        if (document.GetString("type") == "draft") {
+            return false;
+        }
+
+        return true;
+    }
+});
+
+// Dispose() later
+var replicator = new Replicator(config);
+replicator.Start();
+----
+
+<1> The callback should follow the semantics of a
+https://en.wikipedia.org/wiki/Pure_function[pure function].
+Otherwise, long running functions would slow down the replicator considerably.
+Furthermore, your callback should not make assumptions about what thread it is being called on.
+
+.Losing access to a document via the Sync Function.
+****
+Losing access to a document (via the Sync Function) also triggers the pull replication filter.
+
+Filtering out such an event would retain the document locally.
+
+As a result, there would be a local copy of the document disjointed from the one that resides on Couchbase Server.
+
+Further updates to the document stored on Couchbase Server would not be received in pull replications and further local edits could be pushed but the updated versions will not be visible.
+
+For more information, see <<csharp:replication:::auto-purge-on-revoke,Auto Purge on Revoke>>.
+****
+
+[discrete#csharp:replication:::lbl-repl-chan]
+=== Channels
+
+By default, Couchbase Lite gets all the channels to which the configured user account has access.
+
+This behavior is suitable for most apps that rely on
+xref:sync-gateway::learn/authentication.adoc[user authentication]
+and the
+xref:sync-gateway::sync-function-api.adoc[sync function]
+to specify which data to pull for each user.
+
+Optionally, it's also possible to specify a string array of channel names on Couchbase Lite's replicator configuration object.
+In this case, the replication from Sync Gateway will only pull documents tagged with those channels.
+
+[discrete#csharp:replication:::anchor-auto-purge-on-revoke]
+=== Auto-purge on Channel Access Revocation
+
+[CAUTION]
+--
+This is a Breaking Change at 3.0
+--
+[discrete#csharp:replication:::new-outcome]
+==== New outcome
+
+By default, when a user loses access to a channel all documents in the channel (that do not also belong to any of the user’s other channels) are auto-purged from the local database (in devices belonging to the user).
+
+[discrete#csharp:replication:::prior-outcome]
+==== Prior outcome
+
+_Previously these documents remained in the local database_
+
+Prior to this release, CBL auto-purged only in the case when the user loses access to a document by removing the doc from all of the channels belong to the user.
+Now, in addition to 2.x auto purge, Couchbase Lite will also auto-purges the docs when the user loses access to the doc via channel access revocation.
+This feature is enabled by default, but an opt-out is available.
+
+[discrete#csharp:replication:::behavior]
+==== Behavior
+
+Users may lose access to channels in a number of ways:
+
+* User loses direct access to channel
+
+* User is removed from a role
+
+* A channel is removed from a role the user is assigned to
+
+By default, when a user loses access to a channel, the next Couchbase Lite Pull replication auto-purges all documents in the channel from local Couchbase Lite databases (on devices belonging to the user) *unless* they belong to any of the user’s other channels -- see: <<csharp:replication:::tbl-revoke-behavior>>.
+
+Documents that exist in multiple channels belonging to the user (even if they are not actively replicating that channel) are not auto-purged unless the user loses access to all channels.
+
+Users will be receive an `AccessRemoved` notification from the DocumentListener if they lose document access due to channel access revocation; this is sent regardless of the current auto-purge setting.
+
+.Behavior following access revocation
+[#csharp:replication:::tbl-revoke-behavior, cols="^1h,2a,2a", options="header"]
+|===
+
+2+|System State
+^|Impact on Sync
+
+.>h|Replication Type
+^.>h|Access Control on Sync Gateway
+^.>h|Expected behavior when _enable_auto_purge=true_
+
+|Pull only
+|User revoked access to channel.
+
+Sync Function includes `requireAccess(revokedChannel)`
+|Previously synced documents are auto purged on local
+
+|Push only
+|User revoked access to channel. Sync Function includes `requireAccess(revokedChannel)`
+|No impact of auto-purge
+
+Documents get pushed but are rejected by Sync Gateway
+
+|Push-pull
+|User revoked access to channel +
+Sync Function includes `requireAccess(revokedChannel)`
+|Previously synced documents are auto purged on Couchbase Lite.
+
+Local changes continue to be  pushed to remote but are rejected by Sync Gateway
+
+|===
+
+If a user subsequently regains access to a lost channel, then any previously auto-purged documents still assigned to any of their channels are automatically pulled down by the active Sync Gateway when they are next updated -- see behavior summary in <<csharp:replication:::tbl-regain-behavior>>
+
+.Behavior if access is regained
+[#csharp:replication:::tbl-regain-behavior, cols="^1h,2a,2a", options="header"]
+|===
+
+2+|System State
+^|Impact on Sync
+
+.>h|Replication Type
+^.>h|Access Control on Sync Gateway
+^.>h|Expected behavior when _enable_auto_purge=true_
+
+|Pull only
+|User REASSIGNED access to channel
+|Previously purged documents that are still in the channel are automatically pulled by Couchbase Lite when they are next updated
+
+|Push only
+|User REASSIGNED access to channel
+Sync Function includes requireAccess
+(reassignedChannel)
+No impact of auto-purge
+|Local changes previously rejected by Sync Gateway will not be automatically pushed to remote unless resetCheckpoint is involved on CBL.
+Document changes subsequent to the channel reassignment will be pushed up as usual.
+
+|Push-pull
+|User REASSIGNED access to channel
+
+Sync Function includes requireAccess
+(reassignedChannel)
+|Previously purged documents are automatically pulled by couchbase lite
+
+Local changes previously rejected by Sync Gateway will not be automatically pushed to remote unless resetCheckpoint is involved.
+Document changes subsequent to the channel reassignment will be pushed up as usual
+
+|===
+
+
+[discrete#csharp:replication:::config]
+==== Config
+
+Auto-purge behavior is controlled primarily by the ReplicationConfiguration option https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_EnableAutoPurge[EnableAutoPurge].
+Changing the state of this will impact *only* future replications; the replicator will not attempt to sync revisions that were auto purged on channel access removal.
+Clients wishing to sync previously removed documents must use the resetCheckpoint API to resync from the start.
+
+
+.Setting auto-purge
+[#ex-set-auto-purge]
+
+[#csharp:replication:::ex-set-auto-purge]
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="autopurge-override", indent=0]
+
+[source, C#]
+----
+// Set autopurge option
+// here we override its default
+thisConfig.EnableAutoPurge = false;  <1>
+----
+
+====
+
+<.> Here we have opted to turn off the auto purge behavior. By default auto purge is enabled.
+
+[discrete#csharp:replication:::overrides]
+==== Overrides
+Where necessary, clients can override the default auto-purge behavior.
+This can be done either by setting https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorConfiguration.html#Couchbase_Lite_Sync_ReplicatorConfiguration_EnableAutoPurge[EnableAutoPurge] to false, or for finer control by applying pull-filters -- see: <<csharp:replication:::tbl-pull-filters>> and <<csharp:replication:::lbl-repl-fltrs>>
+This ensures backwards compatible with 2.8 clients that use pull filters to prevent auto purge of removed docs.
+
+.Impact of Pull-Filters
+[#csharp:replication:::tbl-pull-filters,cols="^1,2,2"]
+|===
+
+.2+.^h|purge_on_removal setting
+
+2+^h|Pull Filter
+
+^h|Not Defined
+^h|Defined to filter removals/revoked docs
+
+|disabled
+2+a|Doc remains in local database
+
+App notified of “accessRemoved” if a _Documentlistener_ is registered
+
+|enabled (DEFAULT)
+a|Doc is auto purged
+
+App notified of “accessRemoved” if _Documentlistener_ registered
+a|Doc remains in local database
+
+
+
+|===
+
+
+[discrete#csharp:replication:::lbl-repl-delta]
+=== Delta Sync
+
+// tag::rep-delta-sync-concept[]
+
+
+IMPORTANT: This is an https://www.couchbase.com/products/editions[Enterprise Edition] feature.
+
+
+With Delta Sync footnote:[Couchbase Mobile 2.5+], only the changed parts of a Couchbase document are replicated.
+This can result in significant savings in bandwidth consumption as well as throughput improvements, especially when network bandwidth is typically constrained.
+
+Replications to a Server (for example, a Sync Gateway, or passive listener) automatically use delta sync if the property is enabled at database level by the server -- see:
+xref:sync-gateway:ROOT:refer/config-properties.adoc#databases-foo_db-delta_sync[databases.$db.delta_sync.enabled].
+
+xref:csharp:dbreplica.adoc[Intra-Device]
+replications automatically *disable* delta sync, whilst
+<<csharp:replication:::p2psync-websocket.adoc,Peer-to-Peer>>
+replications automatically *enable* delta sync.
+
+// end::rep-delta-sync-concept[]
+
+
+[discrete#csharp:replication:::lbl-init-repl]
+== Initialize
+
+
+In this section::
+<<csharp:replication:::lbl-repl-start>>  | <<csharp:replication:::lbl-repl-ckpt>>
+
+[discrete#csharp:replication:::lbl-repl-start]
+=== Start Replicator
+
+
+Use the `https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html[Replicator]` class's https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html#Couchbase_Lite_Sync_Replicator__ctor_Couchbase_Lite_Sync_ReplicatorConfiguration_[(ReplicatorConfiguration config)] constructor, to initialize the replicator with the configuration you have defined.
+You can, optionally, add a change listener (see <<csharp:replication:::lbl-repl-mon>>) before starting the replicator running using https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html#Couchbase_Lite_Sync_Replicator_Start[Start()].
+
+// Example 7
+.Initialize and run replicator
+
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="p2p-act-rep-start-full;!p2p-act-rep-add-change-listener", indent=0]
+
+[source, C#]
+----
+// Initialize and start a replicator
+// Initialize replicator with configuration data
+var thisReplicator = new Replicator(thisConfig);  <1>
+
+// Start replicator
+thisReplicator.Start(); <2>
+
+----
+
+====
+
+<.> Initialize the replicator with the configuration
+<.> Start the replicator
+
+
+[discrete#csharp:replication:::lbl-repl-ckpt]
+=== Checkpoint Starts
+
+Replicators use xref:refer-glossary.adoc#checkpoint[checkpoints] to keep track of documents sent to the target database.
+
+Without xref:refer-glossary.adoc#checkpoint[checkpoints], Couchbase Lite would replicate the entire database content to the target database on each connection, even though previous replications may already have replicated some or all of that content.
+
+This functionality is generally not a concern to application developers.
+However, if you do want to force the replication to start again from zero, use the xref:refer-glossary.adoc#checkpoint[checkpoint] reset argument when starting the replicator -- as shown in <<csharp:replication:::ex-repl-ckpt>>.
+
+.Resetting checkpoints
+[#ex-repl-ckpt]
+
+[#csharp:replication:::ex-repl-ckpt]
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="replication-reset-checkpoint", indent=0]
+
+[source, C#]
+----
+// replicator is a Replicator instance
+if (resetCheckpointRequired_Example) {
+    replicator.Start(true); // <.>
+} else {
+    replicator.Start(false);
+}
+
+// Stop and dispose replicator later
+----
+
+====
+
+<.> Set start's reset option to `true`. +
+The default `false` is shown here for completeness only; it is unlikely you would explicitly use it in practice.
+
+
+[discrete#csharp:replication:::lbl-repl-mon]
+== Monitor
+
+
+In this section::
+<<csharp:replication:::lbl-repl-chng>>  |
+<<csharp:replication:::lbl-repl-status>>  |
+<<csharp:replication:::lbl-repl-evnts>> |
+<<csharp:replication:::lbl-repl-pend>>
+
+You can monitor a replication’s status by using a combination of <<csharp:replication:::lbl-repl-chng>> and the `replication.status.activity` property -- see; https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorStatus.html#Couchbase_Lite_Sync_ReplicatorStatus_Activity[Activity].
+This enables you to know, for example, when the replication is actively transferring data and when it has stopped.
+
+You can also choose to monitor document changes -- see: <<csharp:replication:::lbl-repl-evnts>>.
+
+[discrete#csharp:replication:::lbl-repl-chng]
+=== Change Listeners
+Use this to monitor changes and to inform on sync progress; this is an optional step.
+You can add and a replicator change listener at any point; it will report changes from the point it is registered.
+
+.Best Practice
+TIP: Don't forget to save the token so you can remove the listener later
+
+Use the https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html[Replicator] class to add a change listener as a callback to the Replicator (https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html#Couchbase_Lite_Sync_Replicator_AddChangeListener_System_EventHandler_Couchbase_Lite_Sync_ReplicatorStatusChangedEventArgs__[addChangeListener()]) -- see: <<csharp:replication:::ex-repl-mon>>.
+You will then be asynchronously notified of state changes.
+
+You can remove a change listener with https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html#Couchbase_Lite_Sync_Replicator_RemoveChangeListener_Couchbase_Lite_ListenerToken_[RemoveChangeListener(ListenerToken)].
+
+
+
+[discrete#csharp:replication:::lbl-repl-status]
+=== Replicator Status
+
+You can use the
+https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorStatus.html[ReplicatorStatus] struct
+to check the replicator status.
+That is, whether it is actively transferring data or if it has stopped -- see: <<csharp:replication:::ex-repl-mon>>.
+
+
+The returned _ReplicationStatus_ structure comprises:
+
+* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorStatus.html#Couchbase_Lite_Sync_ReplicatorStatus_Activity[Activity] -- stopped, offline, connecting, idle or busy -- see states described in: <<csharp:replication:::tbl-states>>
+* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorStatus.html#Couchbase_Lite_Sync_ReplicatorStatus_Progress[Progress]
+** completed -- the total number of changes completed
+** total -- the total number of changes to be processed
+* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.ReplicatorStatus.html#Couchbase_Lite_Sync_ReplicatorStatus_Error[Error] -- the current error, if any
+
+// Example 8
+[#csharp:replication:::ex-repl-mon]
+[[csharp:replication:::ex-repl-mon]]
+.Monitor replication
+====
+
+
+[tabs]
+======
+
+Adding a Change Listener::
++
+--
+[source, C#]
+----
+_thisListenerToken =
+  thisReplicator.AddChangeListener((sender, args) =>
+    {
+      if (args.Status.Activity == ReplicatorActivityLevel.Stopped) {
+          Console.WriteLine("Replication stopped");
+      }
+    });
+----
+--
++
+
+Using replicator.status::
++
+--
+[source, C#]
+----
+_thisReplicator.Stop();
+while (_thisReplicator.Status.Activity != ReplicatorActivityLevel.Stopped) {
+    // Database cannot close until replicators are stopped
+    Console.WriteLine($"Waiting for replicator to stop (currently {_thisReplicator.Status.Activity})...");
+    Thread.Sleep(200);
+}
+_thisDatabase.Close();
+----
+--
+======
+
+
+
+====
+
+
+[discrete#csharp:replication:::lbl-repl-states]
+==== Replication States
+<<csharp:replication:::tbl-states>> shows the different states, or activity levels, reported in the API; and the meaning of each.
+
+.Replicator activity levels
+[#csharp:replication:::tbl-states,cols="^1,4"]
+|===
+h|State
+h|Meaning
+
+|`STOPPED`
+|The replication is finished or hit a fatal error.
+
+|`OFFLINE`
+|The replicator is offline as the remote host is unreachable.
+
+|`CONNECTING`
+|The replicator is connecting to the remote host.
+
+|`IDLE`
+|The replication caught up with all the changes available from the server.
+The `IDLE` state is only used in continuous replications.
+
+|`BUSY`
+|The replication is actively transferring data.
+|===
+
+NOTE: The replication change object also has properties to track the progress (`change.status.completed` and `change.status.total`).
+Since the replication occurs in batches the total count can vary through the course of a replication.
+
+[discrete#csharp:replication:::replication-status-and-app-life-cycle]
+==== Replication Status and App Life Cycle
+
+Couchbase Lite doesn't react to OS backgrounding or foregrounding events and replication(s) will continue running as long as the remote system does not terminate the connection and the app does not terminate.
+It is generally recommended to stop replications before going into the background otherwise socket connections may be closed by the OS and this may interfere with the replication process.
+
+
+// begin inclusion of document changes text
+[discrete#csharp:replication:::lbl-repl-evnts]
+=== Monitor Document Changes
+
+You can choose to register for document updates during a replication.
+
+For example, the code snippet in <<csharp:replication:::ex-reg-doc-listener>> registers a listener to monitor document replication performed by the replicator referenced by the variable `replicator`.
+It prints the document ID of each document received and sent.
+Stop the listener as shown in <<csharp:replication:::ex-stop-doc-listener>>.
+
+.Register a document listener
+[#ex-reg-doc-listener]
+
+[#csharp:replication:::ex-reg-doc-listener]
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="add-document-replication-listener,indent=0]", indent=0]
+
+[source, C#]
+----
+var token = replicator.AddDocumentReplicationListener((sender, args) =>
+{
+    var direction = args.IsPush ? "Push" : "Pull";
+    Console.WriteLine($"Replication type :: {direction}");
+    foreach (var doc in args.Documents) {
+        if (doc.Error == null) {
+            Console.WriteLine($"Doc ID :: {doc.Id}");
+            if (doc.Flags.HasFlag(DocumentFlags.Deleted)) {
+                Console.WriteLine("Successfully replicated a deleted document");
+            }
+        } else {
+            // There was an error
+        }
+    }
+});
+
+replicator.Start();
+----
+====
+
+[#ex-stop-doc-listener]
+.Stop document listener
+
+[#csharp:replication:::ex-stop-doc-listener]
+====
+
+This code snippet shows how to stop the document listener using the token from the previous example.
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="remove-document-replication-listener", indent=0]
+[source, C#]
+----
+replicator.RemoveChangeListener(token);
+----
+
+====
+
+[discrete#csharp:replication:::document-access-removal-behavior]
+==== Document Access Removal Behavior
+
+When access to a document is removed on Sync Gateway (see: Sync Gateway's xref:sync-gateway::sync-function-api.adoc[Sync Function]), the document replication listener sends a notification with the `AccessRemoved` flag set to `true` and subsequently purges the document from the database.
+
+// end inclusion of document changes text
+
+[discrete#csharp:replication:::lbl-repl-pend]
+=== Documents Pending Push
+
+TIP: https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html#Couchbase_Lite_Sync_Replicator_IsDocumentPending_System_String_[Replicator.IsDocumentPending()] is quicker and more efficient.
+Use it in preference to returning a list of pending document IDs, where possible.
+
+You can check whether documents are waiting to be pushed in any forthcoming sync by using either of the following API methods:
+
+* Use the https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html#Couchbase_Lite_Sync_Replicator_GetPendingDocumentIDs[Replicator.GetPendingDocumentIDs()] method, which returns a list of document IDs that have local changes, but which have not yet been pushed to the server.
++
+This can be very useful in tracking the progress of a push sync, enabling the app to provide a visual indicator to the end user on its status, or decide when it is safe to exit.
+
+* Use the https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html#Couchbase_Lite_Sync_Replicator_IsDocumentPending_System_String_[Replicator.IsDocumentPending()] method to quickly check whether an individual document is pending a push.
+
+[#ex-pending]
+.Use Pending Document ID API
+
+[#csharp:replication:::ex-pending]
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="replication-pendingdocuments", indent=0]
+
+[source, C#]
+----
+            var url = new Uri("ws://localhost:4984/mydatabase");
+            var target = new URLEndpoint(url);
+            var database = new Database("myDB");
+            var config = new ReplicatorConfiguration(target);
+            config.AddCollection(database.GetDefaultCollection());
+            config.ReplicatorType = ReplicatorType.Push;
+
+            var replicator = new Replicator(config);
+
+            var pendingDocIDs =
+              new HashSet<string>(replicator.GetPendingDocumentIDs(database.GetDefaultCollection())); // <.>
+
+            if (pendingDocIDs.Count > 0) {
+                Console.WriteLine($"There are {pendingDocIDs.Count} documents pending");
+                replicator.AddChangeListener((sender, change) =>
+                {
+                    Console.WriteLine($"Replicator activity level is " +
+                                      change.Status.Activity.ToString());
+                    // iterate and report-on previously
+                    // retrieved pending docids 'list'
+                    foreach (var docID in pendingDocIDs)
+                        if (!replicator.IsDocumentPending(docID, database.GetDefaultCollection())) // <.>
+                        {
+                            Console.WriteLine($"Doc ID {docID} now pushed");
+                        };
+                });
+
+                replicator.Start();
+            }
+----
+====
+
+<.> https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html#Couchbase_Lite_Sync_Replicator_GetPendingDocumentIDs[Replicator.GetPendingDocumentIDs()] returns a list of the document IDs for all documents waiting to be pushed.
+This is a snapshot and may have changed by the time the response is received and processed.
+<.> https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html#Couchbase_Lite_Sync_Replicator_IsDocumentPending_System_String_[Replicator.IsDocumentPending()] returns `true` if the document is waiting to be pushed, and `false` otherwise.
+
+
+[discrete#csharp:replication:::lbl-repl-stop]
+== Stop
+
+
+Stopping a replication is straightforward.
+It is done using https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html#Couchbase_Lite_Sync_Replicator_Stop[Stop()].
+This initiates an asynchronous operation and so is not necessarily immediate.
+Your app should account for this potential delay before attempting any subsequent operations.
+
+You can find further information on database operations in xref:csharp:database.adoc[Databases].
+
+// Example 9
+.Stop replicator
+
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="p2p-act-rep-stop", indent=0]
+
+[source, C#]
+----
+// Stop replication.
+thisReplicator.Stop();  <1>
+----
+
+
+====
+
+<.> Here we initiate the stopping of the replication using the https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net/api/Couchbase.Lite.Sync.Replicator.html#Couchbase_Lite_Sync_Replicator_Stop[Stop()] method.
+It will stop any active <<csharp:replication:::lbl-repl-chng,change listener>> once the replication is stopped.
+
+
+[discrete#csharp:replication:::lbl-nwk-errs]
+== Error Handling
+
+
+When _replicator_ detects a network error it updates its status depending on the error type (permanent or temporary) and returns an appropriate HTTP error code.
+
+The following code snippet adds a `Change Listener`, which monitors a replication for errors and logs the the returned error code.
+
+.Monitoring for network errors
+
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="replication-error-handling", indent=0]
+
+[source, C#]
+----
+replicator.AddChangeListener((sender, args) =>
+{
+    if (args.Status.Error != null) {
+        Console.WriteLine($"Error :: {args.Status.Error}");
+    }
+});
+----
+
+====
+
+*For permanent network errors* (for example, `404` not found, or `401` unauthorized):
+_Replicator_ will stop permanently, whether `setContinuous`  is _true_ or _false_. Of course, it sets its status to `STOPPED`
+
+*For recoverable or temporary errors:* _Replicator_ sets its status to `OFFLINE`, then:
+
+* If `setContinuous=_true_` it retries the connection indefinitely
+
+* If `setContinuous=_false_` (one-shot) it retries the connection a limited number of times.
+
+The following error codes are considered temporary by the Couchbase Lite replicator and thus will trigger a connection retry.
+
+* `408`: Request Timeout
+
+* `429`: Too Many Requests
+
+* `500`: Internal Server Error
+
+* `502`: Bad Gateway
+
+* `503`: Service Unavailable
+
+* `504`: Gateway Timeout
+
+* `1001`: DNS resolution error
+
+
+
+[discrete#csharp:replication:::load-balancers]
+== Load Balancers
+
+
+Couchbase Lite footnote:[From 2.0] uses WebSockets as the communication protocol to transmit data.
+Some load balancers are not configured for WebSocket connections by default (NGINX for example);
+so it might be necessary to explicitly enable them in the load balancer's configuration (see xref:sync-gateway::load-balancer.adoc[Load Balancers]).
+
+By default, the WebSocket protocol uses compression to optimize for speed and bandwidth utilization.
+The level of compression is set on Sync Gateway and can be tuned in the configuration file (xref:sync-gateway:ROOT:refer/config-properties.adoc#replicator_compression[`replicator_compression`]).
+
+
+[discrete#csharp:replication:::lbl-cert-pinning]
+== Certificate Pinning
+
+Couchbase Lite for C#.Net supports certificate pinning.
+
+Certificate pinning is a technique that can be used by applications to "pin" a host to its certificate.
+The certificate is typically delivered to the client by an out-of-band channel and bundled with the client.
+In this case, Couchbase Lite uses this embedded certificate to verify the trustworthiness of the server (for example, a Sync Gateway) and no longer needs to rely on a trusted third party for that (commonly referred to as the Certificate Authority).
+
+[.status]#Couchbase Lite 3.0.2#
+
+For the 3.02. release, changes have been made to the way certificates on the host are matched:
+[horizontal]
+
+Prior to CBL3.0.2:: The pinned certificate was only compared with the leaf certificate of the host. This is not always suitable as leaf certificates are usually valid for shorter periods of time.
+CBL-3.0.2{plus}:: The pinned certificate will be compared against any certificate in the server's certificate chain.
+
+
+The following steps describe how to configure certificate pinning between Couchbase Lite and Sync Gateway.
+
+. xref:sync-gateway::security.adoc#creating-your-own-self-signed-certificate[Create your own self-signed certificate]
+with the `openssl` command.
+After completing this step, you should have 3 files: `cert.pem`, `cert.cer` and `privkey.pem`.
+
+. xref:sync-gateway::security.adoc#installing-the-certificate[Configure Sync Gateway]
+with the `cert.pem` and `privkey.pem` files.
+After completing this step, Sync Gateway is reachable over `https`/`wss`.
+
+. On the Couchbase Lite side, the replication must point to a URL with the `wss` scheme and configured with the `cert.cer` file created in step 1.
++
+This example loads the certificate from the application sandbox, then converts it to the appropriate type to configure the replication object.
+
+.Cert Pinnings
+[#ex-crt-pinning]
+
+[#csharp:replication:::ex-crt-pinning]
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="certificate-pinning", indent=0]
+
+[source, C#]
+----
+// Note: `GetCertificate` is a placeholder method. This would be the platform-specific method
+// to find and load the certificate as an instance of `X509Certificate2`.
+// For .NET Core / .NET Framework this can be loaded from the filesystem path.
+// For WinUI, from the assets directory.
+// For iOS, from the main bundle.
+// For Android, from the assets directory.
+var certificate = GetCertificate("cert.cer");
+var config = new ReplicatorConfiguration(target)
+{
+    PinnedServerCertificate = certificate
+};
+----
+
+====
+
+. Build and run your app.
+The replication should now run successfully over https/wss with certificate pinning.
+
+For more on pinning certificates see the blog entry: https://blog.couchbase.com/certificate-pinning-android-with-couchbase-mobile/[Certificate Pinning with Couchbase Mobile]
+
+
+[discrete#csharp:replication:::lbl-trouble]
+== Troubleshooting
+
+
+[discrete#csharp:replication:::logs]
+=== Logs
+As always, when there is a problem with replication, logging is your friend.
+You can increase the log output for activity related to replication with Sync Gateway -- see <<csharp:replication:::ex-logs>>.
+
+[#ex-logs]
+.Set logging verbosity
+
+
+[#csharp:replication:::ex-logs]
+====
+
+
+// Show Main Snippet
+// include ::csharp:example$code_snippets/Program.cs[tags="replication-logging", indent=0]
+
+[source, C#]
+----
+// deprecated
+Database.SetLogLevel(LogDomain.Replicator, LogLevel.Verbose);
+Database.SetLogLevel(LogDomain.Network, LogLevel.Verbose);
+----
+
+
+====
+
+
+For more on troubleshooting with logs, see: xref:csharp:troubleshooting-logs.adoc[Using Logs].
+
+[discrete#csharp:replication:::authentication-errors]
+=== Authentication Errors
+If Sync Gateway is configured with a self signed certificate but your app points to a `ws` scheme instead of `wss` you will encounter an error with status code `11006` -- see: <<csharp:replication:::ex-11006>>
+
+[#csharp:replication:::ex-11006]
+.Protocol Mismatch
+====
+[source,console]
+----
+CouchbaseLite Replicator ERROR: {Repl#2} Got LiteCore error: WebSocket error 1006 "connection closed abnormally"
+----
+====
+
+If Sync Gateway is configured with a self signed certificate, and your app points to a `wss` scheme but the replicator configuration isn't using the certificate you will encounter an error with status code `5011` -- see: <<csharp:replication:::ex-5011>>
+
+[#ex-5011]
+.Certificate Mismatch or Not Found
+
+[#csharp:replication:::ex-5011]
+====
+[source,text]
+----
+CouchbaseLite Replicator ERROR: {Repl#2} Got LiteCore error: Network error 11 "server TLS certificate is self-signed or has unknown root cert"
+----
+====
+
+
+[discrete#csharp:replication:::related-content]
+== Related Content
+++++
+<div class="card-row three-column-row">
+++++
+
+[.column]
+=== {empty}
+.How to . . .
+* xref:csharp:gs-prereqs.adoc[Prerequisites]
+* xref:csharp:gs-install.adoc[Install]
+* xref:csharp:gs-build.adoc[Build and Run]
+
+
+
+[.column]
+=== {empty}
+.Learn more . . .
+* xref:csharp:database.adoc[Databases]
+* xref:csharp:document.adoc[Documents]
+* xref:csharp:blob.adoc[Blobs]
+* xref:csharp:replication.adoc[Remote Sync Gateway]
+* xref:csharp:conflict.adoc[Handling Data Conflicts]
+
+
+
+[.column]
+=== {empty}
+.Dive Deeper . . .
+//* Community
+https://forums.couchbase.com/c/mobile/14[Mobile Forum] |
+https://blog.couchbase.com/[Blog] |
+https://docs.couchbase.com/tutorials/[Tutorials]
+
+
+++++
+</div>
+++++


### PR DESCRIPTION
Fixing the code samples will require collaboration with @borrrden and co, but in the meantime, we can copy the previous snippets from version 3.0.

This requires copying the "simplified" version from https://github.com/couchbase/docs-couchbase-lite/pull/910 and making some changes:

* fix image location to :ROOT:
* remove additional == 2 levels of header
* some additional tidying and corrections

as well as copy/pasting code from the previous output into the source snippets as appropriate.

### Known Breakages

The "Related Content" section is no longer in 3 columns. I tidied up some extraneous markup, but didn't manage to fix yet.

### Preview site

https://preview.docs-test.couchbase.com/DOC-12631-csharp-replication-page/couchbase-lite/current/csharp/replication.html

(see https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords for password)