### PR TITLE
DOC-13319 updated download link

### DIFF
--- a/modules/c/pages/gs-install.adoc
+++ b/modules/c/pages/gs-install.adoc
@@ -101,7 +101,7 @@ xref:c:gs-install.adoc#lbl-android[Install for Android]
 [#lbl-apt]
 === Using APT
 
-:url-apt-pkg-file: couchbase-1.0-noarch.deb
+:url-apt-pkg-file: couchbase-release-1.0-noarch.deb
 :url-apt-pkg:  pass:q,a[https://packages.couchbase.com/releases/couchbase-release/{url-apt-pkg-file}]
 
 Using the Advanced Package Tool (apt) is the easiest way to install pass:q,a[Couchbase{nbsp}Lite] on Ubuntu and Debian platforms.


### PR DESCRIPTION
Docs Issue: DOC-13319

PR to update the download link for couchbase lite in C linux 

Docs preview: [preview](https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13319-fix-download-link/)
Credentials: [Preview docs for internal review](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords#Preview-docs-for-internal-review)