### PR TITLE
[DOC-13605]: Feedback on Download Links | Couchbase Docs

### DIFF
--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -660,9 +660,9 @@ Enterprise::
 
 .4+| Linux
 
-| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-aarch64.zip[couchbase-lite-vector-search-{our-vs-version}-linux-aarch64.zip]
-| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-aarch64.zip.sha256[couchbase-lite-vector-search-{our-vs-version}-linux-aarch64.zip.sha256]
-| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-aarch64-symbols.zip[couchbase-lite-vector-search-{our-vs-version}-linux-aarch64-symbols.zip]
+| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-arm64.zip[couchbase-lite-vector-search-{our-vs-version}-linux-arm64.zip]
+| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-arm64.zip.sha256[couchbase-lite-vector-search-{our-vs-version}-linux-arm64.zip.sha256]
+| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-arm64-symbols.zip[couchbase-lite-vector-search-{our-vs-version}-linux-arm64-symbols.zip]
 | {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-x86_64.zip[couchbase-lite-vector-search-{our-vs-version}-linux-x86_64.zip]
 | {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-x86_64.zip.sha256[couchbase-lite-vector-search-{our-vs-version}-linux-x86_64.zip.sha256]
 | {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-x86_64-symbols.zip[couchbase-lite-vector-search-{our-vs-version}-linux-x86_64-symbols.zip]


### PR DESCRIPTION

Corrected the download links to the Linux vector search frameworks.