### PR TITLE
[DOC-13604]: Feedback on Couchbase Lite on Java—Installing | Couchbase Docs

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -26,7 +26,7 @@ asciidoc:
     maintenance-android: 4
     maintenance-java: 4
     maintenance-net: 4
-    base: 3
+    base: 4
 
     # Used for Vector Search Extension.
     vs-major: 1


### PR DESCRIPTION

Fixed the `base` version number in antora.yml