### PR TITLE
DOC-13296 fixup gs downloads

### DIFF
--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -1662,9 +1662,9 @@ Enterprise::
 
 .4+| Linux
 
-| https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-aarch64.zip[couchbase-lite-vector-search-1.0.0-linux-aarch64.zip]
-| https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-aarch64.zip.sha256[couchbase-lite-vector-search-1.0.0-linux-aarch64.zip.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-aarch64-symbols.zip[couchbase-lite-vector-search-1.0.0-linux-aarch64-symbols.zip]
+| https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-arm64.zip.sha256[couchbase-lite-vector-search-1.0.0-linux-arm64.zip.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-arm64.zip[couchbase-lite-vector-search-1.0.0-linux-arm64.zip]
+| https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-arm64-symbols.zip[couchbase-lite-vector-search-1.0.0-linux-arm64-symbols.zip]
 
 | https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-x86_64.zip[couchbase-lite-vector-search-1.0.0-linux-x86_64.zip]
 | https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-x86_64.zip.sha256[couchbase-lite-vector-search-1.0.0-linux-x86_64.zip.sha256]

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -218,7 +218,7 @@ Enterprise Edition::
 |
 
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.2/libcblite-dev-enterprise_3.2.2-debian10_arm64.deb[libcblite-dev-enterprise_3.2.2-debian10_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.2/libcblite-dev-enterprise_3.2.2-debian10_arm64.deb.sha25[libcblite-dev-enterprise_3.2.2-debian10_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.2/libcblite-dev-enterprise_3.2.2-debian10_arm64.deb.sha256[libcblite-dev-enterprise_3.2.2-debian10_arm64.deb.sha256]
 |
 
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.2/libcblite-enterprise_3.2.2-debian10_armhf.deb[libcblite-enterprise_3.2.2-debian10_armhf.deb]
@@ -709,7 +709,7 @@ Enterprise Edition::
 |
 
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.1/libcblite-dev-enterprise_3.2.1-debian10_arm64.deb[libcblite-dev-enterprise_3.2.1-debian10_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.1/libcblite-dev-enterprise_3.2.1-debian10_arm64.deb.sha25[libcblite-dev-enterprise_3.2.1-debian10_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.1/libcblite-dev-enterprise_3.2.1-debian10_arm64.deb.sha256[libcblite-dev-enterprise_3.2.1-debian10_arm64.deb.sha256]
 |
 
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.1/libcblite-enterprise_3.2.1-debian10_armhf.deb[libcblite-enterprise_3.2.1-debian10_armhf.deb]
@@ -1200,7 +1200,7 @@ Enterprise Edition::
 |
 
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.0/libcblite-dev-enterprise_3.2.0-debian10_arm64.deb[libcblite-dev-enterprise_3.2.0-debian10_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.0/libcblite-dev-enterprise_3.2.0-debian10_arm64.deb.sha25[libcblite-dev-enterprise_3.2.0-debian10_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.0/libcblite-dev-enterprise_3.2.0-debian10_arm64.deb.sha256[libcblite-dev-enterprise_3.2.0-debian10_arm64.deb.sha256]
 |
 
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.0/libcblite-enterprise_3.2.0-debian10_armhf.deb[libcblite-enterprise_3.2.0-debian10_armhf.deb]
@@ -1665,6 +1665,7 @@ Enterprise::
 | https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-aarch64.zip[couchbase-lite-vector-search-1.0.0-linux-aarch64.zip]
 | https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-aarch64.zip.sha256[couchbase-lite-vector-search-1.0.0-linux-aarch64.zip.sha256]
 | https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-aarch64-symbols.zip[couchbase-lite-vector-search-1.0.0-linux-aarch64-symbols.zip]
+
 | https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-x86_64.zip[couchbase-lite-vector-search-1.0.0-linux-x86_64.zip]
 | https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-x86_64.zip.sha256[couchbase-lite-vector-search-1.0.0-linux-x86_64.zip.sha256]
 | https://packages.couchbase.com/releases/couchbase-lite-vector-search/1.0.0/couchbase-lite-vector-search-1.0.0-linux-x86_64-symbols.zip[couchbase-lite-vector-search-1.0.0-linux-x86_64-symbols.zip]

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -1582,7 +1582,7 @@ Enterprise::
 Enterprise Edition::
 +
 --
-[#tbl-downloads-ee,cols="1,4,4", options="header"]
+[#tbl-downloads-ee,cols="1,4,4,4", options="header"]
 |===
 | Platform | Download | SHA | Debug Symbols
 


### PR DESCRIPTION
~Draft as missing info on 3 broken links (asked in #mobile-docs-related) though this fix could be merged in separately if needed.~

Preview building to https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13296-fixup-gs-downloads/couchbase-lite/current/c/gs-downloads.html

@RichardSmedley will need porting to 3.3 also.