### PR TITLE
Doc 12623 logging version fix

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -27,7 +27,7 @@ asciidoc:
     maintenance-android: 15
     maintenance-java: 15
     maintenance-net: 15
-    base: 0
+    base: 15
     page-toclevels: 2@
     # Override playbook setting of sqlpp
     sqlpp_cbm: SQL++

--- a/modules/ROOT/pages/_partials/commons/common-logging.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-logging.adoc
@@ -11,6 +11,7 @@
 // :fn-2x5: footnote content
 :fn-2x5: footnote:fn-2x5[From version 2.5]
 ifndef::version-full[:version-full: UNDEFINED-VERSION]
+:cbl-log-version: 3.0.0
 ifndef::cbl-log-version[:cbl-log-version: {version-full}]
 ifndef::snippet[:snippet: UNDEFINED-SNIPPET-PATH]
 :url-cbl-log-binaries: https://packages.couchbase.com/releases/couchbase-lite-log/{cbl-log-version}/couchbase-lite-log-{cbl-log-version}


### PR DESCRIPTION
PR to fix issue in ticket: https://jira.issues.couchbase.com/browse/DOC-12623

Issue is present in all current versions of the doc.

Underlying cause is the cbl log tool was only released every minor/major version so the wget command would always fail using the `version-full` attribute once a patch version was involved.