### PR TITLE
DOC-12646: Correct android namespace and add MAUI activation snippet.

### DIFF
--- a/modules/csharp/pages/gs-install.adoc
+++ b/modules/csharp/pages/gs-install.adoc
@@ -56,7 +56,7 @@ This is the recommended method of dependency management because it supports the 
 
 .`Couchbase.Lite.Enterprise`
 * `Couchbase.Lite.Enterprise.Support.ios`
-* `Couchbase.Lite.Enterprise.Support.Droid`
+* `Couchbase.Lite.Enterprise.Support.Android`
 * `Couchbase.Lite.Enterprise.Support.NetDesktop`
 * `Couchbase.Lite.Enterprise.Support.WinUI`
 

--- a/modules/csharp/pages/gs-install.adoc
+++ b/modules/csharp/pages/gs-install.adoc
@@ -56,13 +56,13 @@ This is the recommended method of dependency management because it supports the 
 
 .`Couchbase.Lite.Enterprise`
 * `Couchbase.Lite.Enterprise.Support.ios`
-* `Couchbase.Lite.Enterprise.Support.android`
+* `Couchbase.Lite.Enterprise.Support.Droid`
 * `Couchbase.Lite.Enterprise.Support.NetDesktop`
 * `Couchbase.Lite.Enterprise.Support.WinUI`
 
 .`Couchbase.Lite`
 * `Couchbase.Lite.Support.ios`
-* `Couchbase.Lite.Support.android`
+* `Couchbase.Lite.Support.Droid`
 * `Couchbase.Lite.Support.NetDesktop`
 * `Couchbase.Lite.Support.WinUI`
 

--- a/modules/csharp/pages/gs-install.adoc
+++ b/modules/csharp/pages/gs-install.adoc
@@ -88,17 +88,37 @@ You can manage your dependencies by following the steps below:
 
 == Activating (on Android platform only)
 
+IMPORTANT: Couchbase Lite must be activated before any other calls can be made.
+
 Within your Android app, include a call to the relevant `Activate()` function inside of the class that is included in the support assembly.
 
 There is only one public class in each support assembly, and the support assembly itself is a nuget dependency.
 
 For example: +
-`Couchbase.Lite.Support.android.Activate()`
+`Couchbase.Lite.Support.Droid.Activate()`
 
 NOTE: The `Activate()` function is required for applications using .NET on the Android platform in general.
 This includes Couchbase Lite and the Vector Search extension.
 
 Currently the support assemblies provide dependency injected mechanisms for default directory logic, and platform specific logging (So, C# will log to logcat with correct log levels and tags. No more "mono-stdout" always at info level.)
+
+=== Activating with MAUI
+
+To activate with .NET MAUI, you must override the `OnCreate()` method in the `MainActivity.cs` file to ensure activation at the beginning of the application lifecyle.
+
+Below is an example of how you can override the `OnCreate()` method.
+
+[source, csharp]
+--
+public class MainActivity : MauiAppCompatActivity
+{
+    protected override void OnCreate(Bundle savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+        Couchbase.Lite.Support.Droid.Activate(this);
+    }
+}       
+--
 
 === Activating Vector Search
 

--- a/modules/csharp/pages/gs-install.adoc
+++ b/modules/csharp/pages/gs-install.adoc
@@ -62,7 +62,7 @@ This is the recommended method of dependency management because it supports the 
 
 .`Couchbase.Lite`
 * `Couchbase.Lite.Support.ios`
-* `Couchbase.Lite.Support.Droid`
+* `Couchbase.Lite.Support.Android`
 * `Couchbase.Lite.Support.NetDesktop`
 * `Couchbase.Lite.Support.WinUI`
 


### PR DESCRIPTION
A PR to resolve the following ticket: https://couchbasecloud.atlassian.net/browse/DOC-12646.

Change List:

- Added admonition informing users Couchbase Lite must be activated before other CBL calls
- Added MAUI snippet
- Corrected `Android` namespace to `Droid`