### PR TITLE
DOC-12386: Replace {tkn-db}

### DIFF
--- a/modules/ROOT/pages/_partials/authentication.adoc
+++ b/modules/ROOT/pages/_partials/authentication.adoc
@@ -16,7 +16,7 @@ You can enable authentication with the following properties in the configuration
 ----
 
 To authenticate with Sync Gateway, an associated user must first be created.
-Sync Gateway users can be created through the xref:sync-gateway:ROOT:refer/rest-api-admin.adoc#/user/post\__db___user_[`+POST /{tkn-db}/_user+`] endpoint on the Admin REST API.
+Sync Gateway users can be created through the xref:sync-gateway:ROOT:refer/rest-api-admin.adoc#/user/post\__db___user_[`+POST /{db}/_user+`] endpoint on the Admin REST API.
 Provided that the user exists on Sync Gateway, there are two ways to authenticate from a Couchbase Lite client: Basic Authentication or Session Authentication.
 
 ==== Basic Authentication
@@ -34,9 +34,9 @@ include::{snippet}[tag=basic-authentication,indent=0]
 ==== Session Authentication
 
 Session authentication is another way to authenticate with Sync Gateway.
-A user session must first be created through the xref:sync-gateway:ROOT:refer/rest-api-public.adoc#/session/post\__db___session[`+POST /{tkn-db}/_session+`] endpoint on the Public REST API.
+A user session must first be created through the xref:sync-gateway:ROOT:refer/rest-api-public.adoc#/session/post\__db___session[`+POST /{db}/_session+`] endpoint on the Public REST API.
 The HTTP response contains a session ID which can then be used to authenticate as the user it was created for.
-The following example initiates a one-shot replication with the session ID that is returned from the `+POST /{tkn-db}/_session+` endpoint.
+The following example initiates a one-shot replication with the session ID that is returned from the `+POST /{db}/_session+` endpoint.
 
 [source]
 ----

--- a/modules/ROOT/pages/_partials/verify-replication.adoc
+++ b/modules/ROOT/pages/_partials/verify-replication.adoc
@@ -1,6 +1,6 @@
 To verify that documents have been replicated, you can:
 
-* Monitor the Sync Gateway sequence number returned by the database endpoint (xref:sync-gateway:ROOT:refer/rest-api-public.adoc#/database/get\__db__[`+GET /{tkn-db}/+`]).
+* Monitor the Sync Gateway sequence number returned by the database endpoint (xref:sync-gateway:ROOT:refer/rest-api-public.adoc#/database/get\__db__[`+GET /{db}/+`]).
 The sequence number increments for every change that happens on the Sync Gateway database.
-* Query a document by ID on the Sync Gateway REST API (xref:sync-gateway:ROOT:refer/rest-api-public.adoc#/document/get\__db___doc_[`+GET /{tkn-db}/{id}+`]).
+* Query a document by ID on the Sync Gateway REST API (xref:sync-gateway:ROOT:refer/rest-api-public.adoc#/document/get\__db___doc_[`+GET /{db}/{id}+`]).
 * Query a document from the Query Workbench on the Couchbase Server Console.


### PR DESCRIPTION
Docs issue: [DOC-12386](https://jira.issues.couchbase.com/browse/DOC-12386)

Starting with release/2.8, which is the earliest supported version. Will merge this forward to all following versions, with modifications as required per version.

(EDIT: apparently 2.8 is at end-of-support, but having got this far I don't think it's worth abandoning this PR and starting again.)

The issue of "linking to the correct version of Sync Gateway" is outside the scope of this PR.

Related PR for Sync Gateway:

* https://github.com/couchbase/docs-sync-gateway/pull/854

[DOC-12386]: https://couchbasecloud.atlassian.net/browse/DOC-12386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ