### PR TITLE
DOC-12925: Logging API snippets iOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
                 stage("Validate iOS") {
                     agent { label 'mobile-builder-ios-pull-request' }
                     steps {
-                        sh 'jenkins/ios.sh 3.2.1 1.0.0'
+                        sh 'jenkins/ios.sh 3.2.2 1.0.0'
                     }
                 }
             }

--- a/modules/objc/examples/code_snippets/SampleCodeTest.m
+++ b/modules/objc/examples/code_snippets/SampleCodeTest.m
@@ -211,19 +211,6 @@
 
 #pragma mark - Logging
 
-- (void) dontTestLogging {
-    // tag::logging[]
-
-    // Replicator / Verbose
-    CBLDatabase.log.console.level = kCBLLogLevelVerbose;
-    CBLDatabase.log.console.domains = kCBLLogDomainReplicator;
-
-    // Query /  Verbose
-    CBLDatabase.log.console.level = kCBLLogLevelVerbose;
-    CBLDatabase.log.console.domains = kCBLLogDomainQuery;
-    // end::logging[]
-}
-
 #if COUCHBASE_ENTERPRISE
 - (void) dontTestDatabaseEncryption {
     // tag::database-encryption[]

--- a/modules/objc/examples/code_snippets/SampleCodeTest.m
+++ b/modules/objc/examples/code_snippets/SampleCodeTest.m
@@ -242,8 +242,8 @@
     // tag::file-logging[]
     NSString *tempFolder = [NSTemporaryDirectory() stringByAppendingPathComponent: @"cbllog"];
     CBLLogFileConfiguration *config = [[CBLLogFileConfiguration alloc] initWithDirectory:tempFolder]; // <.>
-    config.maxRotateCount = 2; // <.>
-    config.maxSize = 1024; // <.>
+    config.maxRotateCount = 12; // <.>
+    config.maxSize = 524288; // <.>
     config.usePlainText = YES; // <.>
     [CBLDatabase.log.file setConfig:config];
     [CBLDatabase.log.file setLevel:kCBLLogLevelVerbose]; // <.>
@@ -256,8 +256,8 @@
     CBLLogSinks.file = [[CBLFileLogSink alloc] initWithLevel:kCBLLogLevelVerbose
                                                    directory:tempFolder
                                                 usePlaintext:false
-                                                maxKeptFiles:2
-                                                 maxFileSize:1024];
+                                                maxKeptFiles:12
+                                                 maxFileSize:524288];
     // end::new-file-logging[]
 }
 

--- a/modules/objc/examples/code_snippets/SampleCodeTest.m
+++ b/modules/objc/examples/code_snippets/SampleCodeTest.m
@@ -102,6 +102,21 @@
 
 // end::custom-logging[]
 
+// tag::new-custom-logging[]
+@interface TestLogger :NSObject<CBLLogSinkProtocol>
+
+@end
+
+@implementation TestLogger
+
+- (void) writeLogWithLevel:(CBLLogLevel)level domain:(CBLLogDomain)domain message:(NSString*)message {
+    // handle the message, for example piping it to
+    // a third party framework
+}
+
+@end
+// end::new-custom-logging[]
+
 // tag::local-win-conflict-resolver[]
 @interface LocalWinConflictResolver :NSObject<CBLConflictResolver>
 @end
@@ -194,6 +209,7 @@
   // end::database-fullsync[]
 }
 
+#pragma mark - Logging
 
 - (void) dontTestLogging {
     // tag::logging[]
@@ -226,13 +242,14 @@
     // tag::console-logging[]
     CBLDatabase.log.console.domains = kCBLLogDomainAll; // <.>
     CBLDatabase.log.console.level = kCBLLogLevelVerbose; // <.>
-
     // end::console-logging[]
+}
 
-    // tag::console-logging-db[]
-    CBLDatabase.log.console.domains = kCBLLogDomainAll;
-
-    // end::console-logging-db[]
+- (void) dontTestEnableNewConsoleLogging {
+    // tag::new-console-logging[]
+    CBLConsoleLogSink* sink = [[CBLConsoleLogSink alloc] initWithLevel:kCBLLogLevelVerbose domains:kCBLLogDomainAll];
+    CBLLogSinks.console = sink;
+    // end::new-console-logging[]
 }
 
 - (void) dontTestFileLogging {
@@ -247,13 +264,28 @@
     // end::file-logging[]
 }
 
+- (void) dontTestNewFileLogging {
+    // tag::new-file-logging[]
+    NSString* tempFolder = [NSTemporaryDirectory() stringByAppendingPathComponent:@"cbllog"];
+    CBLFileLogSink* sink = [[CBLFileLogSink alloc] initWithLevel: kCBLLogLevelInfo directory: tempFolder];
+    CBLLogSinks.file = sink;
+    // end::new-file-logging[]
+}
+
 - (void) dontTestEnableCustomLogging {
-    // tag::set-custom-logging[]
+    // tag::custom-logging[]
     LogTestLogger *logger = [[LogTestLogger alloc] init];
     logger.level = kCBLLogLevelWarning;
     [CBLDatabase.log setCustom:logger];
+    // end::custom-logging[]
+}
 
-    // end::set-custom-logging[]
+- (void) dontTestEnableNewCustomLogging {
+    // tag::new-custom-logging[]
+    TestLogger* logger = [[TestLogger alloc] init];
+    CBLCustomLogSink* sink = [[CBLCustomLogSink alloc] initWithLevel: kCBLLogLevelWarning logSink: logger];
+    CBLLogSinks.custom = sink;
+    // end::new-custom-logging[]
 }
 
 - (void) dontTestLoadingPrebuilt {

--- a/modules/objc/examples/code_snippets/SampleCodeTest.m
+++ b/modules/objc/examples/code_snippets/SampleCodeTest.m
@@ -246,14 +246,18 @@
     config.maxSize = 1024; // <.>
     config.usePlainText = YES; // <.>
     [CBLDatabase.log.file setConfig:config];
-    [CBLDatabase.log.file setLevel:kCBLLogLevelInfo]; // <.>
+    [CBLDatabase.log.file setLevel:kCBLLogLevelVerbose]; // <.>
     // end::file-logging[]
 }
 
 - (void) dontTestNewFileLogging {
     // tag::new-file-logging[]
     NSString* tempFolder = [NSTemporaryDirectory() stringByAppendingPathComponent:  @"cbllog"];
-    CBLLogSinks.file = [[CBLFileLogSink alloc] initWithLevel:kCBLLogLevelInfo directory:tempFolder];;
+    CBLLogSinks.file = [[CBLFileLogSink alloc] initWithLevel:kCBLLogLevelVerbose
+                                                   directory:tempFolder
+                                                usePlaintext:false
+                                                maxKeptFiles:2
+                                                 maxFileSize:1024];
     // end::new-file-logging[]
 }
 

--- a/modules/objc/examples/code_snippets/SampleCodeTest.m
+++ b/modules/objc/examples/code_snippets/SampleCodeTest.m
@@ -89,6 +89,8 @@
 
 @end
 
+#pragma mark - Custom Logger class
+
 @implementation LogTestLogger
 
 @synthesize level=_level;
@@ -209,8 +211,6 @@
   // end::database-fullsync[]
 }
 
-#pragma mark - Logging
-
 #if COUCHBASE_ENTERPRISE
 - (void) dontTestDatabaseEncryption {
     // tag::database-encryption[]
@@ -225,20 +225,14 @@
 }
 #endif
 
-- (void) dontTestEnableConsoleLogging {
+#pragma mark - Logging
+
+- (void) dontTestOldLoggingApi {
     // tag::console-logging[]
     CBLDatabase.log.console.domains = kCBLLogDomainAll; // <.>
     CBLDatabase.log.console.level = kCBLLogLevelVerbose; // <.>
     // end::console-logging[]
-}
-
-- (void) dontTestEnableNewConsoleLogging {
-    // tag::new-console-logging[]
-    CBLLogSinks.console = [[CBLConsoleLogSink alloc] initWithLevel:kCBLLogLevelVerbose domains:kCBLLogDomainAll];
-    // end::new-console-logging[]
-}
-
-- (void) dontTestFileLogging {
+    
     // tag::file-logging[]
     NSString *tempFolder = [NSTemporaryDirectory() stringByAppendingPathComponent: @"cbllog"];
     CBLLogFileConfiguration *config = [[CBLLogFileConfiguration alloc] initWithDirectory:tempFolder]; // <.>
@@ -248,9 +242,19 @@
     [CBLDatabase.log.file setConfig:config];
     [CBLDatabase.log.file setLevel:kCBLLogLevelVerbose]; // <.>
     // end::file-logging[]
+    
+    // tag::custom-logging[]
+    LogTestLogger *logger = [[LogTestLogger alloc] init];
+    logger.level = kCBLLogLevelWarning;
+    [CBLDatabase.log setCustom:logger];
+    // end::custom-logging[]
 }
 
-- (void) dontTestNewFileLogging {
+- (void) dontTestNewLoggingApi {
+    // tag::new-console-logging[]
+    CBLLogSinks.console = [[CBLConsoleLogSink alloc] initWithLevel:kCBLLogLevelVerbose domains:kCBLLogDomainAll];
+    // end::new-console-logging[]
+    
     // tag::new-file-logging[]
     NSString* tempFolder = [NSTemporaryDirectory() stringByAppendingPathComponent:  @"cbllog"];
     CBLLogSinks.file = [[CBLFileLogSink alloc] initWithLevel:kCBLLogLevelVerbose
@@ -259,17 +263,7 @@
                                                 maxKeptFiles:12
                                                  maxFileSize:524288];
     // end::new-file-logging[]
-}
-
-- (void) dontTestEnableCustomLogging {
-    // tag::custom-logging[]
-    LogTestLogger *logger = [[LogTestLogger alloc] init];
-    logger.level = kCBLLogLevelWarning;
-    [CBLDatabase.log setCustom:logger];
-    // end::custom-logging[]
-}
-
-- (void) dontTestEnableNewCustomLogging {
+    
     // tag::new-custom-logging[]
     TestLogSink* sink = [[TestLogSink alloc] init];
     CBLLogSinks.custom = [[CBLCustomLogSink alloc] initWithLevel:kCBLLogLevelWarning logSink:sink];

--- a/modules/objc/examples/code_snippets/SampleCodeTest.m
+++ b/modules/objc/examples/code_snippets/SampleCodeTest.m
@@ -103,11 +103,11 @@
 // end::custom-logging[]
 
 // tag::new-custom-logging[]
-@interface TestLogger :NSObject<CBLLogSinkProtocol>
+@interface TestLogSink :NSObject<CBLLogSinkProtocol>
 
 @end
 
-@implementation TestLogger
+@implementation TestLogSink
 
 - (void) writeLogWithLevel:(CBLLogLevel)level domain:(CBLLogDomain)domain message:(NSString*)message {
     // handle the message, for example piping it to
@@ -234,14 +234,13 @@
 
 - (void) dontTestEnableNewConsoleLogging {
     // tag::new-console-logging[]
-    CBLConsoleLogSink* sink = [[CBLConsoleLogSink alloc] initWithLevel:kCBLLogLevelVerbose domains:kCBLLogDomainAll];
-    CBLLogSinks.console = sink;
+    CBLLogSinks.console = [[CBLConsoleLogSink alloc] initWithLevel:kCBLLogLevelVerbose domains:kCBLLogDomainAll];
     // end::new-console-logging[]
 }
 
 - (void) dontTestFileLogging {
     // tag::file-logging[]
-    NSString *tempFolder = [NSTemporaryDirectory() stringByAppendingPathComponent:@"cbllog"];
+    NSString *tempFolder = [NSTemporaryDirectory() stringByAppendingPathComponent: @"cbllog"];
     CBLLogFileConfiguration *config = [[CBLLogFileConfiguration alloc] initWithDirectory:tempFolder]; // <.>
     config.maxRotateCount = 2; // <.>
     config.maxSize = 1024; // <.>
@@ -253,9 +252,8 @@
 
 - (void) dontTestNewFileLogging {
     // tag::new-file-logging[]
-    NSString* tempFolder = [NSTemporaryDirectory() stringByAppendingPathComponent:@"cbllog"];
-    CBLFileLogSink* sink = [[CBLFileLogSink alloc] initWithLevel: kCBLLogLevelInfo directory: tempFolder];
-    CBLLogSinks.file = sink;
+    NSString* tempFolder = [NSTemporaryDirectory() stringByAppendingPathComponent:  @"cbllog"];
+    CBLLogSinks.file = [[CBLFileLogSink alloc] initWithLevel:kCBLLogLevelInfo directory:tempFolder];;
     // end::new-file-logging[]
 }
 
@@ -269,9 +267,8 @@
 
 - (void) dontTestEnableNewCustomLogging {
     // tag::new-custom-logging[]
-    TestLogger* logger = [[TestLogger alloc] init];
-    CBLCustomLogSink* sink = [[CBLCustomLogSink alloc] initWithLevel: kCBLLogLevelWarning logSink: logger];
-    CBLLogSinks.custom = sink;
+    TestLogSink* sink = [[TestLogSink alloc] init];
+    CBLLogSinks.custom = [[CBLCustomLogSink alloc] initWithLevel:kCBLLogLevelWarning logSink:sink];
     // end::new-custom-logging[]
 }
 

--- a/modules/swift/examples/code_snippets/SampleCodeTest.swift
+++ b/modules/swift/examples/code_snippets/SampleCodeTest.swift
@@ -101,8 +101,8 @@ class SampleCodeTest {
         let tempFolder = NSTemporaryDirectory().appending("cbllog")
         let config = LogFileConfiguration(directory: tempFolder) // <.>
         config.usePlainText = true // <.>
-        config.maxRotateCount = 2 // <.>
-        config.maxSize = 1024 // <.>
+        config.maxRotateCount = 12 // <.>
+        config.maxSize = 524288 // <.>
         Database.log.file.config = config // <.>
         Database.log.file.level = .verbose // <.>
         // end::file-logging[]
@@ -111,7 +111,7 @@ class SampleCodeTest {
     func dontTestNewFileLogging() throws {
         // tag::new-file-logging[]
         let tempFolder = NSTemporaryDirectory().appending("cbllog")
-        LogSinks.file = FileLogSink(level: .verbose, directory: tempFolder, usePlainText: false, maxKeptFiles: 2, maxFileSize: 1024)
+        LogSinks.file = FileLogSink(level: .verbose, directory: tempFolder, usePlainText: false, maxKeptFiles: 12)
         // end::new-file-logging[]
     }
 

--- a/modules/swift/examples/code_snippets/SampleCodeTest.swift
+++ b/modules/swift/examples/code_snippets/SampleCodeTest.swift
@@ -94,8 +94,7 @@ class SampleCodeTest {
     
     func dontTestNewConsoleLogging() throws {
         // tag::new-console-logging[]
-        let sink = ConsoleLogSink(level: .verbose, domains: .all)
-        LogSinks.console = sink
+        LogSinks.console = ConsoleLogSink(level: .verbose, domains: .all)
         // end::new-console-logging[]
     }
 
@@ -113,8 +112,7 @@ class SampleCodeTest {
     func dontTestNewFileLogging() throws {
         // tag::new-file-logging[]
         let tempFolder = NSTemporaryDirectory().appending("cbllog")
-        let sink = FileLogSink(level: .info, directory: tempFolder)
-        LogSinks.file = sink
+        LogSinks.file = FileLogSink(level: .info, directory: tempFolder)
         // end::new-file-logging[]
     }
 
@@ -127,9 +125,7 @@ class SampleCodeTest {
     
     func dontTestNewCustomLogging() throws {
         // tag::new-custom-logging[]
-        let logger = TestLogger()
-        let sink = CustomLogSink(level: .warning, logSink: logger)
-        LogSinks.custom = sink
+        LogSinks.custom = CustomLogSink(level: .warning, logSink: TestLogSink())
         // end::new-custom-logging[]
     }
 
@@ -2642,7 +2638,7 @@ class LogTestLogger: Logger {
 // end::custom-logging[]
 
 // tag::new-custom-logging[]
-class TestLogger: LogSinkProtocol {
+class TestLogSink: LogSinkProtocol {
     
     func writeLog(level: LogLevel, domain: LogDomain, message: String) {
         // handle the message, for example piping it to

--- a/modules/swift/examples/code_snippets/SampleCodeTest.swift
+++ b/modules/swift/examples/code_snippets/SampleCodeTest.swift
@@ -85,29 +85,18 @@ class SampleCodeTest {
     }
 #endif
 
-    func dontTestLogging() throws {
-        // tag::logging[]
-        // verbose / replicator
-        Database.log.console.level = .verbose
-        Database.log.console.domains = .replicator
-
-        // verbose / query
-        Database.log.console.level = .verbose
-        Database.log.console.domains = .query
-        // end::logging[]
-    }
-
     func dontTestConsoleLogging() throws {
         // tag::console-logging[]
         Database.log.console.domains = .all // <.>
         Database.log.console.level = .verbose // <.>
-
         // end::console-logging[]
-        // tag::console-logging-db[]
-
-        Database.log.console.domains = .database
-
-        // end::console-logging-db[]
+    }
+    
+    func dontTestNewConsoleLogging() throws {
+        // tag::new-console-logging[]
+        let sink = ConsoleLogSink(level: .verbose, domains: .all)
+        LogSinks.console = sink
+        // end::new-console-logging[]
     }
 
     func dontTestFileLogging() throws {
@@ -120,12 +109,28 @@ class SampleCodeTest {
         Database.log.file.level = .info // <.>
         // end::file-logging[]
     }
+    
+    func dontTestNewFileLogging() throws {
+        // tag::new-file-logging[]
+        let tempFolder = NSTemporaryDirectory().appending("cbllog")
+        let sink = FileLogSink(level: .info, directory: tempFolder)
+        LogSinks.file = sink
+        // end::new-file-logging[]
+    }
 
     func dontTestEnableCustomLogging() throws {
-        // tag::set-custom-logging[]
+        // tag::custom-logging[]
         let logger = LogTestLogger(.warning)
         Database.log.custom =  logger // <.>
-        // end::set-custom-logging[]
+        // end::custom-logging[]
+    }
+    
+    func dontTestNewCustomLogging() throws {
+        // tag::new-custom-logging[]
+        let logger = TestLogger()
+        let sink = CustomLogSink(level: .warning, logSink: logger)
+        LogSinks.custom = sink
+        // end::new-custom-logging[]
     }
 
     func dontTestLoadingPrebuilt() throws {
@@ -2616,7 +2621,7 @@ class TestPredictiveModel: PredictiveModel {
     }
 }
 
-// MARK: -- Custom Logger
+// MARK: -- Logging
 
 // tag::custom-logging[]
 class LogTestLogger: Logger {
@@ -2635,6 +2640,16 @@ class LogTestLogger: Logger {
     }
 }
 // end::custom-logging[]
+
+// tag::new-custom-logging[]
+class TestLogger: LogSinkProtocol {
+    
+    func writeLog(level: LogLevel, domain: LogDomain, message: String) {
+        // handle the message, for example piping it to
+        // a third party framework
+    }
+}
+// end::new-custom-logging[]
 
 struct Hotel: Codable {
     var id: String

--- a/modules/swift/examples/code_snippets/SampleCodeTest.swift
+++ b/modules/swift/examples/code_snippets/SampleCodeTest.swift
@@ -83,20 +83,14 @@ class SampleCodeTest {
     }
 #endif
 
-    func dontTestConsoleLogging() throws {
+    // MARK: Logging
+    
+    func dontTestOldLoggingApi() throws {
         // tag::console-logging[]
         Database.log.console.domains = .all // <.>
         Database.log.console.level = .verbose // <.>
         // end::console-logging[]
-    }
-    
-    func dontTestNewConsoleLogging() throws {
-        // tag::new-console-logging[]
-        LogSinks.console = ConsoleLogSink(level: .verbose, domains: .all)
-        // end::new-console-logging[]
-    }
-
-    func dontTestFileLogging() throws {
+        
         // tag::file-logging[]
         let tempFolder = NSTemporaryDirectory().appending("cbllog")
         let config = LogFileConfiguration(directory: tempFolder) // <.>
@@ -106,28 +100,28 @@ class SampleCodeTest {
         Database.log.file.config = config // <.>
         Database.log.file.level = .verbose // <.>
         // end::file-logging[]
-    }
-    
-    func dontTestNewFileLogging() throws {
-        // tag::new-file-logging[]
-        let tempFolder = NSTemporaryDirectory().appending("cbllog")
-        LogSinks.file = FileLogSink(level: .verbose, directory: tempFolder, usePlainText: false, maxKeptFiles: 12)
-        // end::new-file-logging[]
-    }
-
-    func dontTestEnableCustomLogging() throws {
+        
         // tag::custom-logging[]
         let logger = LogTestLogger(.warning)
         Database.log.custom =  logger // <.>
         // end::custom-logging[]
     }
     
-    func dontTestNewCustomLogging() throws {
+    func dontTestNewLoggingApi() throws {
+        // tag::new-console-logging[]
+        LogSinks.console = ConsoleLogSink(level: .verbose, domains: .all)
+        // end::new-console-logging[]
+        
+        // tag::new-file-logging[]
+        let tempFolder = NSTemporaryDirectory().appending("cbllog")
+        LogSinks.file = FileLogSink(level: .verbose, directory: tempFolder, usePlainText: false, maxKeptFiles: 12)
+        // end::new-file-logging[]
+        
         // tag::new-custom-logging[]
         LogSinks.custom = CustomLogSink(level: .warning, logSink: TestLogSink())
         // end::new-custom-logging[]
     }
-
+    
     func dontTestLoadingPrebuilt() throws {
         // tag::prebuilt-database[]
         // Note: Getting the path to a database is platform-specific.

--- a/modules/swift/examples/code_snippets/SampleCodeTest.swift
+++ b/modules/swift/examples/code_snippets/SampleCodeTest.swift
@@ -66,8 +66,6 @@ class SampleCodeTest {
         // end::database-fullsync[]
     }
 
-    
-
     // helper
     func isValidCredentials(_ u: String, password: String) -> Bool { return true }
     func isValidCertificates(_ certs: [SecCertificate]) -> Bool { return true }
@@ -103,16 +101,17 @@ class SampleCodeTest {
         let tempFolder = NSTemporaryDirectory().appending("cbllog")
         let config = LogFileConfiguration(directory: tempFolder) // <.>
         config.usePlainText = true // <.>
+        config.maxRotateCount = 2 // <.>
         config.maxSize = 1024 // <.>
         Database.log.file.config = config // <.>
-        Database.log.file.level = .info // <.>
+        Database.log.file.level = .verbose // <.>
         // end::file-logging[]
     }
     
     func dontTestNewFileLogging() throws {
         // tag::new-file-logging[]
         let tempFolder = NSTemporaryDirectory().appending("cbllog")
-        LogSinks.file = FileLogSink(level: .info, directory: tempFolder)
+        LogSinks.file = FileLogSink(level: .verbose, directory: tempFolder, usePlainText: false, maxKeptFiles: 2, maxFileSize: 1024)
         // end::new-file-logging[]
     }
 


### PR DESCRIPTION
- New snippets for the new Logging API 3.2.2
- Cleaned up a bit the existing tags so there is no duplicate code and to respect the ticket description. We will need to verify where those were used and replace them, if needed.