### PR TITLE
DOC-12822: replace protected keyword with interest

### DIFF
--- a/modules/ROOT/pages/_partials/commons/common-indexing.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-indexing.adoc
@@ -249,7 +249,7 @@ Using the document above you can perform queries on a single nested array like s
 
 [source, sqlpp]
 --
-SELECT name, interest FROM _ UNNEST likes as like WHERE like = "travel" 
+SELECT name, interest FROM _ UNNEST likes as interest WHERE interest = "travel" 
 --
 
 The query above produces the following output from the document:

--- a/modules/ROOT/pages/_partials/commons/common-query-n1ql-mobile.adoc
+++ b/modules/ROOT/pages/_partials/commons/common-query-n1ql-mobile.adoc
@@ -384,7 +384,7 @@ Using the document above we can perform queries on a single nested array like so
 
 [source, sqlpp]
 --
-SELECT name, interest FROM _ UNNEST likes as like WHERE like = "travel" 
+SELECT name, interest FROM _ UNNEST likes as interest WHERE interest = "travel" 
 --
 
 The query above will produce the following output from the document:


### PR DESCRIPTION
Adding to previous fix. Replace parameters correctly so `like` is always referred to as `interest`.

Ticket here: https://jira.issues.couchbase.com/browse/DOC-12822