### PR TITLE
Update iOS's authenticatorWithRootCerts() and peerIdentity() code snippet

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
                 stage("Validate iOS") {
                     agent { label 'mobile-builder-ios-pull-request' }
                     steps {
-                        sh 'jenkins/ios.sh 3.2.4 1.0.0'
+                        sh 'jenkins/ios.sh 3.3.0 1.0.0'
                     }
                 }
             }

--- a/modules/objc/examples/code_snippets/MultipeerReplicator.m
+++ b/modules/objc/examples/code_snippets/MultipeerReplicator.m
@@ -76,26 +76,24 @@
     
     // If the identity doesn't exist or expired, create a new one.
     if (!identity || [identity.expiration compare:[NSDate date]] == NSOrderedAscending) {
-        // Create an issuer identity from the private key and certificate data in DER format.
-        NSData *privateKey = [self getIssuerPrivateKeyData];
-        NSData *cert = [self getIssuerCertificateData];
-        CBLTLSIdentity *issuer = [CBLTLSIdentity createIdentityWithPrivateKey:privateKey
-                                                                  certificate:cert
-                                                                        error:&error];
+        // Get the issuer's private key and certificate data (DER format) for signing the identity's certificate.
+        NSData *caKey = [self getIssuerPrivateKeyData];
+        NSData *caCert = [self getIssuerCertificateData];
         
         // Create a new identity signed with the issuer.
         NSDictionary *attrs = @{ kCBLCertAttrCommonName: @"MyApp" };
         NSDate *expiration = [[NSCalendar currentCalendar] dateByAddingUnit:NSCalendarUnitYear
-                                                                     value:2
-                                                                    toDate:[NSDate date]
-                                                                   options:0];
+                                                                      value:2
+                                                                     toDate:[NSDate date]
+                                                                    options:0];
         
-        identity = [CBLTLSIdentity createIdentityForKeyUsages:kCBLKeyUsagesClientAuth|kCBLKeyUsagesServerAuth
-                                                   attributes:attrs
-                                                   expiration:expiration
-                                                       issuer:issuer
-                                                        label:persistentLabel
-                                                        error:&error];
+        identity = [CBLTLSIdentity createSignedIdentityInsecureForKeyUsages:kCBLKeyUsagesClientAuth|kCBLKeyUsagesServerAuth
+                                                                 attributes:attrs
+                                                                 expiration:expiration
+                                                                      caKey:caKey
+                                                              caCertificate:caCert
+                                                                      label:persistentLabel
+                                                                      error:&error];
     }
     // end::multipeer-tlsidentity
     return identity;
@@ -120,15 +118,12 @@
 }
 
 - (id<CBLMultipeerAuthenticator>)authenticatorWithRootCerts {
-    NSData *privateKey = [self getIssuerPrivateKeyData];
-    NSData *cert = [self getIssuerCertificateData];
-    NSError *error = nil;
-    CBLTLSIdentity *issuer = [CBLTLSIdentity createIdentityWithPrivateKey:privateKey
-                                                              certificate:cert
-                                                                    error:&error];
     // tag::multipeer-authenticator-rootcerts
+    // Get issuer's certificate data (DER format), which was used to sign the peer's certificate.
+    NSData *caCert = [self getIssuerCertificateData];
+    SecCertificateRef caCertRef = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)caCert);
     id<CBLMultipeerAuthenticator> authenticator =
-    [[CBLMultipeerCertificateAuthenticator alloc] initWithRootCerts:issuer.certs];
+    [[CBLMultipeerCertificateAuthenticator alloc] initWithRootCerts:@[(__bridge_transfer id)caCertRef]];
     // end::multipeer-authenticator-rootcerts
     return authenticator;
 }
@@ -172,7 +167,6 @@
 }
 
 - (void)statusListener {
-    NSError *error = nil;
     CBLMultipeerReplicator *replicator = [self createMultipeerReplicator];
     // tag::multipeer-status-listener
     [replicator addStatusListenerWithQueue:nil listener:^(CBLMultipeerReplicatorStatus *status) {

--- a/modules/swift/examples/code_snippets/MultipeerReplicator.swift
+++ b/modules/swift/examples/code_snippets/MultipeerReplicator.swift
@@ -65,23 +65,21 @@ class MultipeerReplicatorSnippets {
 
         // If the identity doesn't exist or expired, create a new one.
         if identity == nil {
-            // Create an issuer identity from the private key and certificate data.
-            let privateKey = try getIssuerPrivateKeyData()
-            let cert = try getIssuerCertificateData()
-            let issuer = try TLSIdentity.createIdentity(
-                withPrivateKey: privateKey,
-                certificate: cert)
-
             // Define certificate attributes and expiration date.
             let attrs: [String: String] = [certAttrCommonName: "MyApp"]
             let expiration = Calendar.current.date(byAdding: .year, value: 2, to: Date())!
 
+            // Get issuer's private key and certificate data (DER format) for signing the identity's certificate.
+            let caKey = try getIssuerPrivateKeyData()
+            let caCert = try getIssuerCertificateData()
+            
             // Create a new identity signed with the issuer and save it with the persistent label.
-            identity = try TLSIdentity.createIdentity(
+            identity = try TLSIdentity.createSignedIdentityInsecure(
                 for: [.clientAuth, .serverAuth],
                 attributes: attrs,
                 expiration: expiration,
-                issuer: issuer,
+                caKey: caKey,
+                caCertificate: caCert,
                 label: persistentLabel)
         }
         // end::multipeer-tlsidentity[]
@@ -106,12 +104,11 @@ class MultipeerReplicatorSnippets {
     }
 
     func authenticatorWithRootCerts() throws -> MultipeerAuthenticator {
-        let privateKey = try getIssuerPrivateKeyData()
-        let cert = try getIssuerCertificateData()
-        let issuer = try TLSIdentity.createIdentity(withPrivateKey: privateKey, certificate: cert)
-
         // tag::multipeer-authenticator-rootcerts[]
-        let authenticator = MultipeerCertificateAuthenticator(rootCerts: issuer.certs)
+        // Get issuer's certificate data (DER format), which was used to sign the peer's certificate.
+        let caCert = try getIssuerCertificateData()
+        let caCertRef = SecCertificateCreateWithData(nil, caCert as CFData)!
+        let authenticator = MultipeerCertificateAuthenticator(rootCerts: [caCertRef])
         // end::multipeer-authenticator-rootcerts[]
         return authenticator
     }


### PR DESCRIPTION
* Updated authenticatorWithRootCerts() and peerIdentity() code snippet according to the API changes.

* Fixed iOS version in Jenkinsfile.