### PR TITLE
DOC-11630 updated the maintainance version for cbl c and fix link

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -22,7 +22,7 @@ asciidoc:
     minor: 2
     maintenance-ios: 3
     maintenance-swift: 3
-    maintenance-c: 3
+    maintenance-c: 4
     maintenance-android: 3
     maintenance-java: 3
     maintenance-net: 3

--- a/modules/c/pages/document.adoc
+++ b/modules/c/pages/document.adoc
@@ -287,7 +287,7 @@ include::c:example$code_snippets/main.cpp[tags="datatype_mutable_dictionary", in
 === Using Arrays
 
 .API References
-* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-c}{empty}/couchbase-lite-c/C/html/group__f_l_array.html[Fleece Arrays]
+* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-c}{empty}/couchbase-lite-c/C/html/group___f_l_array.html[Fleece Arrays]
 
 * 
 

--- a/modules/c/pages/document.adoc
+++ b/modules/c/pages/document.adoc
@@ -289,8 +289,6 @@ include::c:example$code_snippets/main.cpp[tags="datatype_mutable_dictionary", in
 .API References
 * https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-c}{empty}/couchbase-lite-c/C/html/group___f_l_array.html[Fleece Arrays]
 
-* 
-
 .Read Only
 [#ex-array]
 


### PR DESCRIPTION
Doc issue: DOC-11630

PR to upgrade maintenance version for CBL C and fix fleece array link 

Docs preview: [Fix the fleece array link](https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-11630-fix-fleece-array-link/)
Preview credentials: [Preview docs for internal review](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords#Preview-docs-for-internal-review)