### PR TITLE
Fix typo or copy/paste error in Prebuilt Database pages

### DIFF
--- a/modules/android/pages/prebuilt-database.adoc
+++ b/modules/android/pages/prebuilt-database.adoc
@@ -22,7 +22,7 @@ _Abstract -- This content explains how to include a snapshot of a pre-built data
 == Overview
 
 
-_Couchbase{nbsp}Lite_ supports  pre-built databases. You can pre-load your app with data instead of syncing it from pass:q,a[_pass:q,a[Sync{nbsp}Gateway]_] during startup to minimize consumer wait time (arising from data setup) on initial install and launch of the application.
+_Couchbase{nbsp}Lite_ supports  pre-built databases. You can pre-load your app with data instead of syncing it from _Sync{nbsp}Gateway_ during startup to minimize consumer wait time (arising from data setup) on initial install and launch of the application.
 
 Avoiding an initial bulk sync reduces startup time and network transfer costs.
 

--- a/modules/csharp/pages/prebuilt-database.adoc
+++ b/modules/csharp/pages/prebuilt-database.adoc
@@ -19,7 +19,7 @@ _Abstract -- This content explains how to include a snapshot of a pre-built data
 == Overview
 
 
-_Couchbase{nbsp}Lite_ supports  pre-built databases. You can pre-load your app with data instead of syncing it from pass:q,a[_pass:q,a[Sync{nbsp}Gateway]_] during startup to minimize consumer wait time (arising from data setup) on initial install and launch of the application.
+_Couchbase{nbsp}Lite_ supports  pre-built databases. You can pre-load your app with data instead of syncing it from _Sync{nbsp}Gateway_ during startup to minimize consumer wait time (arising from data setup) on initial install and launch of the application.
 
 Avoiding an initial bulk sync reduces startup time and network transfer costs.
 

--- a/modules/java/pages/prebuilt-database.adoc
+++ b/modules/java/pages/prebuilt-database.adoc
@@ -19,7 +19,7 @@ _Abstract -- This content explains how to include a snapshot of a pre-built data
 == Overview
 
 
-_Couchbase{nbsp}Lite_ supports  pre-built databases. You can pre-load your app with data instead of syncing it from pass:q,a[_pass:q,a[Sync{nbsp}Gateway]_] during startup to minimize consumer wait time (arising from data setup) on initial install and launch of the application.
+_Couchbase{nbsp}Lite_ supports  pre-built databases. You can pre-load your app with data instead of syncing it from _Sync{nbsp}Gateway_ during startup to minimize consumer wait time (arising from data setup) on initial install and launch of the application.
 
 Avoiding an initial bulk sync reduces startup time and network transfer costs.
 

--- a/modules/objc/pages/prebuilt-database.adoc
+++ b/modules/objc/pages/prebuilt-database.adoc
@@ -21,7 +21,7 @@ _Abstract -- This content explains how to include a snapshot of a pre-built data
 == Overview
 
 
-_Couchbase{nbsp}Lite_ supports  pre-built databases. You can pre-load your app with data instead of syncing it from pass:q,a[_pass:q,a[Sync{nbsp}Gateway]_] during startup to minimize consumer wait time (arising from data setup) on initial install and launch of the application.
+_Couchbase{nbsp}Lite_ supports  pre-built databases. You can pre-load your app with data instead of syncing it from _Sync{nbsp}Gateway_ during startup to minimize consumer wait time (arising from data setup) on initial install and launch of the application.
 
 Avoiding an initial bulk sync reduces startup time and network transfer costs.
 

--- a/modules/swift/pages/prebuilt-database.adoc
+++ b/modules/swift/pages/prebuilt-database.adoc
@@ -21,7 +21,7 @@ _Abstract -- This content explains how to include a snapshot of a pre-built data
 == Overview
 
 
-_Couchbase{nbsp}Lite_ supports  pre-built databases. You can pre-load your app with data instead of syncing it from pass:q,a[_pass:q,a[Sync{nbsp}Gateway]_] during startup to minimize consumer wait time (arising from data setup) on initial install and launch of the application.
+_Couchbase{nbsp}Lite_ supports  pre-built databases. You can pre-load your app with data instead of syncing it from _Sync{nbsp}Gateway_ during startup to minimize consumer wait time (arising from data setup) on initial install and launch of the application.
 
 Avoiding an initial bulk sync reduces startup time and network transfer costs.
 


### PR DESCRIPTION
Introduced in #962 in 3.2 docs (also affects 3.3) 

Example:
https://docs.couchbase.com/couchbase-lite/current/csharp/prebuilt-database.html#overview 