### PR TITLE
DOC-12400 updated the ios file logging annotation, fix upgrade version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -20,7 +20,7 @@ asciidoc:
     # releasetag: 
     major: 3
     minor: 2
-    maintenance-ios: 3
+    maintenance-ios: 4
     maintenance-swift: 3
     maintenance-c: 4
     maintenance-android: 3

--- a/modules/swift/examples/code_snippets/SampleCodeTest.swift
+++ b/modules/swift/examples/code_snippets/SampleCodeTest.swift
@@ -94,7 +94,7 @@ class SampleCodeTest {
         // tag::file-logging[]
         let tempFolder = NSTemporaryDirectory().appending("cbllog")
         let config = LogFileConfiguration(directory: tempFolder) // <.>
-        config.usePlainText = true // <.>
+        config.usePlainText = false // <.>
         config.maxRotateCount = 12 // <.>
         config.maxSize = 524288 // <.>
         Database.log.file.config = config // <.>

--- a/modules/swift/pages/troubleshooting-logs.adoc
+++ b/modules/swift/pages/troubleshooting-logs.adoc
@@ -139,13 +139,15 @@ include::swift:example$code_snippets/SampleCodeTest.swift[tags="file-logging", i
 
 <.> Set the log file directory.
 <.> Set the logging format to binary by disabling text logging. 
-*Note* this is the default, and you only need to include this for reference.
+This is the default, and you only need to include this for reference.
 <.> Change the max rotation count from the default (1) to 12.
-*Note* this means thirteen files may exist at any one time; the twelve rotated log files, plus the active log file
++
+NOTE: Thirteen files may exist at any one time; the twelve rotated log files, plus the active log file.
 <.> Set the maximum size (bytes) for your log file.
 <.> Set the global https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{empty}/couchbase-lite-swift/Classes/LogFileConfiguration.html[LogFileConfiguration] to use the config you just created, which will cause file logging to be enabled.
 <.> Increase the log output level from the default (_warnings_) to _verbose_ -- see: https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{empty}/couchbase-lite-swift/Classes/FileLogger.html#/s:18CouchbaseLiteSwift10FileLoggerC5levelAA8LogLevelOvp[log.file.level: LogLevel].
-*Note* that you can no longer use https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{empty}/couchbase-lite-swift/Classes/Database.html#/s:18CouchbaseLiteSwift8DatabaseC11setLogLevel_6domainyAA0fG0O_AA0F6DomainOtFZ[Database.setLogLevel()] as it is now deprecated.
++
+NOTE: You can no longer use https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{empty}/couchbase-lite-swift/Classes/Database.html#/s:18CouchbaseLiteSwift8DatabaseC11setLogLevel_6domainyAA0fG0O_AA0F6DomainOtFZ[Database.setLogLevel()] as it is now deprecated.
 Further, you can no longer set a log level for a specific domain.
 
 Related::

--- a/modules/swift/pages/troubleshooting-logs.adoc
+++ b/modules/swift/pages/troubleshooting-logs.adoc
@@ -137,14 +137,15 @@ include::swift:example$code_snippets/SampleCodeTest.swift[tags="file-logging", i
 
 ====
 
-<.> Set the log file directory
-<.> Here we change the max rotation count from the default (1) to 5. +
-*Note* this means six files may exist at any one time; the five rotated log files, plus the active log file
-<.> Here we set the maximum size (bytes) for our log file
-<.> Here we select the binary log format (included for reference only as this is the default)
-<.> Here we increase the log output level from the default (_warnings_) to _info_ -- see: https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{empty}/couchbase-lite-swift/Classes/FileLogger.html#/s:18CouchbaseLiteSwift10FileLoggerC5levelAA8LogLevelOvp[log.file.level: LogLevel]
-+
-*Note* that the use of https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{empty}/couchbase-lite-swift/Classes/Database.html#/s:18CouchbaseLiteSwift8DatabaseC11setLogLevel_6domainyAA0fG0O_AA0F6DomainOtFZ[Database.setLogLevel()] is now deprecated.
+<.> Set the log file directory.
+<.> Set the logging format to binary by disabling text logging. 
+*Note* this is the default, and you only need to include this for reference.
+<.> Change the max rotation count from the default (1) to 12.
+*Note* this means thirteen files may exist at any one time; the twelve rotated log files, plus the active log file
+<.> Set the maximum size (bytes) for your log file.
+<.> Set the global https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{empty}/couchbase-lite-swift/Classes/LogFileConfiguration.html[LogFileConfiguration] to use the config you just created, which will cause file logging to be enabled.
+<.> Increase the log output level from the default (_warnings_) to _verbose_ -- see: https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{empty}/couchbase-lite-swift/Classes/FileLogger.html#/s:18CouchbaseLiteSwift10FileLoggerC5levelAA8LogLevelOvp[log.file.level: LogLevel].
+*Note* that you can no longer use https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{empty}/couchbase-lite-swift/Classes/Database.html#/s:18CouchbaseLiteSwift8DatabaseC11setLogLevel_6domainyAA0fG0O_AA0F6DomainOtFZ[Database.setLogLevel()] as it is now deprecated.
 Further, you can no longer set a log level for a specific domain.
 
 Related::


### PR DESCRIPTION
Docs Issue: DOC-12400

PR to update the ios file logging annotations and upgrade ios maintenance version

Docs [preview](https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-12400-update-ios-file-logging-annotations)
Credentials: [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords)