### PR TITLE
[DOC-13523]: Feedback on Download Links | Couchbase Docs

### DIFF
--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -176,7 +176,8 @@ Enterprise Edition::
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-armhf-symbols.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-armhf-symbols.tar.gz]
 
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz.sha256[couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz.sha256[couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64-symbols.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-x86_64-symbols.tar.gz]
 
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian11_amd64.deb[libcblite-enterprise_3.2.4-debian11_amd64.deb]
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian11_amd64.deb.sha256[libcblite-enterprise_3.2.4-debian11_amd64.deb.sha256]
@@ -377,7 +378,8 @@ Enterprise Edition::
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-armhf-symbols.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-armhf-symbols.tar.gz]
 
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz.sha256[couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz.sha256[couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64-symbols.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-x86_64-symbols.tar.gz]
 
 
 // Ubuntu 22.04
@@ -454,7 +456,8 @@ Community Edition::
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-armhf-symbols.tar.gz[couchbase-lite-c-community-3.2.4-linux-armhf-symbols.tar.gz]
 
 | https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz[couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz.sha256[couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz.
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz.sha256[couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-x86_64-symbols.tar.gz[couchbase-lite-c-community-3.2.4-linux-x86_64-symbols.tar.gz]
 
 
 // Ubuntu 22.04


### PR DESCRIPTION
Corrected and updated URL links in the documentation to ensure accuracy and proper navigation

----

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13523-Feedback-on-Download-Links--Couchbase-Docs

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.