### PR TITLE
DOC-13549-version vectors cbl 4.0 c

### DIFF
--- a/modules/c/nav-c.adoc
+++ b/modules/c/nav-c.adoc
@@ -11,10 +11,12 @@ include::partial$_set_page_context_for_c.adoc[]
   * xref:c:database.adoc[]
 
   * xref:c:prebuilt-database.adoc[]
-  
+
     * xref:c:scopes-collections-manage.adoc[]
 
   * xref:c:document.adoc[]
+
+  * xref:c:version-vectors.adoc[]
 
   * xref:c:blob.adoc[]
 
@@ -42,7 +44,7 @@ include::partial$_set_page_context_for_c.adoc[]
   * xref:c:conflict.adoc[]
 
   * xref:c:upgrade.adoc[]
- 
+
   * https://docs.couchbase.com/mobile/{version-maintenance}/couchbase-lite-c/C/html/modules.html[API Reference]
 
   * Product Notes

--- a/modules/c/pages/version-vectors.adoc
+++ b/modules/c/pages/version-vectors.adoc
@@ -1,0 +1,281 @@
+= Version Vectors
+:page-toclevels: 2@
+:page-role:
+:description: Couchbase Lite 4.0 -- Version Vectors -- Document versioning and conflict resolution
+
+:source-language: C
+
+[abstract]
+--
+Description -- _{description}_ +
+Related Content -- xref:c:database.adoc[Databases] | xref:c:document.adoc[Documents] | xref:c:conflict.adoc[Handling Data Conflicts] | xref:c:replication.adoc[Data Sync]
+--
+
+[#overview]
+== Overview
+
+Couchbase Lite 4.0 introduces version vectors as a replacement for the previous revision tree system used in earlier versions.
+This change improves how Couchbase Lite tracks document changes, handles conflicts, and synchronizes data across devices and with Sync Gateway.
+
+Version vectors provide a more efficient and scalable approach to document versioning that aligns Couchbase Lite with Couchbase Server's versioning system, enabling seamless synchronization across the entire Couchbase ecosystem.
+
+[#what-are-version-vectors]
+== What are Version Vectors?
+
+A version vector is a data structure that tracks the complete history of document modifications across different sources.
+Instead of maintaining a tree-like structure of document revisions, version vectors use a more efficient approach based on logical timestamps.
+
+[#key-components]
+=== Key Components
+
+Source ID:: A unique identifier for each Couchbase Lite database instance that can modify documents.
+Each Couchbase Lite database on a device receives its own unique source ID, ensuring that document changes tracks back to their originating database.
+
+Timestamp:: A logical clock value that establishes the ordering of document changes within a single source.
+Couchbase Lite 4.0 uses Hybrid Logical Clocks (HLC), which combine real-time with logical counters to verify proper tracking.
+
+Version:: A combination of timestamp and source ID that uniquely identifies the specific point in time and location where the development process creates a particular document revision.
+This approach replaces traditional revision ID concepts.
+
+Version Vector:: An ordered array containing the latest version from every source that's modified the document.
+
+[#version-vectors-vs-revision-trees]
+== Version Vectors vs. Revision Trees
+
+Version vectors represents an improvement over revision tree system used in Couchbase Lite 3.x and earlier versions.
+While the revision tree approach maintained complex branching trees of all document revisions with revision IDs in the format `<generation>-<document-hash>`, version vectors use a more efficient structure that tracks only the latest version from each source using timestamp-based identifiers in the format `<timestamp>@<source-id>`.
+
+This change eliminates the storage overhead of maintaining complete revision history trees and replaces the `"most active wins"` conflict resolution logic with `"last write wins"` approach based on hybrid logical timestamps.
+
+As a result, version vectors reduce storage requirements and simplify synchronization through vector comparison rather than tree merging operations.
+It also improves overall performance and scalability as the number of connected devices increases.
+
+[#benefits-of-version-vectors]
+=== Benefits of Version Vectors
+
+Improved Performance:: Version vectors require less storage space and processing power compared to maintaining complete revision trees.
+
+Better Scalability:: The system scales more efficiently as the number of connected devices increases.
+
+Simplified Conflict Resolution:: Last-write-wins logic based on timestamps is more predictable and easier to understand.
+
+Enhanced Synchronization:: Alignment with Couchbase Server's versioning enables more efficient sync operations.
+
+Reduced Complexity:: Eliminates the need to manage complex tree structures and revision genealogies.
+
+[#impact-on-document-identification]
+== Impact on Document Identification
+
+The transition to version vectors transforms how documents receive identification and referencing within C applications.
+
+[#revision-id-format-changes]
+=== Revision ID Format Changes
+
+**CBL 3.x Format**
+----
+1-7bf9c5c9d5e2c7a5d8f0e3c6a9d2f4b7
+----
+
+**CBL 4.0 Format**
+----
+1773b25174850000@4a7c8e5f-2d3b-4f9e-8c1a-6b4d9e2f7a5c
+----
+
+The new format contains:
+
+* **Timestamp portion**: `1773b25174850000` (hybrid logical clock value)
+* **Source ID portion**: `4a7c8e5f-2d3b-4f9e-8c1a-6b4d9e2f7a5c` (UUID)
+
+[#document-api-changes]
+=== Document API Changes
+
+The `c4doc_getRevID()` function continues to work but now returns version-based IDs.
+You can also view the document's logical timestamp using the `c4rev_getTimestamp()` function:
+
+.Accessing Document Version Information
+[#ex-document-version-info]
+====
+[source, C, indent=0]
+----
+// Existing revision ID access (now returns version format)
+FLSlice revisionId = c4doc_getRevID(doc);
+
+// Get timestamp from revision ID
+uint64_t timestamp = c4rev_getTimestamp(revisionId);
+----
+====
+
+The timestamp value returns a `uint64_t` representing nanoseconds since the Unix epoch (January 1, 1970 00:00:00 UTC).
+A timestamp value of zero indicates no timestamp is available.
+
+[#impact-on-conflict-resolution]
+== Impact on Conflict Resolution
+
+Version vectors change how Couchbase Lite resolves conflicts during synchronization.
+
+[#previous-conflict-resolution]
+=== Previous Conflict Resolution (CBL 3.x)
+
+The revision tree system used `"most active wins"` logic:
+
+* Conflicts resolves by comparing revision generation numbers
+* The document with the highest generation number (most edits) would win
+* This could lead to scenarios where older documents with more edits would override newer documents with fewer edits
+
+[#new-conflict-resolution]
+=== New Conflict Resolution (CBL 4.0)
+
+Version vectors implement `"last write wins"` conflict resolution:
+
+.Default Conflict Resolution Logic
+[#ex-conflict-resolution]
+====
+[source, C, indent=0]
+----
+CBLDocument* resolve_conflict(CBLConflict* conflict) {
+    CBLDocument* localDoc = CBLConflict_LocalDocument(conflict);
+    CBLDocument* remoteDoc = CBLConflict_RemoteDocument(conflict);
+
+    if (!localDoc || !remoteDoc) {
+        return NULL; // Deleted revision always wins
+    }
+
+    uint64_t localTimestamp = c4rev_getTimestamp(CBLDocument_RevisionID(localDoc));
+    uint64_t remoteTimestamp = c4rev_getTimestamp(CBLDocument_RevisionID(remoteDoc));
+
+    if (localTimestamp > remoteTimestamp) {
+        return localDoc;
+    } else {
+        return remoteDoc;
+    }
+}
+----
+====
+
+This approach:
+
+* Compares hybrid logical timestamps to determine which revision was written last
+* Provides more intuitive conflict resolution behavior
+* Ensures that the most recent change (by wall-clock time) typically wins
+* Reduces unexpected conflict resolution outcomes
+
+[#custom-conflict-resolution]
+=== Custom Conflict Resolution
+
+While the default resolver changes, you can still implement custom conflict resolution logic.
+The new timestamp access provides additional context for making resolution decisions.
+
+.Custom Conflict Resolution Example
+[#ex-custom-conflict-resolution]
+====
+[source, C, indent=0]
+----
+CBLDocument* custom_resolve_conflict(CBLConflict* conflict) {
+    CBLDocument* localDoc = CBLConflict_LocalDocument(conflict);
+    CBLDocument* remoteDoc = CBLConflict_RemoteDocument(conflict);
+
+    if (!localDoc || !remoteDoc) {
+        return NULL;
+    }
+
+    uint64_t localTimestamp = c4rev_getTimestamp(CBLDocument_RevisionID(localDoc));
+    uint64_t remoteTimestamp = c4rev_getTimestamp(CBLDocument_RevisionID(remoteDoc));
+
+    // Use timestamp along with other business logic
+    if (localTimestamp > remoteTimestamp) {
+        // Local is newer, but check business rules
+        return apply_business_rules(localDoc, remoteDoc);
+    } else {
+        return apply_business_rules(remoteDoc, localDoc);
+    }
+}
+----
+====
+
+[#compatibility-and-migration]
+== Compatibility
+
+Couchbase Lite 4.0 provides backward compatibility for existing databases:
+
+Automatic Upgrade:: When opening a CBL 3.1 or 3.2 database with CBL 4.0, documents are automatically upgraded to use version vectors.
+
+Lazy Migration:: The upgrade occurs incrementally as documents are accessed and modified.
+
+No Downgrade:: Version vector upgrades prevent CBL 3.x versions from opening these databases.
+
+[#synchronization-compatibility]
+=== Synchronization Compatibility
+
+Version vector synchronization has specific requirements:
+
+Sync Gateway Compatibility:: CBL 4.0 requires Sync Gateway 4.0 or later.
+Attempting to sync with older Sync Gateway versions results in an error.
+
+Peer-to-Peer Compatibility:: CBL 4.0 can only perform peer-to-peer sync with other CBL 4.0+ instances.
+Sync attempts with CBL 3.x peers fails with an appropriate error message.
+
+[#development-considerations]
+== Development Considerations
+
+[#testing-applications]
+=== Testing Applications
+
+When testing applications with version vectors, be aware that:
+
+* **Non-deterministic IDs**: Version-based revision IDs resist prior calculation due to timestamp components.
+* **Test Assertions**: Update test cases to verify revision ID existence and ordering rather than specific values.
+* **Conflict Testing**: Verify that conflict resolution now uses timestamp-based logic
+
+.Testing Document Revisions
+[#ex-testing-revisions]
+====
+[source, C, indent=0]
+----
+// Instead of testing specific revision ID values
+// assert(strcmp(FLSlice_ToCString(c4doc_getRevID(doc)), "1-abc123") == 0);
+
+// Test for presence and format
+FLSlice revID = c4doc_getRevID(doc);
+assert(revID.size > 0);
+assert(memchr(revID.buf, '@', revID.size) != NULL); // Contains '@'
+
+// Test timestamp ordering
+// ... update document ...
+uint64_t originalTimestamp = c4rev_getTimestamp(revID);
+uint64_t updatedTimestamp = c4rev_getTimestamp(c4doc_getRevID(updatedDoc));
+assert(updatedTimestamp > originalTimestamp);
+----
+====
+
+[#related-content]
+== Related Content
+
+++++
+<div class="card-row three-column-row">
+++++
+
+[.column]
+=== {empty}
+.How to . . .
+* xref:c:gs-prereqs.adoc[Prerequisites]
+* xref:c:gs-install.adoc[Install]
+* xref:c:gs-build.adoc[Build and Run]
+
+[.column]
+=== {empty}
+.Learn more . . .
+* xref:c:database.adoc[Databases]
+* xref:c:document.adoc[Documents]
+* xref:c:conflict.adoc[Handling Data Conflicts]
+* xref:c:replication.adoc[Data Sync]
+
+[.column]
+=== {empty}
+.Dive Deeper . . .
+https://forums.couchbase.com/c/mobile/14[Mobile Forum] |
+https://blog.couchbase.com/[Blog] |
+https://docs.couchbase.com/tutorials/[Tutorials]
+
+++++
+</div>
+++++


### PR DESCRIPTION
Preview: [CBL C version vectors](https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13549-version-vectors-cbl-c/couchbase-lite/current/c/version-vectors.html)

PR to add version vectors for CBL 4.0 C platform 