### PR TITLE
Doc 12711 CBL 3-1-10 Maintenance Release Documentation.

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -22,12 +22,12 @@ asciidoc:
     release: '3.1'
     major: 3
     minor: 1
-    maintenance-ios: 9
-    maintenance-c: 9
-    maintenance-android: 9
-    maintenance-java: 9
-    maintenance-net: 9
-    base: 9 # generic maintenance base, may no longer apply when versions deviate, change to version-maint-mobilesdk later rather than using base
+    maintenance-ios: 10
+    maintenance-c: 10
+    maintenance-android: 10
+    maintenance-java: 10
+    maintenance-net: 10
+    base: 10 # generic maintenance base, may no longer apply when versions deviate, change to version-maint-mobilesdk later rather than using base
     page-toclevels: 2@
     # releasetag:
     # show_edition:

--- a/modules/ROOT/pages/_partials/commons/common-quickstart-skeleton.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-quickstart-skeleton.adoc
@@ -27,6 +27,9 @@ image::ROOT:manage-and-store-data-locally.svg[,250]
 [.content]
 .Get Started
 // * {url-download-package}
+ifdef::is-c[]
+* xref:{param-module}:gs-downloads.adoc[Download]
+endif::is-c[]
 * xref:{param-module}:gs-install.adoc[Install]
 * xref:{param-module}:gs-build.adoc[Build]
 ifndef::is-android[* {url-api-references}[Browse API References ...]]

--- a/modules/android/pages/releasenotes.adoc
+++ b/modules/android/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_android.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-android-release-note.3.1.10.adoc[]
+
 include::partial$release-notes/couchbase-mobile-android-release-note.3.1.9.adoc[]
 
 include::partial$release-notes/couchbase-mobile-android-release-note.3.1.8.adoc[]

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.10.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.10.adoc
@@ -1,0 +1,21 @@
+[#maint-3-1-10]
+== 3.1.10 -- November 2024
+
+Version 3.1.10 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+// Lite Core Start
+* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
+
+* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+// Lite Core End
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.10.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.1.10.adoc
@@ -9,9 +9,7 @@ None for this release
 
 === Issues and Resolutions
 // Lite Core Start
-* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
-
-* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+* https://jira.issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
 // Lite Core End
 
 === Deprecations

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -24,16 +24,22 @@ include::{root-partials}_show_get_started_topic_group.adoc[]
  
 .Downloads are available for the following versions:
 ****
-<<release-3-1-9>>
-<<release-3-1-7>>
-<<release-3-1-6>>
-<<release-3-1-3>>
-<<release-3-1-1>>
-<<release-3-1-0>>
+<<release-3-1-10>>  |
+<<release-3-1-9>>   |
+<<release-3-1-7>>   |
+<<release-3-1-6>>   |
+<<release-3-1-3>>   |
+<<release-3-1-1>>   |
+<<release-3-1-0>>   |
 // | 
 ****
 
 // This block will always represent the major release version
+:param-version: 3.1.10
+:param-version-hyphenated: 3-1-10
+include::partial$downloadslist.adoc[]
+:param-version!:
+
 :param-version: 3.1.9
 :param-version-hyphenated: 3-1-9
 include::partial$downloadslist.adoc[]

--- a/modules/c/pages/releasenotes.adoc
+++ b/modules/c/pages/releasenotes.adoc
@@ -13,6 +13,8 @@ include::partial$_set_page_context_for_c.adoc[]
 include::{root-partials}_show_page_header_block.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-c-release-note.3.1.10.adoc[]
+
 include::partial$release-notes/couchbase-mobile-c-release-note.3.1.9.adoc[]
 
 include::partial$release-notes/couchbase-mobile-c-release-note.3.1.7.adoc[]

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.10.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.10.adoc
@@ -9,9 +9,9 @@ None for this release
 
 === Issues and Resolutions
 // Lite Core Start
-* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
+* https://jira.issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
 
-* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+* https://jira.issues.couchbase.com/browse/CBL-6427[CBL-6427 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
 // Lite Core End
 
 === Deprecations

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.10.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.1.10.adoc
@@ -1,0 +1,21 @@
+[#maint-3-1-10]
+== 3.1.10 -- November 2024
+
+Version 3.1.10 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+// Lite Core Start
+* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
+
+* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+// Lite Core End
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]

--- a/modules/csharp/pages/releasenotes.adoc
+++ b/modules/csharp/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_csharp.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-csharp-release-note.3.1.10.adoc[]
+
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.1.9.adoc[]
 
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.1.7.adoc[]

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.10.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.10.adoc
@@ -1,0 +1,24 @@
+[#maint-3-1-10]
+== 3.1.10 -- November 2024
+
+Version 3.1.10 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+// Lite Core Start
+* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
+
+* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+// Lite Core End
+* https://issues.couchbase.com/browse/CBL-6299[CBL-6299 -- Fixed ReplicatedDocument ToString doesn't properly null check]
+
+* https://issues.couchbase.com/browse/CBL-6294[CBL-6294 -- Fixed C4IndexOptions leaks stopWords]
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.10.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.1.10.adoc
@@ -9,13 +9,11 @@ None for this release
 
 === Issues and Resolutions
 // Lite Core Start
-* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
-
-* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+* https://jira.issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
 // Lite Core End
-* https://issues.couchbase.com/browse/CBL-6299[CBL-6299 -- Fixed ReplicatedDocument ToString doesn't properly null check]
+* https://jira.issues.couchbase.com/browse/CBL-6299[CBL-6299 -- Fixed ReplicatedDocument ToString doesn't properly null check]
 
-* https://issues.couchbase.com/browse/CBL-6294[CBL-6294 -- Fixed C4IndexOptions leaks stopWords]
+* https://jira.issues.couchbase.com/browse/CBL-6294[CBL-6294 -- Fixed C4IndexOptions leaks stopWords]
 
 === Deprecations
 

--- a/modules/java/pages/releasenotes.adoc
+++ b/modules/java/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_java.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-java-release-note.3.1.10.adoc[]
+
 include::partial$release-notes/couchbase-mobile-java-release-note.3.1.9.adoc[]
 
 include::partial$release-notes/couchbase-mobile-java-release-note.3.1.7.adoc[]

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.10.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.10.adoc
@@ -1,0 +1,21 @@
+[#maint-3-1-10]
+== 3.1.10 -- November 2024
+
+Version 3.1.10 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+// Lite Core Start
+* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
+
+* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+// Lite Core End
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.10.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.1.10.adoc
@@ -9,9 +9,7 @@ None for this release
 
 === Issues and Resolutions
 // Lite Core Start
-* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
-
-* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+* https://jira.issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
 // Lite Core End
 
 === Deprecations

--- a/modules/objc/pages/releasenotes.adoc
+++ b/modules/objc/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_objc.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.10.adoc[]
+
 include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.9.adoc[]
 
 include::partial$release-notes/couchbase-mobile-objc-release-note.3.1.7.adoc[]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.10.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.10.adoc
@@ -1,0 +1,22 @@
+[#maint-3-1-10]
+== 3.1.10 -- November 2024
+
+Version 3.1.10 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+// Lite Core Start
+* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
+
+* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+// Lite Core End
+* https://issues.couchbase.com/browse/CBL-6194[CBL-6194 -- Client Side Proxy CONNECT request is broken]
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.10.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.1.10.adoc
@@ -9,11 +9,9 @@ None for this release
 
 === Issues and Resolutions
 // Lite Core Start
-* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
-
-* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+* https://jira.issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
 // Lite Core End
-* https://issues.couchbase.com/browse/CBL-6194[CBL-6194 -- Client Side Proxy CONNECT request is broken]
+* https://jira.issues.couchbase.com/browse/CBL-6194[CBL-6194 -- Client Side Proxy CONNECT request is broken]
 
 === Deprecations
 

--- a/modules/swift/pages/releasenotes.adoc
+++ b/modules/swift/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 include::partial$_set_page_context_for_swift.adoc[]
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.10.adoc[]
+
 include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.9.adoc[]
 
 include::partial$release-notes/couchbase-mobile-swift-release-note.3.1.7.adoc[]

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.10.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.10.adoc
@@ -1,0 +1,22 @@
+[#maint-3-1-10]
+== 3.1.10 -- November 2024
+
+Version 3.1.10 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+// Lite Core Start
+* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
+
+* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+// Lite Core End
+* https://issues.couchbase.com/browse/CBL-6194[CBL-6194 -- Client Side Proxy CONNECT request is broken]
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.1, see xref:ROOT:cbl-whatsnew.adoc[New in 3.1]

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.10.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.1.10.adoc
@@ -9,11 +9,9 @@ None for this release
 
 === Issues and Resolutions
 // Lite Core Start
-* https://issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
-
-* https://issues.couchbase.com/browse/CBL-6377[CBL-6377 -- Fixed crash when calling onWebSocketGotTLSCertificate callback after the connection is closed]
+* https://jira.issues.couchbase.com/browse/CBL-6282[CBL-6282 -- Replicator starts slowly for big databases]
 // Lite Core End
-* https://issues.couchbase.com/browse/CBL-6194[CBL-6194 -- Client Side Proxy CONNECT request is broken]
+* https://jira.issues.couchbase.com/browse/CBL-6194[CBL-6194 -- Client Side Proxy CONNECT request is broken]
 
 === Deprecations
 


### PR DESCRIPTION
This is a maintenance release for CBL 3.1.10.
Also some flyby fixes

- Tidied formatting of download version links.
- Added downloads to C quickstart page

 Home: https://preview.docs-test.couchbase.com/maint3110/home/index.html 

## Preview Credentials: https://couchbasecloud.atlassian.net/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords

Changed Pages
-------------------

- CBL-C Downloads : https://preview.docs-test.couchbase.com/maint3110/couchbase-lite/current/c/gs-downloads.html
- C Quckstart: https://preview.docs-test.couchbase.com/maint3110/couchbase-lite/current/c/quickstart.html
- Android Release Notes: https://preview.docs-test.couchbase.com/maint3110/couchbase-lite/current/android/releasenotes.html#maint-3-1-10
- C Release Notes: https://preview.docs-test.couchbase.com/maint3110/couchbase-lite/current/c/releasenotes.html#maint-3-1-10
- .NET Release Notes: https://preview.docs-test.couchbase.com/maint3110/couchbase-lite/current/csharp/releasenotes.html#maint-3-1-10
- Java Release Notes: https://preview.docs-test.couchbase.com/maint3110/couchbase-lite/current/java/releasenotes.html#maint-3-1-10
- Objective-C Release Notes: https://preview.docs-test.couchbase.com/maint3110/couchbase-lite/current/objc/releasenotes.html#maint-3-1-10
- Swift Release Notes: https://preview.docs-test.couchbase.com/maint3110/couchbase-lite/current/swift/releasenotes.html#maint-3-1-10


----------------------
Pages still needing changes/updates
-----------------------

....

-----------------------


