### PR TITLE
update release notes, antora yml and download pages

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: couchbase-lite
 version: '3.3'
-prerelease: 
+prerelease:
 title: Couchbase Lite
 start_page: ROOT:index.adoc
 nav:
@@ -14,19 +14,22 @@ nav:
 - modules/swift/nav-swift.adoc
 asciidoc:
   attributes:
-    prerelease: 
-    previous-release: 
+    prerelease:
+    previous-release:
     release: '3.3'
 
-    # releasetag: 
+    # releasetag:
     major: 3
     minor: 3
+    minor-net: 2
+    minor-java: 2
+    minor-c: 2
     maintenance-ios: 0
     maintenance-swift: 0
-    maintenance-c: 0
+    maintenance-c: 4
     maintenance-android: 0
-    maintenance-java: 0
-    maintenance-net: 0
+    maintenance-java: 4
+    maintenance-net: 4
     base: 0
 
     # Used for Vector Search Extension.

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.3.0.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.3.0.adoc
@@ -1,5 +1,5 @@
 [#maint-3-3-0]
-== 3.3.0 -- September 2025
+== 3.3.0 -- October 2025
 
 Version 3.3.0 for {param-title} delivers the following features and enhancements:
 

--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -44,7 +44,7 @@ ifdef::param-version+param-version-hyphenated[]
 [id=release-{our-version-hyphenated}]
 == Couchbase Lite Release {our-version}
 
-_Couchbase Lite for C_ is available for all {supported-os--xref}.
+_Couchbase Lite for C_ is available for all xref:c:supported-os.adoc[Supported Platforms].
 You can obtain downloads for _Linux_ and _macOS_ from the links here in the downloads table.
 Ensure you select the correct package for your application's compiler and architecture.
 
@@ -522,7 +522,7 @@ ifdef::vs-param-version+vs-param-version-hyphenated[]
 [id=vs-release-{our-vs-version-hyphenated}]
 == Vector Search Release {our-vs-version}
 
-_Couchbase Lite Vector Search - C_ is available for all {supported-os--xref}.
+_Couchbase Lite Vector Search - C_ is available for all xref:c:supported-os.adoc[Supported Platforms].
 You can obtain downloads for _Linux_ and _macOS_ from the links here in the downloads table.
 Ensure you select the correct package for your application's compiler and architecture.
 
@@ -539,7 +539,7 @@ page for instructions on how to get the software using a package manager.
 <<linux-{our-vs-version-hyphenated}>>   |
 ****
 
-[IMPORTANT] 
+[IMPORTANT]
 --
 You must have Couchbase Lite installed before you can use the Vector Search Extension.
 Vector Search is available only for 64-bit architectures.
@@ -559,7 +559,7 @@ Enterprise::
 --
 [#tbl-downloads-ee,cols="1,4,4", options="header"]
 |===
-| Platform | Download | SHA 
+| Platform | Download | SHA
 
 .4+| Android
 
@@ -608,7 +608,7 @@ Enterprise Edition::
 --
 [#tbl-downloads-ee,cols="1,4,4", options="header"]
 |===
-| Platform | Download | SHA 
+| Platform | Download | SHA
 
 .3+| iOS
 | {vs_source_url}couchbase-lite-vector-search_xcframework_{our-vs-version}.zip[couchbase-lite-vector-search_xcframework_{our-vs-version}.zip]

--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -583,7 +583,7 @@ Enterprise::
 Enterprise Edition::
 +
 --
-[#tbl-downloads-ee,cols="1,4,4", options="header"]
+[#tbl-downloads-ee,cols="1,4,4,4", options="header"]
 |===
 | Platform | Download | SHA | Debug Symbols
 

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -25,15 +25,15 @@ xref:c:gs-build.adoc[Build and Run]
 
 .Downloads are available for the following versions:
 ****
-<<release-3-3-0>>   |
+<<release-3-2-4>>   |
 <<vs-release-1-0-0>>   |
 // |
 ****
 
 
 // This block will always represent the major release version
-:param-version: 3.3.0
-:param-version-hyphenated: 3-3-0
+:param-version: 3.2.4
+:param-version-hyphenated: 3-2-4
 include::partial$downloadslist.adoc[]
 :param-version!:
 :param-version-hyphenated!:

--- a/modules/c/pages/gs-install.adoc
+++ b/modules/c/pages/gs-install.adoc
@@ -922,7 +922,7 @@ Community Edition::
 =====
 
 
-[#ubuntu-3-2-1,id=ubuntu-3-2-1]
+[#ubuntu-3-2-4,id=ubuntu-3-2-4]
 ==== Ubuntu
 
 [#tbl-downloads-3.2.4]
@@ -1101,6 +1101,7 @@ Please use the <<debian-3-3-0,Debian `.deb` download>> choosing the appropriate 
 === Vector Search Release 1.0.0
 
 _Couchbase Lite Vector Search - C_ is available for all xref:c:supported-os.adoc[Supported Platforms].
+
 You can obtain downloads for _Linux_ and _macOS_ from the links here in the downloads table.
 Ensure you select the correct package for your application's compiler and architecture.
 

--- a/modules/c/pages/gs-install.adoc
+++ b/modules/c/pages/gs-install.adoc
@@ -616,7 +616,7 @@ Please plan to migrate your apps to use an appropriate alternative version.
 [#release-3-2-1,id=release-3-2-1]
 === Couchbase Lite Release 3.2.4
 
-_Couchbase Lite for C_ is available for all xref:c:supported-os.adoc[Supported Platforms].
+_Couchbase Lite for C_ {major}.{minor-c}.{maintenance-c} is available for all xref:c:supported-os.adoc[Supported Platforms].
 You can obtain downloads for _Linux_ and _macOS_ from the links here in the downloads table.
 Ensure you select the correct package for your application's compiler and architecture.
 

--- a/modules/c/pages/gs-install.adoc
+++ b/modules/c/pages/gs-install.adoc
@@ -40,7 +40,7 @@ xref:c:gs-build.adoc[Build and Run]
 == Download
 
 
-Couchbase Lite for C {major}.{minor}.{maintenance-c}{empty} is available for all supported platforms -- see: xref:c:gs-install.adoc#lbl-platforms[].
+Couchbase Lite for C is available for all supported platforms -- see: xref:c:gs-install.adoc#lbl-platforms[].
 
 You can obtain the downloads here:
 
@@ -550,15 +550,15 @@ Please plan to migrate your apps to use an appropriate alternative version.
 [#linux]
 === Linux
 
-[cols="^1,^1,^1,^1^,^1,^1",options="header"]
+[cols="^1,^1,^1,^1,^1",options="header"]
 |===
-.>| Distro	| Version .>| x64 .>| ARM 32 .>| ARM 64
+| Distro | Version | x64 | ARM 32 | ARM 64
 
-.4+| Debian
+.2+| Debian
 | 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
-.4+| Raspberry Pi OS 
+.2+| Raspberry Pi OS
 | 11 (Bullseye) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
@@ -571,15 +571,15 @@ Please plan to migrate your apps to use an appropriate alternative version.
 [#embedded-linux]
 === Embedded Linux
 
-[cols="^1,^1,^1,^1^,^1,^1",options="header"]
+[cols="^1,^1,^1,^1,^1",options="header"]
 |===
-.>| Distro	| Version .>| x64 .>| ARM 32 .>| ARM 64
+| Distro | Version | x64 | ARM 32 | ARM 64
 
-.4+| Debian
+.2+| Debian
 | 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
-.4+| Raspberry Pi OS 
+.2+| Raspberry Pi OS
 | 11 (Bullseye) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
@@ -607,14 +607,14 @@ Please plan to migrate your apps to use an appropriate alternative version.
 // Include the same parameters as in gs-downloads, but only for latest version
 
 
-:release-dir-ee: pass:q,a[libcblite-3.3.0]
-:release-dir-dev-ee: pass:q,a[libcblite-dev-3.3.0]
+:release-dir-ee: pass:q,a[libcblite-3.2.4]
+:release-dir-dev-ee: pass:q,a[libcblite-dev-3.2.4]
 
 
 // If both parameters are defined, render CBL downloads
 
 [#release-3-2-1,id=release-3-2-1]
-=== Couchbase Lite Release 3.3.0
+=== Couchbase Lite Release 3.2.4
 
 _Couchbase Lite for C_ is available for all xref:c:supported-os.adoc[Supported Platforms].
 You can obtain downloads for _Linux_ and _macOS_ from the links here in the downloads table.
@@ -626,16 +626,16 @@ page for instructions on how to get the software using a package manager.
 
 .Available platforms are:
 ****
-<<macos-3-2-1>>  |
-<<windows-3-2-1>>  |
-<<debian-3-2-1>>  |
-<<ubuntu-3-2-1>>  |
+<<macos-3-2-4>>  |
+<<windows-3-2-4>>  |
+<<debian-3-2-4>>  |
+<<ubuntu-3-2-4>>  |
 ****
 
-[#macos-3-2-1,id=macos-3-2-1]
+[#macos-3-2-4,id=macos-3-2-4]
 ==== MacOS
 
-[#tbl-downloads-3.3.0]
+[#tbl-downloads-3.2.4]
 .Download link table
 [tabs]
 =====
@@ -650,9 +650,9 @@ Enterprise Edition::
 | Platform | Download | SHA | Debug Symbols
 
 .1+| MacOS
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-macos.zip[couchbase-lite-c-enterprise-3.3.0-macos.zip]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-macos.zip.sha256[couchbase-lite-c-enterprise-3.3.0-macos.zip.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-macos-symbols.zip[couchbase-lite-c-enterprise-3.3.0-macos-symbols.zip]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-macos.zip[couchbase-lite-c-enterprise-3.2.4-macos.zip]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-macos.zip.sha256[couchbase-lite-c-enterprise-3.2.4-macos.zip.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-macos-symbols.zip[couchbase-lite-c-enterprise-3.2.4-macos-symbols.zip]
 
 |===
 --
@@ -666,9 +666,9 @@ Community Edition::
 | Platform | Download | SHA | Debug Symbols
 
 | MacOS
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-macos.zip[couchbase-lite-c-community-3.3.0-macos.zip]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-macos.zip.sha256[couchbase-lite-c-community-3.3.0-macos.zip.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-macos-symbols.zip[couchbase-lite-c-community-3.3.0-macos-symbols.zip]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-macos.zip[couchbase-lite-c-community-3.2.4-macos.zip]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-macos.zip.sha256[couchbase-lite-c-community-3.2.4-macos.zip.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-macos-symbols.zip[couchbase-lite-c-community-3.2.4-macos-symbols.zip]
 
 |===
 
@@ -676,10 +676,10 @@ Community Edition::
 
 =====
 
-[#windows-3-2-1,id=windows-3-2-1]
+[#windows-3-2-4,id=windows-3-2-4]
 ==== Windows
 
-[#tbl-downloads-3.3.0]
+[#tbl-downloads-3.2.4]
 .Download link table
 [tabs]
 =====
@@ -694,9 +694,9 @@ Enterprise Edition::
 | Platform | Download | SHA | Debug Symbols
 
 .1+| Windows
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-windows-x86_64.zip[couchbase-lite-c-enterprise-3.3.0-windows-x86_64.zip]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-windows-x86_64.zip[couchbase-lite-c-enterprise-3.2.4-windows-x86_64.zip]
 | {empty}
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-windows-x86_64-symbols.zip[couchbase-lite-c-enterprise-3.3.0-windows-x86_64-symbols.zip]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-windows-x86_64-symbols.zip[couchbase-lite-c-enterprise-3.2.4-windows-x86_64-symbols.zip]
 
 |===
 --
@@ -710,9 +710,9 @@ Community Edition::
 | Platform | Download | SHA | Debug Symbols
 
 .1+| Windows
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-windows-x86_64.zip[couchbase-lite-c-community-3.3.0-windows-x86_64.zip]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-windows-x86_64.zip[couchbase-lite-c-community-3.2.4-windows-x86_64.zip]
 | {empty}
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-windows-x86_64-symbols.zip[couchbase-lite-c-community-3.3.0-windows-x86_64-symbols.zip]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-windows-x86_64-symbols.zip[couchbase-lite-c-community-3.2.4-windows-x86_64-symbols.zip]
 
 |===
 
@@ -720,10 +720,10 @@ Community Edition::
 
 =====
 
-[#debian-3-2-1,id=debian-3-2-1]
+[#debian-3-2-4,id=debian-3-2-4]
 ==== Debian
 
-[#tbl-downloads-3.3.0]
+[#tbl-downloads-3.2.4]
 .Download link table
 [tabs]
 =====
@@ -739,85 +739,85 @@ Enterprise Edition::
 
 .99+|  Debian
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-arm64.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-arm64.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-arm64.tar.gz.sha256[couchbase-lite-c-enterprise-3.3.0-linux-arm64.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-arm64-symbols.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-arm64-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-arm64.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-arm64.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-arm64.tar.gz.sha256[couchbase-lite-c-enterprise-3.2.4-linux-arm64.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-arm64-symbols.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-arm64-symbols.tar.gz]
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-armhf.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-armhf.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-armhf.tar.gz.sha256[couchbase-lite-c-enterprise-3.3.0-linux-armhf.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-armhf-symbols.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-armhf-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-armhf.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-armhf.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-armhf.tar.gz.sha256[couchbase-lite-c-enterprise-3.2.4-linux-armhf.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-armhf-symbols.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-armhf-symbols.tar.gz]
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-x86_64.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-x86_64.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-x86_64.tar.gz.sha256[couchbase-lite-c-enterprise-3.3.0-linux-x86_64.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-x86_64-symbols.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-x86_64-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz.sha256[couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64-symbols.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-x86_64-symbols.tar.gz]
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian11_amd64.deb[libcblite-enterprise_3.3.0-debian11_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian11_amd64.deb.sha256[libcblite-enterprise_3.3.0-debian11_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian11_amd64.deb[libcblite-enterprise_3.2.4-debian11_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian11_amd64.deb.sha256[libcblite-enterprise_3.2.4-debian11_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian11_amd64.deb[libcblite-dev-enterprise_3.3.0-debian11_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian11_amd64.deb.sha256[libcblite-dev-enterprise_3.3.0-debian11_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian11_amd64.deb[libcblite-dev-enterprise_3.2.4-debian11_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian11_amd64.deb.sha256[libcblite-dev-enterprise_3.2.4-debian11_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian11_arm64.deb[libcblite-enterprise_3.3.0-debian11_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian11_arm64.deb.sha256[libcblite-enterprise_3.3.0-debian11_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian11_arm64.deb[libcblite-enterprise_3.2.4-debian11_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian11_arm64.deb.sha256[libcblite-enterprise_3.2.4-debian11_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian11_arm64.deb[libcblite-dev-enterprise_3.3.0-debian11_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian11_arm64.deb.sha256[libcblite-dev-enterprise_3.3.0-debian11_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian11_arm64.deb[libcblite-dev-enterprise_3.2.4-debian11_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian11_arm64.deb.sha256[libcblite-dev-enterprise_3.2.4-debian11_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian11_armhf.deb[libcblite-enterprise_3.3.0-debian11_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian11_armhf.deb.sha256[libcblite-enterprise_3.3.0-debian11_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian11_armhf.deb[libcblite-enterprise_3.2.4-debian11_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian11_armhf.deb.sha256[libcblite-enterprise_3.2.4-debian11_armhf.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian11_armhf.deb[libcblite-dev-enterprise_3.3.0-debian11_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian11_armhf.deb.sha256[libcblite-dev-enterprise_3.3.0-debian11_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian11_armhf.deb[libcblite-dev-enterprise_3.2.4-debian11_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian11_armhf.deb.sha256[libcblite-dev-enterprise_3.2.4-debian11_armhf.deb.sha256]
 |
 
 
 // Debian 10
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian10_amd64.deb[libcblite-enterprise_3.3.0-debian10_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian10_amd64.deb.sha256[libcblite-enterprise_3.3.0-debian10_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian10_amd64.deb[libcblite-enterprise_3.2.4-debian10_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian10_amd64.deb.sha256[libcblite-enterprise_3.2.4-debian10_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian10_amd64.deb[libcblite-dev-enterprise_3.3.0-debian10_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian10_amd64.deb.sha256[libcblite-dev-enterprise_3.3.0-debian10_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian10_amd64.deb[libcblite-dev-enterprise_3.2.4-debian10_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian10_amd64.deb.sha256[libcblite-dev-enterprise_3.2.4-debian10_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian10_arm64.deb[libcblite-enterprise_3.3.0-debian10_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian10_arm64.deb.sha256[libcblite-enterprise_3.3.0-debian10_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian10_arm64.deb[libcblite-enterprise_3.2.4-debian10_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian10_arm64.deb.sha256[libcblite-enterprise_3.2.4-debian10_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian10_arm64.deb[libcblite-dev-enterprise_3.3.0-debian10_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian10_arm64.deb.sha25[libcblite-dev-enterprise_3.3.0-debian10_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian10_arm64.deb[libcblite-dev-enterprise_3.2.4-debian10_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian10_arm64.deb.sha25[libcblite-dev-enterprise_3.2.4-debian10_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian10_armhf.deb[libcblite-enterprise_3.3.0-debian10_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian10_armhf.deb.sha256[libcblite-enterprise_3.3.0-debian10_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian10_armhf.deb[libcblite-enterprise_3.2.4-debian10_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian10_armhf.deb.sha256[libcblite-enterprise_3.2.4-debian10_armhf.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian10_armhf.deb[libcblite-dev-enterprise_3.3.0-debian10_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian10_armhf.deb.sha256[libcblite-dev-enterprise_3.3.0-debian10_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian10_armhf.deb[libcblite-dev-enterprise_3.2.4-debian10_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian10_armhf.deb.sha256[libcblite-dev-enterprise_3.2.4-debian10_armhf.deb.sha256]
 |
 
 
 // Debian 9
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian9_amd64.deb[libcblite-enterprise_3.3.0-debian9_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian9_amd64.deb.sha256[libcblite-enterprise_3.3.0-debian9_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian9_amd64.deb[libcblite-enterprise_3.2.4-debian9_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian9_amd64.deb.sha256[libcblite-enterprise_3.2.4-debian9_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian9_amd64.deb[libcblite-dev-enterprise_3.3.0-debian9_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian9_amd64.deb.sha256[libcblite-dev-enterprise_3.3.0-debian9_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian9_amd64.deb[libcblite-dev-enterprise_3.2.4-debian9_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian9_amd64.deb.sha256[libcblite-dev-enterprise_3.2.4-debian9_amd64.deb.sha256]
 |
 
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian9_armhf.deb[libcblite-enterprise_3.3.0-debian9_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-debian9_armhf.deb.sha256[libcblite-enterprise_3.3.0-debian9_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian9_armhf.deb[libcblite-enterprise_3.2.4-debian9_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-debian9_armhf.deb.sha256[libcblite-enterprise_3.2.4-debian9_armhf.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian9_armhf.deb[libcblite-dev-enterprise_3.3.0-debian9_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-debian9_armhf.deb.sha256[libcblite-dev-enterprise_3.3.0-debian9_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian9_armhf.deb[libcblite-dev-enterprise_3.2.4-debian9_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-debian9_armhf.deb.sha256[libcblite-dev-enterprise_3.2.4-debian9_armhf.deb.sha256]
 |
 
 |===
@@ -833,86 +833,86 @@ Community Edition::
 
 .99+| Debian
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-arm64.tar.gz[couchbase-lite-c-community-3.3.0-linux-arm64.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-arm64.tar.gz.sha256[couchbase-lite-c-community-3.3.0-linux-arm64.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-arm64-symbols.tar.gz[couchbase-lite-c-community-3.3.0-linux-arm64-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-arm64.tar.gz[couchbase-lite-c-community-3.2.4-linux-arm64.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-arm64.tar.gz.sha256[couchbase-lite-c-community-3.2.4-linux-arm64.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-arm64-symbols.tar.gz[couchbase-lite-c-community-3.2.4-linux-arm64-symbols.tar.gz]
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-armhf.tar.gz[couchbase-lite-c-community-3.3.0-linux-armhf.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-armhf.tar.gz.sha256[couchbase-lite-c-community-3.3.0-linux-armhf.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-armhf-symbols.tar.gz[couchbase-lite-c-community-3.3.0-linux-armhf-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-armhf.tar.gz[couchbase-lite-c-community-3.2.4-linux-armhf.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-armhf.tar.gz.sha256[couchbase-lite-c-community-3.2.4-linux-armhf.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-armhf-symbols.tar.gz[couchbase-lite-c-community-3.2.4-linux-armhf-symbols.tar.gz]
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-x86_64.tar.gz[couchbase-lite-c-community-3.3.0-linux-x86_64.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-x86_64.tar.gz.sha256[couchbase-lite-c-community-3.3.0-linux-x86_64.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-x86_64-symbols.tar.gz[couchbase-lite-c-community-3.3.0-linux-x86_64-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz.sha256[couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-x86_64-symbols.tar.gz[couchbase-lite-c-community-3.2.4-linux-x86_64-symbols.tar.gz]
 
 // Debian 11
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian11_amd64.deb[libcblite-community_3.3.0-debian11_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian11_amd64.deb.sha256[libcblite-community_3.3.0-debian11_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian11_amd64.deb[libcblite-community_3.2.4-debian11_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian11_amd64.deb.sha256[libcblite-community_3.2.4-debian11_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian11_amd64.deb[libcblite-dev-community_3.3.0-debian11_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian11_amd64.deb.sha256[libcblite-dev-community_3.3.0-debian11_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian11_amd64.deb[libcblite-dev-community_3.2.4-debian11_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian11_amd64.deb.sha256[libcblite-dev-community_3.2.4-debian11_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian11_arm64.deb[libcblite-community_3.3.0-debian11_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian11_arm64.deb.sha256[libcblite-community_3.3.0-debian11_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian11_arm64.deb[libcblite-community_3.2.4-debian11_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian11_arm64.deb.sha256[libcblite-community_3.2.4-debian11_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian11_arm64.deb[libcblite-dev-community_3.3.0-debian11_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian11_arm64.deb.sha256[libcblite-dev-community_3.3.0-debian11_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian11_arm64.deb[libcblite-dev-community_3.2.4-debian11_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian11_arm64.deb.sha256[libcblite-dev-community_3.2.4-debian11_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian11_armhf.deb[libcblite-community_3.3.0-debian11_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian11_armhf.deb.sha256[libcblite-community_3.3.0-debian11_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian11_armhf.deb[libcblite-community_3.2.4-debian11_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian11_armhf.deb.sha256[libcblite-community_3.2.4-debian11_armhf.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian11_armhf.deb[libcblite-dev-community_3.3.0-debian11_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian11_armhf.deb.sha256[libcblite-dev-community_3.3.0-debian11_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian11_armhf.deb[libcblite-dev-community_3.2.4-debian11_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian11_armhf.deb.sha256[libcblite-dev-community_3.2.4-debian11_armhf.deb.sha256]
 |
 
 
 // Debian 10
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian10_amd64.deb[libcblite-community_3.3.0-debian10_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian10_amd64.deb.sha256[libcblite-community_3.3.0-debian10_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian10_amd64.deb[libcblite-community_3.2.4-debian10_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian10_amd64.deb.sha256[libcblite-community_3.2.4-debian10_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian10_amd64.deb[libcblite-dev-community_3.3.0-debian10_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian10_amd64.deb.sha256[libcblite-dev-community_3.3.0-debian10_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian10_amd64.deb[libcblite-dev-community_3.2.4-debian10_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian10_amd64.deb.sha256[libcblite-dev-community_3.2.4-debian10_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian10_arm64.deb[libcblite-community_3.3.0-debian10_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian10_arm64.deb.sha256[libcblite-community_3.3.0-debian10_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian10_arm64.deb[libcblite-community_3.2.4-debian10_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian10_arm64.deb.sha256[libcblite-community_3.2.4-debian10_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian10_arm64.deb[libcblite-dev-community_3.3.0-debian10_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian10_arm64.deb.sha256[libcblite-dev-community_3.3.0-debian10_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian10_arm64.deb[libcblite-dev-community_3.2.4-debian10_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian10_arm64.deb.sha256[libcblite-dev-community_3.2.4-debian10_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian10_armhf.deb[libcblite-community_3.3.0-debian10_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian10_armhf.deb.sha256[libcblite-community_3.3.0-debian10_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian10_armhf.deb[libcblite-community_3.2.4-debian10_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian10_armhf.deb.sha256[libcblite-community_3.2.4-debian10_armhf.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian10_armhf.deb[libcblite-dev-community_3.3.0-debian10_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian10_armhf.deb.sha256[libcblite-dev-community_3.3.0-debian10_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian10_armhf.deb[libcblite-dev-community_3.2.4-debian10_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian10_armhf.deb.sha256[libcblite-dev-community_3.2.4-debian10_armhf.deb.sha256]
 |
 
 
 // Debian 9
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian9_amd64.deb[libcblite-community_3.3.0-debian9_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian9_amd64.deb.sha256[libcblite-community_3.3.0-debian9_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian9_amd64.deb[libcblite-community_3.2.4-debian9_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian9_amd64.deb.sha256[libcblite-community_3.2.4-debian9_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian9_amd64.deb[libcblite-dev-community_3.3.0-debian9_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian9_amd64.deb.sha256[libcblite-dev-community_3.3.0-debian9_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian9_amd64.deb[libcblite-dev-community_3.2.4-debian9_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian9_amd64.deb.sha256[libcblite-dev-community_3.2.4-debian9_amd64.deb.sha256]
 |
 
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian9_armhf.deb[libcblite-community_3.3.0-debian9_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-debian9_armhf.deb.sha256[libcblite-community_3.3.0-debian9_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian9_armhf.deb[libcblite-community_3.2.4-debian9_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-debian9_armhf.deb.sha256[libcblite-community_3.2.4-debian9_armhf.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian9_armhf.deb[libcblite-dev-community_3.3.0-debian9_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-debian9_armhf.deb.sha256[libcblite-dev-community_3.3.0-debian9_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian9_armhf.deb[libcblite-dev-community_3.2.4-debian9_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-debian9_armhf.deb.sha256[libcblite-dev-community_3.2.4-debian9_armhf.deb.sha256]
 |
 
 |===
@@ -925,7 +925,7 @@ Community Edition::
 [#ubuntu-3-2-1,id=ubuntu-3-2-1]
 ==== Ubuntu
 
-[#tbl-downloads-3.3.0]
+[#tbl-downloads-3.2.4]
 .Download link table
 [tabs]
 =====
@@ -941,68 +941,68 @@ Enterprise Edition::
 
 .99+| Ubuntu
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-arm64.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-arm64.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-arm64.tar.gz.sha256[couchbase-lite-c-enterprise-3.3.0-linux-arm64.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-arm64-symbols.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-arm64-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-arm64.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-arm64.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-arm64.tar.gz.sha256[couchbase-lite-c-enterprise-3.2.4-linux-arm64.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-arm64-symbols.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-arm64-symbols.tar.gz]
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-armhf.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-armhf.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-armhf.tar.gz.sha256[couchbase-lite-c-enterprise-3.3.0-linux-armhf.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-armhf-symbols.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-armhf-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-armhf.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-armhf.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-armhf.tar.gz.sha256[couchbase-lite-c-enterprise-3.2.4-linux-armhf.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-armhf-symbols.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-armhf-symbols.tar.gz]
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-x86_64.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-x86_64.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-x86_64.tar.gz.sha256[couchbase-lite-c-enterprise-3.3.0-linux-x86_64.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-enterprise-3.3.0-linux-x86_64-symbols.tar.gz[couchbase-lite-c-enterprise-3.3.0-linux-x86_64-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz.sha256[couchbase-lite-c-enterprise-3.2.4-linux-x86_64.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-enterprise-3.2.4-linux-x86_64-symbols.tar.gz[couchbase-lite-c-enterprise-3.2.4-linux-x86_64-symbols.tar.gz]
 
 
 // Ubuntu 22.04
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu22.04_amd64.deb[libcblite-enterprise_3.3.0-ubuntu22.04_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu22.04_amd64.deb.sha256[libcblite-enterprise_3.3.0-ubuntu22.04_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu22.04_amd64.deb[libcblite-enterprise_3.2.4-ubuntu22.04_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu22.04_amd64.deb.sha256[libcblite-enterprise_3.2.4-ubuntu22.04_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu22.04_amd64.deb[libcblite-dev-enterprise_3.3.0-ubuntu22.04_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu22.04_amd64.deb.sha256[libcblite-dev-enterprise_3.3.0-ubuntu22.04_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu22.04_amd64.deb[libcblite-dev-enterprise_3.2.4-ubuntu22.04_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu22.04_amd64.deb.sha256[libcblite-dev-enterprise_3.2.4-ubuntu22.04_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu22.04_arm64.deb[libcblite-enterprise_3.3.0-ubuntu22.04_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu22.04_arm64.deb.sha256[libcblite-enterprise_3.3.0-ubuntu22.04_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu22.04_arm64.deb[libcblite-enterprise_3.2.4-ubuntu22.04_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu22.04_arm64.deb.sha256[libcblite-enterprise_3.2.4-ubuntu22.04_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu22.04_arm64.deb[libcblite-dev-enterprise_3.3.0-ubuntu22.04_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu22.04_arm64.deb.sha256[libcblite-dev-enterprise_3.3.0-ubuntu22.04_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu22.04_arm64.deb[libcblite-dev-enterprise_3.2.4-ubuntu22.04_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu22.04_arm64.deb.sha256[libcblite-dev-enterprise_3.2.4-ubuntu22.04_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu22.04_armhf.deb[libcblite-enterprise_3.3.0-ubuntu22.04_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu22.04_armhf.deb.sha256[libcblite-enterprise_3.3.0-ubuntu22.04_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu22.04_armhf.deb[libcblite-enterprise_3.2.4-ubuntu22.04_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu22.04_armhf.deb.sha256[libcblite-enterprise_3.2.4-ubuntu22.04_armhf.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu22.04_armhf.deb[libcblite-dev-enterprise_3.3.0-ubuntu22.04_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu22.04_armhf.deb.sha256[libcblite-dev-enterprise_3.3.0-ubuntu22.04_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu22.04_armhf.deb[libcblite-dev-enterprise_3.2.4-ubuntu22.04_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu22.04_armhf.deb.sha256[libcblite-dev-enterprise_3.2.4-ubuntu22.04_armhf.deb.sha256]
 |
 
 
 // Ubuntu 20.04
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu20.04_amd64.deb[libcblite-enterprise_3.3.0-ubuntu20.04_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu20.04_amd64.deb.sha256[libcblite-enterprise_3.3.0-ubuntu20.04_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu20.04_amd64.deb[libcblite-enterprise_3.2.4-ubuntu20.04_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu20.04_amd64.deb.sha256[libcblite-enterprise_3.2.4-ubuntu20.04_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu20.04_amd64.deb[libcblite-dev-enterprise_3.3.0-ubuntu20.04_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu20.04_amd64.deb.sha256[libcblite-dev-enterprise_3.3.0-ubuntu20.04_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu20.04_amd64.deb[libcblite-dev-enterprise_3.2.4-ubuntu20.04_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu20.04_amd64.deb.sha256[libcblite-dev-enterprise_3.2.4-ubuntu20.04_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu20.04_arm64.deb[libcblite-enterprise_3.3.0-ubuntu20.04_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu20.04_arm64.deb.sha256[libcblite-enterprise_3.3.0-ubuntu20.04_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu20.04_arm64.deb[libcblite-enterprise_3.2.4-ubuntu20.04_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu20.04_arm64.deb.sha256[libcblite-enterprise_3.2.4-ubuntu20.04_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu20.04_arm64.deb[libcblite-dev-enterprise_3.3.0-ubuntu20.04_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu20.04_arm64.deb.sha256[libcblite-dev-enterprise_3.3.0-ubuntu20.04_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu20.04_arm64.deb[libcblite-dev-enterprise_3.2.4-ubuntu20.04_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu20.04_arm64.deb.sha256[libcblite-dev-enterprise_3.2.4-ubuntu20.04_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu20.04_armhf.deb[libcblite-enterprise_3.3.0-ubuntu20.04_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-enterprise_3.3.0-ubuntu20.04_armhf.deb.sha256[libcblite-enterprise_3.3.0-ubuntu20.04_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu20.04_armhf.deb[libcblite-enterprise_3.2.4-ubuntu20.04_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-enterprise_3.2.4-ubuntu20.04_armhf.deb.sha256[libcblite-enterprise_3.2.4-ubuntu20.04_armhf.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu20.04_armhf.deb[libcblite-dev-enterprise_3.3.0-ubuntu20.04_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-enterprise_3.3.0-ubuntu20.04_armhf.deb.sha256[libcblite-dev-enterprise_3.3.0-ubuntu20.04_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu20.04_armhf.deb[libcblite-dev-enterprise_3.2.4-ubuntu20.04_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-enterprise_3.2.4-ubuntu20.04_armhf.deb.sha256[libcblite-dev-enterprise_3.2.4-ubuntu20.04_armhf.deb.sha256]
 |
 
 
@@ -1019,68 +1019,68 @@ Community Edition::
 
 .99+| Ubuntu
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-arm64.tar.gz[couchbase-lite-c-community-3.3.0-linux-arm64.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-arm64.tar.gz.sha256[couchbase-lite-c-community-3.3.0-linux-arm64.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-arm64-symbols.tar.gz[couchbase-lite-c-community-3.3.0-linux-arm64-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-arm64.tar.gz[couchbase-lite-c-community-3.2.4-linux-arm64.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-arm64.tar.gz.sha256[couchbase-lite-c-community-3.2.4-linux-arm64.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-arm64-symbols.tar.gz[couchbase-lite-c-community-3.2.4-linux-arm64-symbols.tar.gz]
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-armhf.tar.gz[couchbase-lite-c-community-3.3.0-linux-armhf.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-armhf.tar.gz.sha256[couchbase-lite-c-community-3.3.0-linux-armhf.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-armhf-symbols.tar.gz[couchbase-lite-c-community-3.3.0-linux-armhf-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-armhf.tar.gz[couchbase-lite-c-community-3.2.4-linux-armhf.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-armhf.tar.gz.sha256[couchbase-lite-c-community-3.2.4-linux-armhf.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-armhf-symbols.tar.gz[couchbase-lite-c-community-3.2.4-linux-armhf-symbols.tar.gz]
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-x86_64.tar.gz[couchbase-lite-c-community-3.3.0-linux-x86_64.tar.gz]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-x86_64.tar.gz.sha256[couchbase-lite-c-community-3.3.0-linux-x86_64.tar.gz.sha256]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/couchbase-lite-c-community-3.3.0-linux-x86_64-symbols.tar.gz[couchbase-lite-c-community-3.3.0-linux-x86_64-symbols.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz[couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz.sha256[couchbase-lite-c-community-3.2.4-linux-x86_64.tar.gz.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/couchbase-lite-c-community-3.2.4-linux-x86_64-symbols.tar.gz[couchbase-lite-c-community-3.2.4-linux-x86_64-symbols.tar.gz]
 
 
 // Ubuntu 22.04
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu22.04_amd64.deb[libcblite-community_3.3.0-ubuntu22.04_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu22.04_amd64.deb.sha256[libcblite-community_3.3.0-ubuntu22.04_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu22.04_amd64.deb[libcblite-community_3.2.4-ubuntu22.04_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu22.04_amd64.deb.sha256[libcblite-community_3.2.4-ubuntu22.04_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu22.04_amd64.deb[libcblite-dev-community_3.3.0-ubuntu22.04_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu22.04_amd64.deb.sha256[libcblite-dev-community_3.3.0-ubuntu22.04_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu22.04_amd64.deb[libcblite-dev-community_3.2.4-ubuntu22.04_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu22.04_amd64.deb.sha256[libcblite-dev-community_3.2.4-ubuntu22.04_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu22.04_arm64.deb[libcblite-community_3.3.0-ubuntu22.04_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu22.04_arm64.deb.sha256[libcblite-community_3.3.0-ubuntu22.04_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu22.04_arm64.deb[libcblite-community_3.2.4-ubuntu22.04_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu22.04_arm64.deb.sha256[libcblite-community_3.2.4-ubuntu22.04_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu22.04_arm64.deb[libcblite-dev-community_3.3.0-ubuntu22.04_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu22.04_arm64.deb.sha256[libcblite-dev-community_3.3.0-ubuntu22.04_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu22.04_arm64.deb[libcblite-dev-community_3.2.4-ubuntu22.04_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu22.04_arm64.deb.sha256[libcblite-dev-community_3.2.4-ubuntu22.04_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu22.04_armhf.deb[libcblite-community_3.3.0-ubuntu22.04_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu22.04_armhf.deb.sha256[libcblite-community_3.3.0-ubuntu22.04_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu22.04_armhf.deb[libcblite-community_3.2.4-ubuntu22.04_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu22.04_armhf.deb.sha256[libcblite-community_3.2.4-ubuntu22.04_armhf.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu22.04_armhf.deb[libcblite-dev-community_3.3.0-ubuntu22.04_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu22.04_armhf.deb.sha256[libcblite-dev-community_3.3.0-ubuntu22.04_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu22.04_armhf.deb[libcblite-dev-community_3.2.4-ubuntu22.04_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu22.04_armhf.deb.sha256[libcblite-dev-community_3.2.4-ubuntu22.04_armhf.deb.sha256]
 |
 
 
 // Ubuntu 20.04
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu20.04_amd64.deb[libcblite-community_3.3.0-ubuntu20.04_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu20.04_amd64.deb.sha256[libcblite-community_3.3.0-ubuntu20.04_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu20.04_amd64.deb[libcblite-community_3.2.4-ubuntu20.04_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu20.04_amd64.deb.sha256[libcblite-community_3.2.4-ubuntu20.04_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu20.04_amd64.deb[libcblite-dev-community_3.3.0-ubuntu20.04_amd64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu20.04_amd64.deb.sha256[libcblite-dev-community_3.3.0-ubuntu20.04_amd64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu20.04_amd64.deb[libcblite-dev-community_3.2.4-ubuntu20.04_amd64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu20.04_amd64.deb.sha256[libcblite-dev-community_3.2.4-ubuntu20.04_amd64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu20.04_arm64.deb[libcblite-community_3.3.0-ubuntu20.04_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu20.04_arm64.deb.sha256[libcblite-community_3.3.0-ubuntu20.04_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu20.04_arm64.deb[libcblite-community_3.2.4-ubuntu20.04_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu20.04_arm64.deb.sha256[libcblite-community_3.2.4-ubuntu20.04_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu20.04_arm64.deb[libcblite-dev-community_3.3.0-ubuntu20.04_arm64.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu20.04_arm64.deb.sha256[libcblite-dev-community_3.3.0-ubuntu20.04_arm64.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu20.04_arm64.deb[libcblite-dev-community_3.2.4-ubuntu20.04_arm64.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu20.04_arm64.deb.sha256[libcblite-dev-community_3.2.4-ubuntu20.04_arm64.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu20.04_armhf.deb[libcblite-community_3.3.0-ubuntu20.04_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-community_3.3.0-ubuntu20.04_armhf.deb.sha256[libcblite-community_3.3.0-ubuntu20.04_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu20.04_armhf.deb[libcblite-community_3.2.4-ubuntu20.04_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-community_3.2.4-ubuntu20.04_armhf.deb.sha256[libcblite-community_3.2.4-ubuntu20.04_armhf.deb.sha256]
 |
 
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu20.04_armhf.deb[libcblite-dev-community_3.3.0-ubuntu20.04_armhf.deb]
-| https://packages.couchbase.com/releases/couchbase-lite-c/3.3.0/libcblite-dev-community_3.3.0-ubuntu20.04_armhf.deb.sha256[libcblite-dev-community_3.3.0-ubuntu20.04_armhf.deb.sha256]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu20.04_armhf.deb[libcblite-dev-community_3.2.4-ubuntu20.04_armhf.deb]
+| https://packages.couchbase.com/releases/couchbase-lite-c/3.2.4/libcblite-dev-community_3.2.4-ubuntu20.04_armhf.deb.sha256[libcblite-dev-community_3.2.4-ubuntu20.04_armhf.deb.sha256]
 |
 
 |===

--- a/modules/c/pages/supported-os.adoc
+++ b/modules/c/pages/supported-os.adoc
@@ -8,7 +8,7 @@
 :source-language: c
 
 :source-language: c
-:url-api-references-classes: https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-c}{empty}/couchbase-lite-c/C/html/group__
+:url-api-references-classes: https://docs.couchbase.com/mobile/{major}.{minor-c}.{maintenance-c}/couchbase-lite-c/C/html/group__
 
 
 [abstract]
@@ -83,7 +83,7 @@ Please plan to migrate your apps to use an appropriate alternative version.
 | 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
-.2+| Raspberry Pi OS 
+.2+| Raspberry Pi OS
 | 11 (Bullseye) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
@@ -104,7 +104,7 @@ Please plan to migrate your apps to use an appropriate alternative version.
 | 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
-.2+| Raspberry Pi OS 
+.2+| Raspberry Pi OS
 | 11 (Bullseye) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.3.0.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.3.0.adoc
@@ -1,25 +1,27 @@
-[#maint-3-3-0]
-== 3.3.0 -- September 2025
+[#maint-3-2-4]
+== 3.2.4 -- June 2025
 
-Version 3.3.0 for {param-title} delivers the following features and enhancements:
-
-=== Downgrade Support
-
-Downgrades from 3.3.x to any other version of Couchbase Lite are not supported.
+Version 3.2.4 for {param-title} delivers the following features and enhancements:
 
 === Enhancements
 
-// Lite Core begin
-
-
-// Lite Core end
+* https://jira.issues.couchbase.com/browse/CBL-7004[CBL-7004 -- Add API to Access the TLSIdentity Used by CBLURLEndpointListener]
 
 === Issues and Resolutions
 
-// Lite Core begin
+include::ROOT:partial$release-notes/couchbase-mobile-litecore-release-note.3.2.4.adoc[tags=fixes]
 
-// Lite Core end
+* https://jira.issues.couchbase.com/browse/CBL-7048[CBL-7048 -- Anonymous TLSIdentity Not Regenerated on Listener Restart]
 
+* https://jira.issues.couchbase.com/browse/CBL-7046[CBL-7046 -- Crash When CBLKeyPair_PublicKeyDigest or PublicKeyData Fails to Retrieve External Public Key]
+
+* https://jira.issues.couchbase.com/browse/CBL-7044[CBL-7044 -- Add Missing mbedTLS Error Domain]
+
+* https://jira.issues.couchbase.com/browse/CBL-7041[CBL-7041 -- Invalid or Inconsistent Certificate Locality Key Name]
+
+* https://jira.issues.couchbase.com/browse/CBL-6999[CBL-6999 -- Missing Implementation of CBLReplicator_ServerCertificate for Accessing Server TLS Certificate]
+
+* https://jira.issues.couchbase.com/browse/CBL-6975[CBL-6975 -- CreateIdentity with Persistent Key Crashes Inside Autorelease Pool on iOS ]
 
 === Known Issues
 
@@ -27,6 +29,6 @@ None for this release
 
 === Deprecations
 
-No new deprecations for GA release
+None for this release
 
 NOTE: For an overview of the latest features offered in Couchbase Lite 3.3.0, see xref:ROOT:cbl-whatsnew.adoc[New in 3.3]

--- a/modules/csharp/pages/gs-install.adoc
+++ b/modules/csharp/pages/gs-install.adoc
@@ -19,17 +19,17 @@ _Abstract -- Using Nuget to install Couchbase Lite on csharp_ +
 
 .Quick Steps
 ****
-For experienced developers, this is all you need to add _Couchbase Lite for C#.Net {major}.{minor}.{base}{empty}_ to your application projects.
+For experienced developers, this is all you need to add _Couchbase Lite for C#.Net {major}.{minor-net}.{base}{empty}_ to your application projects.
 
 . Create or open an existing Visual Studio project
 
 . Install either of the following packages from Nuget.
 +
-* Community Edition -- `Couchbase.Lite` package for {major}.{minor}.{base}{empty}
+* Community Edition -- `Couchbase.Lite` package for {major}.{minor-net}.{base}{empty}
 
-* Enterprise Edition -- `Couchbase.Lite.Enterprise` package for {major}.{minor}.{base}{empty}
+* Enterprise Edition -- `Couchbase.Lite.Enterprise` package for {major}.{minor-net}.{base}{empty}
 
-** Vector Search Extension -- `Couchbase.Lite.VectorSearch` package for {vs-major}.{vs-minor}.{vs-maintenance-net}{empty}
+** Vector Search Extension -- `Couchbase.Lite.VectorSearch` package for {vs-major}.{vs-minor-net}.{vs-maintenance-net}{empty}
 
 . Within your app, include a call to the relevant `Activate()` function inside of the class that is included in the support assembly.
 
@@ -163,7 +163,7 @@ include::csharp:example$code_snippets/VectorSearch.cs[tags=vs-setup-packaging]
 .Concepts
 * xref:csharp:landing-p2psync.adoc[Peer-to-Peer Sync]
 
-* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net[API References]
+* https://docs.couchbase.com/mobile/{major}.{minor-net}.{maintenance-net}{empty}/couchbase-lite-net[API References]
 
 .
 

--- a/modules/csharp/pages/gs-install.adoc
+++ b/modules/csharp/pages/gs-install.adoc
@@ -19,17 +19,17 @@ _Abstract -- Using Nuget to install Couchbase Lite on csharp_ +
 
 .Quick Steps
 ****
-For experienced developers, this is all you need to add _Couchbase Lite for C#.Net {major}.{minor-net}.{base}{empty}_ to your application projects.
+For experienced developers, this is all you need to add _Couchbase Lite for C#.Net {major}.{minor-net}.{maintenance-net}_ to your application projects.
 
 . Create or open an existing Visual Studio project
 
 . Install either of the following packages from Nuget.
 +
-* Community Edition -- `Couchbase.Lite` package for {major}.{minor-net}.{base}{empty}
+* Community Edition -- `Couchbase.Lite` package for {major}.{minor-net}.{maintenance-net}
 
-* Enterprise Edition -- `Couchbase.Lite.Enterprise` package for {major}.{minor-net}.{base}{empty}
+* Enterprise Edition -- `Couchbase.Lite.Enterprise` package for {major}.{minor-net}.{maintenance-net}
 
-** Vector Search Extension -- `Couchbase.Lite.VectorSearch` package for {vs-major}.{vs-minor-net}.{vs-maintenance-net}{empty}
+** Vector Search Extension -- `Couchbase.Lite.VectorSearch` package for {vs-major}.{vs-minor}.{vs-maintenance-net}
 
 . Within your app, include a call to the relevant `Activate()` function inside of the class that is included in the support assembly.
 
@@ -163,7 +163,7 @@ include::csharp:example$code_snippets/VectorSearch.cs[tags=vs-setup-packaging]
 .Concepts
 * xref:csharp:landing-p2psync.adoc[Peer-to-Peer Sync]
 
-* https://docs.couchbase.com/mobile/{major}.{minor-net}.{maintenance-net}{empty}/couchbase-lite-net[API References]
+* https://docs.couchbase.com/mobile/{major}.{minor-net}.{maintenance-net}/couchbase-lite-net[API References]
 
 .
 

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.3.0.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.3.0.adoc
@@ -1,26 +1,17 @@
-[#maint-3-3-0]
-== 3.3.0 -- September 2025
+[#maint-3-2-4]
+== 3.2.4 -- June 2025
 
-Version 3.3.0 for {param-title} delivers the following features and enhancements:
-
-=== Downgrade Support
-
-Downgrades from 3.3.x to any other version of Couchbase Lite are not supported.
+Version 3.2.4 for {param-title} delivers the following features and enhancements:
 
 === Enhancements
 
-// Lite Core begin
-
-
-// Lite Core end
-
+None for this release
 
 === Issues and Resolutions
 
-// Lite Core begin
+include::ROOT:partial$release-notes/couchbase-mobile-litecore-release-note.3.2.4.adoc[tags=fixes]
 
-
-// Lite Core end
+* https://jira.issues.couchbase.com/browse/CBL-7016[CBL-7016 -- Invalid or Inconsistent Certificate Locality Key Name]
 
 === Known Issues
 
@@ -28,6 +19,7 @@ None for this release
 
 === Deprecations
 
-No new deprecations for GA release
+None for this release
+
 
 NOTE: For an overview of the latest features offered in Couchbase Lite 3.3.0, see xref:ROOT:cbl-whatsnew.adoc[New in 3.3]

--- a/modules/java/pages/gs-install.adoc
+++ b/modules/java/pages/gs-install.adoc
@@ -19,21 +19,21 @@ Related Content -- xref:java:gs-install.adoc[Install] | xref:java:gs-prereqs.ado
 // include::ROOT:partial$block-related-get-started.adoc[]
 
 
-:url-download-ee: https://packages.couchbase.com/releases/couchbase-lite-java/{major}.{minor}.{base}{empty}/couchbase-lite-java-ee-{major}.{minor}.{base}{empty}.zip[Enterprise Edition]
-:url-download-ce: https://packages.couchbase.com/releases/couchbase-lite-java/{major}.{minor}.{base}{empty}/couchbase-lite-java-{major}.{minor}.{base}{empty}.zip[Community Edition]
+:url-download-ee: https://packages.couchbase.com/releases/couchbase-lite-java/{major}.{minor-java}.{maintenance-java}/couchbase-lite-java-ee-{major}.{minor-java}.{maintenance-java}.zip[Enterprise Edition]
+:url-download-ce: https://packages.couchbase.com/releases/couchbase-lite-java/{major}.{minor-java}.{maintenance-java}/couchbase-lite-java-{major}.{minor-java}.{maintenance-java}.zip[Community Edition]
 
 
 [#introduction]
 == Introduction
 
 
-_Couchbase{nbsp}Lite_ on Java {major}.{minor}.{base}{empty} enables development and deployment of Couchbase{nbsp}Lite applications to a JVM environment.
+_Couchbase{nbsp}Lite_ on Java {major}.{minor-java}.{maintenance-java} enables development and deployment of Couchbase{nbsp}Lite applications to a JVM environment.
 You can deploy Standalone (Java Desktop/Console) apps or Web Apps (using, for example, Tomcat; including embedded Tomcat deployments).
 
 
 .Quick Steps
 ****
-For experienced developers, this is all you need to add _Couchbase{nbsp}Lite for Java {major}.{minor}.{base}{empty}_ to your application projects.
+For experienced developers, this is all you need to add _Couchbase{nbsp}Lite for Java {major}.{minor-java}.{maintenance-java}_ to your application projects.
 
 [tabs]
 =====
@@ -47,7 +47,7 @@ Include the following in your Gradle `build.gradle` or Maven `pom.xml` file, as 
 `https://mobile.maven.couchbase.com/maven2/dev/`
 
 * The Couchbase{nbsp}Lite Enterprise Edition dependency: +
-`couchbase-lite-java-ee:{major}.{minor}.{base}{empty}`
+`couchbase-lite-java-ee:{major}.{minor-java}.{maintenance-java}`
 
 . If you want to use Vector Search, add the Couchbase Lite Vector Search dependency: `couchbase-lite-java-vector-search`
 . You must then use `CouchbaseLite.enableVectorSearch();` to enable the vector search extension.
@@ -58,7 +58,7 @@ Community Edition::
 +
 --
 . Include the Couchbase{nbsp}Lite for Java dependency in your Gradle `build.gradle` or Maven `pom.xml` file, as appropriate: +
-`couchbase-lite-java:{major}.{minor}.{base}{empty}`
+`couchbase-lite-java:{major}.{minor-java}.{maintenance-java}`
 . For Gradle: +
 Check you have `mavenCentral()` in `repositories` (or in `settings.gradle`). +
 Maven automatically checks its own repo for dependencies.
@@ -164,7 +164,7 @@ compileOptions {
 [source,groovy, subs="attributes+"]
 ----
 dependencies {
-    implementation "com.couchbase.lite:couchbase-lite-java:{major}.{minor}.{base}{empty}"
+    implementation "com.couchbase.lite:couchbase-lite-java:{major}.{minor-java}.{maintenance-java}"
 
 //   ... other section content as required by user
 }
@@ -210,7 +210,7 @@ compileOptions {
 [source,groovy, subs="attributes+"]
 ----
 dependencies {
-    implementation "com.couchbase.lite:couchbase-lite-java:{major}.{minor}.{base}{empty}"
+    implementation "com.couchbase.lite:couchbase-lite-java:{major}.{minor-java}.{maintenance-java}"
 
   // All standard 64-bit ARM architectures
   implementation 'com.couchbase.lite:couchbase-lite-java-vector-search-arm64-{vs-major}.{vs-minor}.{vs-maintenance-java}{empty}'
@@ -264,7 +264,7 @@ compileOptions {
 [source,groovy, subs="attributes+"]
 ----
 dependencies {
-    implementation "com.couchbase.lite:couchbase-lite-java:{major}.{minor}.{base}{empty}"
+    implementation "com.couchbase.lite:couchbase-lite-java:{major}.{minor-java}.{maintenance-java}"
 
 //   ... other section content as required by user
 }
@@ -313,7 +313,7 @@ Enterprise Edition::
     <dependency>
       <groupId>com.couchbase.lite</groupId>
       <artifactId>couchbase-lite-java-ee</artifactId>
-      <version>{major}.{minor}.{base}{empty}</version>
+      <version>{major}.{minor-java}.{maintenance-java}</version>
     </dependency>
 
     <!-- ... any other section content as required by user-home  -->
@@ -359,7 +359,7 @@ Community edition::
   <dependency>
       <groupId>com.couchbase.lite</groupId>
       <artifactId>couchbase-lite-java</artifactId>
-      <version>{major}.{minor}.{base}{empty}</version>
+      <version>{major}.{minor-java}.{maintenance-java}</version>
   </dependency>
 
   //   ... any other section content as required by user
@@ -455,7 +455,7 @@ Community::
 [source,groovy,subs=attributes+]
 ----
 dependencies {
-    implementation "com.couchbase.lite:couchbase-lite-java:{major}.{minor}.{base}{empty}"
+    implementation "com.couchbase.lite:couchbase-lite-java:{major}.{minor-java}.{maintenance-java}"
 
 //   ... other section content as required by user
 }
@@ -478,7 +478,7 @@ repositories {
     }
 
 dependencies {
-    implementation "com.couchbase.lite:couchbase-lite-java-ee:{major}.{minor}.{base}{empty}"
+    implementation "com.couchbase.lite:couchbase-lite-java-ee:{major}.{minor-java}.{maintenance-java}"
 
 //   ... other section content as required by user
     }

--- a/modules/java/pages/gs-install.adoc
+++ b/modules/java/pages/gs-install.adoc
@@ -213,7 +213,7 @@ dependencies {
     implementation "com.couchbase.lite:couchbase-lite-java:{major}.{minor-java}.{maintenance-java}"
 
   // All standard 64-bit ARM architectures
-  implementation 'com.couchbase.lite:couchbase-lite-java-vector-search-arm64-{vs-major}.{vs-minor}.{vs-maintenance-java}{empty}'
+  implementation 'com.couchbase.lite:couchbase-lite-java-vector-search-arm64-{vs-major}.{vs-minor}.{vs-maintenance-java}'
 
 //   ... other section content as required by user
 }

--- a/modules/java/pages/gs-prereqs.adoc
+++ b/modules/java/pages/gs-prereqs.adoc
@@ -65,9 +65,9 @@ Before proceeding to xref:java:gs-install.adoc[], you will need to make the supp
 [#steps]
 === Steps
 
-. Download the _zip_ file from here -- https://packages.couchbase.com/releases/couchbase-lite-java/{major}.{minor}.{maintenance-java}{empty}/couchbase-lite-java-linux-supportlibs-{major}.{minor}.{maintenance-java}{empty}.zip
+. Download the _zip_ file from here -- https://packages.couchbase.com/releases/couchbase-lite-java/{major}.{minor-java}.{maintenance-java}/couchbase-lite-java-linux-supportlibs-{major}.{minor-java}.{maintenance-java}.zip
 .
-. Unpack the downloaded file to a location accessible to your build and runtime environments, for example `your_dir/couchbase-lite-java-{major}.{minor}.{maintenance-java}{empty}`.
+. Unpack the downloaded file to a location accessible to your build and runtime environments, for example `your_dir/couchbase-lite-java-{major}.{minor-java}.{maintenance-java}`.
 
 [#bmkLinuxSharedLibs]
 . Set up the Native Libraries for Linux.
@@ -77,7 +77,7 @@ The simplest way to set this is through the shell variable `LD_LIBRARY_PATH`:
 +
 [source,bash,subs="attributes+"]
 ----
-export LD_LIBRARY_PATH=<your_dir>/couchbase-lite-java-{major}.{minor}.{maintenance-java}/:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=<your_dir>/couchbase-lite-java-{major}.{minor-java}.{maintenance-java}/:$LD_LIBRARY_PATH
 ----
 +
 Where `<your_dir>` is the path where you unpacked the support libraries in step 2.

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.3.0.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.3.0.adoc
@@ -1,26 +1,17 @@
-[#maint-3-3-0]
-== 3.3.0 -- September 2025
+[#maint-3-2-4]
+== 3.2.4 -- June 2025
 
-Version 3.3.0 for {param-title} delivers the following features and enhancements:
-
-=== Downgrade Support
-
-Downgrades from 3.3.x to any other version of Couchbase Lite are not supported.
+Version 3.2.4 for {param-title} delivers the following features and enhancements:
 
 === Enhancements
 
-// Lite Core begin
-
-// Lite Core end first ticket below is JAVA ONLY
-
+* https://jira.issues.couchbase.com/browse/CBL-6978[CBL-6978 -- Stopping a Replicator should stop all Conflict Resolutions]
 
 === Issues and Resolutions
 
-// Lite Core begin
+include::ROOT:partial$release-notes/couchbase-mobile-litecore-release-note.3.2.4.adoc[tags=fixes]
 
-
-// Lite Core end first issue below is JAVA ONLY
-
+* https://jira.issues.couchbase.com/browse/CBL-7015[CBL-7015 -- Invalid or Inconsistent Certificate Locality Key Name]
 
 === Known Issues
 
@@ -28,6 +19,6 @@ None for this release
 
 === Deprecations
 
-No new deprecations for GA release
+None for this release
 
 NOTE: For an overview of the latest features offered in Couchbase Lite 3.3.0, see xref:ROOT:cbl-whatsnew.adoc[New in 3.3]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.3.0.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.3.0.adoc
@@ -1,27 +1,34 @@
-[#maint-3-3-0]
-== 3.3.0 -- September 2025
+[#maint-3-2-0]
+== 3.3.0 -- October 2025
 
 Version 3.3.0 for {param-title} delivers the following features and enhancements:
-
-=== Downgrade Support
-
-Downgrades from 3.3.x to any other version of Couchbase Lite are not supported.
 
 === Enhancements
 
 // Lite Core begin
 
+* https://jira.issues.couchbase.com/browse/CBL-6733[CBL-6733 -- Multipeer Replicator for Peer-to-Peer Sync over Wi-Fi]
+* https://jira.issues.couchbase.com/browse/CBL-7195[CBL-7195 -- Upgrade SQLite to 3.50.3]
+* https://jira.issues.couchbase.com/browse/CBL-7206[CBL-7206 -- Update Minimum Supported iOS to 15.0 and macOS to 13.0]
+* https://jira.issues.couchbase.com/browse/CBL-7234[CBL-7234 -- Add API for creating `ReplicatorConfiguration` with collection configs and endpoint]
+* https://jira.issues.couchbase.com/browse/CBL-7360[CBL-7360 -- Update mbedTLS to 3.6.4]
+* https://jira.issues.couchbase.com/browse/CBL-7409[CBL-7409 -- Improve conflict resolution with multiple remotes]
 
 // Lite Core end
-
-
-
 
 === Issues and Resolutions
 
-// Lite Core begin
+==== Fixed Issues
 
-// Lite Core end
+* https://jira.issues.couchbase.com/browse/CBL-6791[CBL-6791 -- Starting a Live Query in the Background May Crash the App]
+* https://jira.issues.couchbase.com/browse/CBL-6799[CBL-6799 -- Potential crash in `URLEndpointListener` due to accessing a NULL responseTimer during stop]
+* https://jira.issues.couchbase.com/browse/CBL-7146[CBL-7146 -- UserAgent shows incorrect info]
+* https://jira.issues.couchbase.com/browse/CBL-7167[CBL-7167 -- Getting non existing TLS Identity using label shouldn't throw an error]
+* https://jira.issues.couchbase.com/browse/CBL-7179[CBL-7179 -- Swift Codable skips nil values during encoding]
+* https://jira.issues.couchbase.com/browse/CBL-7181[CBL-7181 -- Assertion Failure in `URLEndpointListener` Due to Collection Mismatch with Connected Replicator]
+* https://jira.issues.couchbase.com/browse/CBL-7189[CBL-7189 -- Assertion failure caused by pull filter during replication]
+* https://jira.issues.couchbase.com/browse/CBL-7429[CBL-7429 -- Swift Codable Result.data(as:) decoding fails for some ISO8601 formats]
+* https://jira.issues.couchbase.com/browse/CBL-7468[CBL-7468 -- TLS ClientHello missing Server Name when network interface is specified]
 
 
 === Known Issues
@@ -30,6 +37,10 @@ None for this release
 
 === Deprecations
 
-No new deprecations for GA release
+* https://jira.issues.couchbase.com/browse/CBL-6813[CBL-6813 -- Deprecate: removeChangeListenerWithToken for Replicator, Query and MessageEndpointListener]
+* https://jira.issues.couchbase.com/browse/CBL-7008[CBL-7008 -- Deprecate: Create Identity API with Server Flag]
+* https://jira.issues.couchbase.com/browse/CBL-7236[CBL-7236 -- Deprecate: `ReplicatorConfiguration` constructor with a target endpoint only]
+* https://jira.issues.couchbase.com/browse/CBL-7238[CBL-7238 -- Deprecate: `ReplicatorConfiguration` API for managing collection configurations]
+* https://jira.issues.couchbase.com/browse/CBL-7240[CBL-7240 -- Deprecate: `CollectionConfiguration` constructor without collection]
 
 NOTE: For an overview of the latest features offered in Couchbase Lite 3.3.0, see xref:ROOT:cbl-whatsnew.adoc[New in 3.3]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.3.0.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.3.0.adoc
@@ -1,4 +1,4 @@
-[#maint-3-2-0]
+[#maint-3-3-0]
 == 3.3.0 -- October 2025
 
 Version 3.3.0 for {param-title} delivers the following features and enhancements:

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.3.0.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.3.0.adoc
@@ -1,5 +1,5 @@
 [#maint-3-2-0]
-== 3.3.0 -- September 2025
+== 3.3.0 -- October 2025
 
 Version 3.3.0 for {param-title} delivers the following features and enhancements:
 

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.3.0.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.3.0.adoc
@@ -1,4 +1,4 @@
-[#maint-3-2-0]
+[#maint-3-3-0]
 == 3.3.0 -- October 2025
 
 Version 3.3.0 for {param-title} delivers the following features and enhancements:


### PR DESCRIPTION
PR to update download links for Java, .NET, C#. I also updated antora.yml because they do not all have the same minor and maintenance versions 

Preview:

- [C download links](https://preview.docs-test.couchbase.com/docs-couchbase-lite-update-version-c-csharp-java/couchbase-lite/current/c/gs-downloads.html#macos-3-2-4)
- [C Install CBL C page](https://preview.docs-test.couchbase.com/docs-couchbase-lite-update-version-c-csharp-java/couchbase-lite/current/c/gs-install.html)
- [C Release Note](https://preview.docs-test.couchbase.com/docs-couchbase-lite-update-version-c-csharp-java/couchbase-lite/current/c/releasenotes.html)
- [.NET install page](https://preview.docs-test.couchbase.com/docs-couchbase-lite-update-version-c-csharp-java/couchbase-lite/current/csharp/gs-install.html)
- [.NET Release note](https://preview.docs-test.couchbase.com/docs-couchbase-lite-update-version-c-csharp-java/couchbase-lite/current/csharp/releasenotes.html)
- [Java Install Page](https://preview.docs-test.couchbase.com/docs-couchbase-lite-update-version-c-csharp-java/couchbase-lite/current/java/gs-install.html)
- [Java Release note](https://preview.docs-test.couchbase.com/docs-couchbase-lite-update-version-c-csharp-java/couchbase-lite/current/java/releasenotes.html)
- [Obj-C Release Note](https://preview.docs-test.couchbase.com/docs-couchbase-lite-update-version-c-csharp-java/couchbase-lite/current/objc/releasenotes.html)