### PR TITLE
DOC-12804: Correct snippet explanation. Vale quick wins

### DIFF
--- a/modules/ROOT/pages/_partials/commons/common-indexing.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-indexing.adoc
@@ -201,14 +201,16 @@ The syntax for array index configuration is shown below:
 |`path`
 |image:ROOT:no.png[]
 |Path to the array to be indexed.
+Use `"[]"` to represent a property that is an array of each nested array level.
+For a single array or the last level array, the `"[]"` is optional.
+For instance `contacts[].phones` to specify an array of phones within each contact. 
 
 |`expressions`
 |image:ROOT:yes.png[]
-|An optional array of strings, where each string represents an expression defining the values within the array to be indexed.
-Use `"[]"` to represent a property that is an array of each nested array level.
-For instance `contacts[].phones` to specify an array of phones within each contact.
-For a single array or the last level array, the `"[]"` is optional. 
-If the array specified by the path contains scalar values, this parameter can be null.
+|An optional array of strings where each string represents values within the array to be indexed.
+In N1QL/SQL++ syntax, these expressions are separated by commas. 
+In JSON syntax, as supported by Couchbase Lite for C, the expressions are represented as a JSON array. 
+If the array specified by the path contains scalar values, the expressions should be left unset or set to null.
 
 |===
 

--- a/modules/ROOT/pages/_partials/commons/common-indexing.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-indexing.adoc
@@ -201,8 +201,8 @@ The syntax for array index configuration is shown below:
 |`path`
 |image:ROOT:no.png[]
 |Path to the array to be indexed.
-Use `"[]"` to represent a property that is an array of each nested array level.
-For a single array or the last level array, the `"[]"` is optional.
+Use `[]` to represent a property that is an array of each nested array level.
+For a single array or the last level array, the `[]` is optional.
 For instance `contacts[].phones` to specify an array of phones within each contact. 
 
 |`expressions`

--- a/modules/ROOT/pages/_partials/commons/common-indexing.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-indexing.adoc
@@ -243,14 +243,14 @@ For the following examples, you can assume we are querying results from the foll
 
 --
 
-Using the document above we can perform queries on a single nested array like so:
+Using the document above you can perform queries on a single nested array like so:
 
 [source, sqlpp]
 --
 SELECT name, like FROM _ UNNEST likes as like WHERE like = "travel" 
 --
 
-The query above will produce the following output from the document:
+The query above produces the following output from the document:
 
 [source, JSON]
 --
@@ -341,7 +341,7 @@ UNNEST contact.phones as phone
 WHERE phone.type = "mobile"
 --
 
-The query above will then produce the following output:
+The query produces the following output:
 
 [source, JSON]
 --
@@ -424,7 +424,7 @@ include::c:example$code_snippets/main.cpp[tags=array-index-nested]
 ----
 endif::is-c[]
 
-The above snippet will create an array index to allow you to iterate through `contacts[].type` in the document, namely `"primary"` and `"secondary"`.
+The above snippet creates an array index to allow you to iterate through `contacts[].phones[].type` in the document, namely `"home"` and `"mobile"`.
 
 IMPORTANT: Array literals are not supported in CBL 3.2.1.
 Attempting to create a query with array literals will return an error.

--- a/modules/ROOT/pages/_partials/commons/common-indexing.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-indexing.adoc
@@ -247,7 +247,7 @@ Using the document above you can perform queries on a single nested array like s
 
 [source, sqlpp]
 --
-SELECT name, like FROM _ UNNEST likes as like WHERE like = "travel" 
+SELECT name, interest FROM _ UNNEST likes as like WHERE like = "travel" 
 --
 
 The query above produces the following output from the document:

--- a/modules/ROOT/pages/_partials/commons/common-query-n1ql-mobile.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-query-n1ql-mobile.adoc
@@ -422,7 +422,7 @@ Attempting to create a query with array literals will return an error.
 == WHERE statement
 
 === Purpose
-Specifies the selecion criteria used to filter results.
+Specifies the selection criteria used to filter results.
 
 As with SQL, use the `WHERE` statement to choose which documents are returned by your query.
 

--- a/modules/ROOT/pages/_partials/commons/common-query-n1ql-mobile.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-query-n1ql-mobile.adoc
@@ -384,7 +384,7 @@ Using the document above we can perform queries on a single nested array like so
 
 [source, sqlpp]
 --
-SELECT name, like FROM _ UNNEST likes as like WHERE like = "travel" 
+SELECT name, interest FROM _ UNNEST likes as like WHERE like = "travel" 
 --
 
 The query above will produce the following output from the document:


### PR DESCRIPTION
PR for the ticket: https://jira.issues.couchbase.com/browse/DOC-12804

Summary: Correct explanation for the last snippet in this section: https://jira.issues.couchbase.com/browse/DOC-12804
Additional fixes for the following related tickets:

- https://jira.issues.couchbase.com/browse/DOC-12821
- https://jira.issues.couchbase.com/browse/DOC-12822
These are folded in as they all relate to the same section and content.

JSON for context

```
{
   "Name":"Sam",
   "contacts":[
     {
       "type":"primary",
       "address":{"street":"1 St","city":"San Pedro","state":"CA"},
       "phones":[
         {"type":"home","number":"310-123-4567"},
         {"type":"mobile","number":"310-123-6789"}
       ]
     },
     {
       "type":"secondary",
       "address":{"street":"5 St","city":"Seattle","state":"WA"},
       "phones":[
         {"type":"home","number":"206-123-4567"},
         {"type":"mobile","number":"206-123-6789"}
       ]
     }
   ],
   "likes":["soccer","travel"]
 }

```
Path should be `contacts[].phones[].type` not `contacts[].type` and the types themselves are `home` and `mobile`.
