### PR TITLE
[DOC-13568]: Update console logging code snippets in platform-specific database guides

### DIFF
--- a/modules/android/pages/database.adoc
+++ b/modules/android/pages/database.adoc
@@ -520,7 +520,7 @@ Java::
 --
 [source, Java]
 ----
-include::android:example$codesnippet_collection.java[tags="console-logging-db", indent=0]
+include::android:example$codesnippet_collection.java[tags="console-logging", indent=0]
 ----
 --
 

--- a/modules/objc/pages/database.adoc
+++ b/modules/objc/pages/database.adoc
@@ -357,7 +357,7 @@ For more on using Couchbase logs -- see: xref:objc:troubleshooting-logs.adoc[Usi
 
 [source, objc]
 ----
-include::objc:example$code_snippets/SampleCodeTest.m[tags="console-logging-db", indent=0]
+include::objc:example$code_snippets/SampleCodeTest.m[tags="console-logging", indent=0]
 ----
 
 

--- a/modules/swift/pages/database.adoc
+++ b/modules/swift/pages/database.adoc
@@ -357,7 +357,7 @@ For more on using Couchbase logs -- see: xref:swift:troubleshooting-logs.adoc[Us
 
 [source, swift]
 ----
-include::swift:example$code_snippets/SampleCodeTest.swift[tags="console-logging-db", indent=0]
+include::swift:example$code_snippets/SampleCodeTest.swift[tags="console-logging", indent=0]
 ----
 
 

--- a/preview/DOC-13568-Feedback-on-Databases--Couchbase-Docs.yml
+++ b/preview/DOC-13568-Feedback-on-Databases--Couchbase-Docs.yml
@@ -1,0 +1,3 @@
+sources:
+  docs-couchbase-lite:
+    branches: [HEAD]


### PR DESCRIPTION
- Adjusted include tags in Obj-C, Android, and Swift database guides to utilize "console-logging" instead of "console-logging-db".
- Introduced a new YAML configuration for previewing database documentation.
- Ensures consistency and accuracy of platform-specific database guide samples.

----

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13568-Feedback-on-Databases--Couchbase-Docs

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.