### PR TITLE
[DOC-9807]: Example for "IN" query

### DIFF
--- a/modules/swift/examples/code_snippets/SampleCodeTest.swift
+++ b/modules/swift/examples/code_snippets/SampleCodeTest.swift
@@ -421,7 +421,7 @@ class SampleCodeTest {
 
     func dontTestCollectionOperatorIn() throws {
         // tag::query-collection-operator-in[]
-        let values = [
+        let properties = [
             Expression.property("first"),
             Expression.property("last"),
             Expression.property("username")
@@ -429,7 +429,7 @@ class SampleCodeTest {
 
         let query = QueryBuilder.select(SelectResult.all())
             .from(DataSource.collection(collection))
-            .where(Expression.string("Armani").in(values))
+            .where(Expression.string("Armani").in(properties))
         // end::query-collection-operator-in[]
 
         print(query)


### PR DESCRIPTION
Changed `values` to `properties` in the example code. 
Hopefully should make the code a bit clearer.

----

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-9807-Example-for-IN-query

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.