### PR TITLE
DOC-12623: Explicitly define log version

### DIFF
--- a/modules/ROOT/pages/_partials/commons/common-logging.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-logging.adoc
@@ -11,6 +11,7 @@
 // :fn-2x5: footnote content
 :fn-2x5: footnote:fn-2x5[From version 2.5]
 ifndef::version-full[:version-full: UNDEFINED-VERSION]
+:cbl-log-version: 2.8.0
 ifndef::cbl-log-version[:cbl-log-version: {version-full}]
 ifndef::snippet[:snippet: UNDEFINED-SNIPPET-PATH]
 :url-cbl-log-binaries: https://packages.couchbase.com/releases/couchbase-lite-log/{cbl-log-version}/couchbase-lite-log-{cbl-log-version}


### PR DESCRIPTION
This is required as the cbl-log tool only has releases per minor/major version and NOT maintenance version. Rendering examples incorrect.

PR to fix issue in ticket: https://jira.issues.couchbase.com/browse/DOC-12623

Issue is present in all current versions of the doc.

Underlying cause is the cbl log tool was only released every minor/major version(latest being 3.0.0) so the wget command would always fail using the version-full attribute once a patch version was involved.