### PR TITLE
Add code snippet for creating a self-signed identity

### DIFF
--- a/modules/objc/examples/code_snippets/MultipeerReplicator.m
+++ b/modules/objc/examples/code_snippets/MultipeerReplicator.m
@@ -65,7 +65,36 @@
     return collections;
 }
 
-- (CBLTLSIdentity *)peerIdentity {
+- (CBLTLSIdentity *)createSelfSignedIdentity {
+    // tag::multipeer-selfsigned-tlsidentity
+    // Note: This example is simplified for demonstration and does not include error handling.
+    NSString *persistentLabel = @"com.myapp.identity";
+    
+    // Retrieve the TLS identity from the keychain using the persistent label.
+    NSError *error = nil;
+    CBLTLSIdentity *identity = [CBLTLSIdentity identityWithLabel:persistentLabel error:&error];
+    
+    // If the identity doesn't exist or expired, create a new one.
+    if (!identity || [identity.expiration compare:[NSDate date]] == NSOrderedAscending) {
+        // Define certificate attributes and expiration date.
+        NSDictionary *attrs = @{ kCBLCertAttrCommonName: @"MyApp" };
+        NSDate *expiration = [[NSCalendar currentCalendar] dateByAddingUnit:NSCalendarUnitYear
+                                                                      value:2
+                                                                     toDate:[NSDate date]
+                                                                    options:0];
+        
+        // Create and store a new self-signed identity in the keychain with a persistent label.
+        identity = [CBLTLSIdentity createIdentityForKeyUsages:kCBLKeyUsagesClientAuth|kCBLKeyUsagesServerAuth
+                                                   attributes:attrs
+                                                   expiration:expiration
+                                                        label:persistentLabel
+                                                        error:&error];
+    }
+    // end::multipeer-selfsigned-tlsidentity
+    return identity;
+}
+
+- (CBLTLSIdentity *)createCASignedIdentity {
     // tag::multipeer-tlsidentity
     // Note: This example is simplified for demonstration and does not include error handling.
     NSString *persistentLabel = @"com.myapp.identity";
@@ -80,13 +109,14 @@
         NSData *caKey = [self getIssuerPrivateKeyData];
         NSData *caCert = [self getIssuerCertificateData];
         
-        // Create a new identity signed with the issuer.
+        // Define certificate attributes and expiration date.
         NSDictionary *attrs = @{ kCBLCertAttrCommonName: @"MyApp" };
         NSDate *expiration = [[NSCalendar currentCalendar] dateByAddingUnit:NSCalendarUnitYear
                                                                       value:2
                                                                      toDate:[NSDate date]
                                                                     options:0];
         
+        // Create and store a new identity signed with the issuer in the keychain with a persistent label.
         identity = [CBLTLSIdentity createSignedIdentityInsecureForKeyUsages:kCBLKeyUsagesClientAuth|kCBLKeyUsagesServerAuth
                                                                  attributes:attrs
                                                                  expiration:expiration
@@ -129,7 +159,7 @@
 }
 
 - (CBLMultipeerReplicatorConfiguration *)createConfig {
-    CBLTLSIdentity *identity = [self peerIdentity];
+    CBLTLSIdentity *identity = [self createCASignedIdentity];
     id<CBLMultipeerAuthenticator> authenticator = [self authenticatorWithRootCerts];
     NSArray<CBLMultipeerCollectionConfiguration *> *collections = [self collectionConfig];
     
@@ -229,9 +259,8 @@
 - (void)neighborPeers {
     CBLMultipeerReplicator *replicator = [self createMultipeerReplicator];
     // tag::multipeer-neighbor-peers
-    NSArray<CBLPeerID *> *neighborPeers = replicator.neighborPeers;
     NSLog(@"Neighbor Peers:");
-    for (CBLPeerID *peerID in neighborPeers) {
+    for (CBLPeerID *peerID in replicator.neighborPeers) {
         NSLog(@" %@", peerID);
     }
     // end::multipeer-neighbor-peers
@@ -245,9 +274,8 @@
     void (^printPeerInfo)(CBLPeerInfo *) = ^(CBLPeerInfo *info) {
         NSLog(@"Peer ID: %@", info.peerID);
         NSLog(@" Status: %@", info.online ? @"online" : @"offline");
-        NSArray<CBLPeerID *> *neighborPeers = replicator.neighborPeers;
         NSLog(@" Neighbor Peers:");
-        for (CBLPeerID *peerID in neighborPeers) {
+        for (CBLPeerID *peerID in info.neighborPeers) {
             NSLog(@"  %@", peerID);
         }
         

--- a/modules/swift/examples/code_snippets/MultipeerReplicator.swift
+++ b/modules/swift/examples/code_snippets/MultipeerReplicator.swift
@@ -50,7 +50,37 @@ class MultipeerReplicatorSnippets {
         return collections
     }
 
-    func peerIdentity() throws -> TLSIdentity {
+    func createselfSignedIdentity() throws -> TLSIdentity {
+        // tag::multipeer-selfsigned-tlsidentity[]
+        let persistentLabel = "com.myapp.identity"
+
+        // Retrieve the TLS identity from the keychain using the persistent label.
+        var identity = try TLSIdentity.identity(withLabel: persistentLabel)
+
+        // If the identity exists but is expired, delete it.
+        if let existing = identity, existing.expiration < Date() {
+            try TLSIdentity.deleteIdentity(withLabel: persistentLabel)
+            identity = nil
+        }
+
+        // If the identity doesn't exist or expired, create a new one.
+        if identity == nil {
+            // Define certificate attributes and expiration date.
+            let attrs: [String: String] = [certAttrCommonName: "MyApp"]
+            let expiration = Calendar.current.date(byAdding: .year, value: 2, to: Date())!
+            
+            // Create and store a new self-signed identity in the keychain with a persistent label.
+            identity = try TLSIdentity.createIdentity(
+                for: [.clientAuth, .serverAuth],
+                attributes: attrs,
+                expiration: expiration,
+                label: persistentLabel)
+        }
+        // end::multipeer-selfsigned-tlsidentity[]
+        return identity!
+    }
+    
+    func createCASignedIdentity() throws -> TLSIdentity {
         // tag::multipeer-tlsidentity[]
         let persistentLabel = "com.myapp.identity"
 
@@ -73,7 +103,7 @@ class MultipeerReplicatorSnippets {
             let caKey = try getIssuerPrivateKeyData()
             let caCert = try getIssuerCertificateData()
             
-            // Create a new identity signed with the issuer and save it with the persistent label.
+            // Create and store a new identity signed with the issuer in the keychain with a persistent label.
             identity = try TLSIdentity.createSignedIdentityInsecure(
                 for: [.clientAuth, .serverAuth],
                 attributes: attrs,
@@ -114,7 +144,7 @@ class MultipeerReplicatorSnippets {
     }
 
     func createConfig() throws -> MultipeerReplicatorConfiguration {
-        let identity = try peerIdentity()
+        let identity = try createCASignedIdentity()
         let authenticator = try authenticatorWithRootCerts()
         let collections = try collectionConfig()
 
@@ -216,9 +246,8 @@ class MultipeerReplicatorSnippets {
     func neighborPeers() throws {
         let replicator = try createMultipeerReplicator()
         // tag::multipeer-neighbor-peers[]
-        let neighborPeers = replicator.neighborPeers
         print("Neighbor Peers:")
-        neighborPeers.forEach { peerID in
+        replicator.neighborPeers.forEach { peerID in
             print(" \(peerID)")
         }
         // end::multipeer-neighbor-peers[]
@@ -232,9 +261,8 @@ class MultipeerReplicatorSnippets {
         let printPeerInfo: (PeerInfo) -> Void = { info in
             print("Peer ID: \(info.peerID)")
             print(" Status: \(info.online ? "online" : "offline")")
-            let neighborPeers = replicator.neighborPeers
             print(" Neighbor Peers:")
-            neighborPeers.forEach { peerID in
+            info.neighborPeers.forEach { peerID in
                 print("  \(peerID)")
             }
 


### PR DESCRIPTION
* Added code snippet for creating a self-signed identity (tag: multipeer-selfsigned-tlsidentity)
* Fixed a mistake in multipeer-peer-info snippet.
* Updated code format in multipeer-neighbor-peers snippet.