### PR TITLE
DOC-12623: Fix logging version.

### DIFF
--- a/modules/ROOT/pages/_partials/commons/common-logging.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-logging.adoc
@@ -11,6 +11,7 @@
 // :fn-2x5: footnote content
 :fn-2x5: footnote:fn-2x5[From version 2.5]
 ifndef::version-full[:version-full: UNDEFINED-VERSION]
+:cbl-log-version: 3.0.0
 ifndef::cbl-log-version[:cbl-log-version: {version-full}]
 ifndef::snippet[:snippet: UNDEFINED-SNIPPET-PATH]
 :url-cbl-log-binaries: https://packages.couchbase.com/releases/couchbase-lite-log/{cbl-log-version}/couchbase-lite-log-{cbl-log-version}
@@ -183,6 +184,8 @@ Related::
 {url-api-class-log} | {url-api-class-log-custom-getcust} | {url-api-class-log-custom}
 
 == Decoding binary logs
+
+NOTE: The latest version of the cbl-log tool is `3.0.0`.
 
 You can use the *cbl-log* tool to decode binary log files -- see <<eg-cbl-log>>.
 


### PR DESCRIPTION
Enforce cbl log tool version 3.0.0
The tool had previously been updated every minor/major release but stopped at 3.0. No functionality changes to the tool have occurred for some time. For now, users can correctly download version 3.0 if required.

PR to fix issue in ticket: https://jira.issues.couchbase.com/browse/DOC-12623

Issue is present in all current versions of the doc.

Underlying cause is the cbl log tool was only released every minor/major version so the wget command would always fail using the version-full attribute once a patch version was involved.