### PR TITLE
CBL-6822 patch

### DIFF
--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.2.2.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.2.2.adoc
@@ -17,6 +17,8 @@ Version 3.2.2 for {param-title} delivers the following features and enhancements
 
 * https://jira.issues.couchbase.com/browse/CBL-6534[CBL-6534 - No Such Table Error When Upgrading from 3.1.9 to 3.2.1]
 
+* https://jira.issues.couchbase.com/browse/CBL-6822[CBL-6822 - Replicator may hang while stopping the housekeeper task during stop]
+
 // Lite Core end
 
 === Known Issues

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.2.2.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.2.2.adoc
@@ -17,6 +17,8 @@ Version 3.2.2 for {param-title} delivers the following features and enhancements
 
 * https://jira.issues.couchbase.com/browse/CBL-6534[CBL-6534 - No Such Table Error When Upgrading from 3.1.9 to 3.2.1]
 
+* https://jira.issues.couchbase.com/browse/CBL-6822[CBL-6822 - Replicator may hang while stopping the housekeeper task during stop]
+
 // Lite Core end
 
 * https://jira.issues.couchbase.com/browse/CBL-6669[CBL-6669 - CBLArrayIndexConfiguration.path requires null terminated char]

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.2.2.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.2.2.adoc
@@ -19,6 +19,8 @@ Version 3.2.2 for {param-title} delivers the following features and enhancements
 
 * https://jira.issues.couchbase.com/browse/CBL-6534[CBL-6534 - No Such Table Error When Upgrading from 3.1.9 to 3.2.1]
 
+* https://jira.issues.couchbase.com/browse/CBL-6822[CBL-6822 - Replicator may hang while stopping the housekeeper task during stop]
+
 // Lite Core end
 
 * https://jira.issues.couchbase.com/browse/CBL-6540[CBL-6540 - ReplicatorConfiguration's AllowReplicatingInBackground behavior is reversed]

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.2.2.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.2.2.adoc
@@ -17,6 +17,8 @@ Version 3.2.2 for {param-title} delivers the following features and enhancements
 
 * https://jira.issues.couchbase.com/browse/CBL-6534[CBL-6534 - No Such Table Error When Upgrading from 3.1.9 to 3.2.1]
 
+* https://jira.issues.couchbase.com/browse/CBL-6822[CBL-6822 - Replicator may hang while stopping the housekeeper task during stop]
+
 // Lite Core end
 
 === Known Issues

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.2.2.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.2.2.adoc
@@ -17,6 +17,8 @@ Version 3.2.2 for {param-title} delivers the following features and enhancements
 
 * https://jira.issues.couchbase.com/browse/CBL-6534[CBL-6534 - No Such Table Error When Upgrading from 3.1.9 to 3.2.1]
 
+* https://jira.issues.couchbase.com/browse/CBL-6822[CBL-6822 - Replicator may hang while stopping the housekeeper task during stop]
+
 // Lite Core end
 
 === Known Issues

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.2.2.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.2.2.adoc
@@ -17,6 +17,8 @@ Version 3.2.2 for {param-title} delivers the following features and enhancements
 
 * https://jira.issues.couchbase.com/browse/CBL-6534[CBL-6534 - No Such Table Error When Upgrading from 3.1.9 to 3.2.1]
 
+* https://jira.issues.couchbase.com/browse/CBL-6822[CBL-6822 - Replicator may hang while stopping the housekeeper task during stop]
+
 // Lite Core end
 
 === Known Issues


### PR DESCRIPTION
Adds CBL-6822 to the release notes for 3.2

Docs preview: [Couchbase Lite Release Notes](https://preview.docs-test.couchbase.com/docs-couchbase-lite-CBL-6822/couchbase-lite/current/cbl-whatsnew.html#couchbase-lite-release-notes)
Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)
