### PR TITLE
updated platform support

### DIFF
--- a/modules/c/pages/supported-os.adoc
+++ b/modules/c/pages/supported-os.adoc
@@ -25,7 +25,7 @@ Couchbase Lite for C is available on the platforms shown in the tables below.
 [IMPORTANT]
 .Deprecation Notice
 --
-Support for the following will be deprecated in this release and will be removed in a future release:
+Support for the following is deprecated in this release and becomes unsupported in a future release:
 
 * macOS 13 (Ventura)
 
@@ -39,7 +39,7 @@ Please plan to migrate your apps to use an appropriate alternative version.
 |===
 .>| API | x86 | x64 .>| ARM 32 .>| ARM 64
 
-| 22+ | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| 24 | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
 |===
 
@@ -50,7 +50,7 @@ Please plan to migrate your apps to use an appropriate alternative version.
 |===
 .>| Version | x86 | x64 | ARM 32 | ARM 64
 
-| 13+
+| 15+
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -83,7 +83,7 @@ Please plan to migrate your apps to use an appropriate alternative version.
 | 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
-.2+| Raspberry Pi OS 
+.2+| Raspberry Pi OS
 | 11 (Bullseye) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
@@ -104,7 +104,7 @@ Please plan to migrate your apps to use an appropriate alternative version.
 | 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
-.2+| Raspberry Pi OS 
+.2+| Raspberry Pi OS
 | 11 (Bullseye) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 

--- a/modules/csharp/pages/supported-os.adoc
+++ b/modules/csharp/pages/supported-os.adoc
@@ -24,7 +24,7 @@ Run-times which have received more testing and are *officially* supported are sh
 [IMPORTANT]
 .Deprecation Notice
 --
-Support for the following will be deprecated in this release and will be removed in a future release:
+This release deprecates support for the following, and support will be removed in a future release:
 
 * Xamarin Android - All Versions
 * Xamarin iOS - All Versions
@@ -63,11 +63,11 @@ a| MacOS 12
 
 |.NET Android
 |8.0
-|API 22+
+|API 24
 
 |Xamarin Android
 |10+
-|API 22
+|API 24
 
 |Xamarin iOS
 |10+
@@ -93,7 +93,7 @@ The following run-times are compatible but are not QE tested, and so are not off
 |n/a*
 |===
 
-*{sp}There are many different variants of Linux, and we don't have the resources to test all of them.
-They are tested on Ubuntu 20.04, but have been shown to work on CentOS, and in theory work on any distro supported by .NET.
+*{sp}There are different variants of Linux, and there are insufficient resources to test all of them.
+They're tested on Ubuntu 20.04, but work on CentOS, and in theory work on any distro supported by .NET.
 
 


### PR DESCRIPTION
Preview: [URL](https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13572-update-platform-support/couchbase-lite/current/csharp/supported-os.html)

PR to update the platform support for CBL 3.3, updated the CBL .NET to 24 for Android 