### PR TITLE
Update Couchbase Lite C API doc by removing outdated links

### DIFF
--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -198,51 +198,13 @@ Enterprise Edition::
 | {source_url}libcblite-dev-enterprise_{our-version}-debian11_armhf.deb.sha256[libcblite-dev-enterprise_{our-version}-debian11_armhf.deb.sha256]
 |
 
-
-// Debian 10
-| {source_url}libcblite-enterprise_{our-version}-debian10_amd64.deb[libcblite-enterprise_{our-version}-debian10_amd64.deb]
-| {source_url}libcblite-enterprise_{our-version}-debian10_amd64.deb.sha256[libcblite-enterprise_{our-version}-debian10_amd64.deb.sha256]
+| {source_url}libcblite-dev-enterprise_{our-version}-debian12_armhf.deb[libcblite-dev-enterprise_{our-version}-debian12_armhf.deb]
+| {source_url}libcblite-dev-enterprise_{our-version}-debian12_armhf.deb.sha256[libcblite-dev-enterprise_{our-version}-debian12_armhf.deb.sha256]
 |
 
-| {source_url}libcblite-dev-enterprise_{our-version}-debian10_amd64.deb[libcblite-dev-enterprise_{our-version}-debian10_amd64.deb]
-| {source_url}libcblite-dev-enterprise_{our-version}-debian10_amd64.deb.sha256[libcblite-dev-enterprise_{our-version}-debian10_amd64.deb.sha256]
+| {source_url}libcblite-dev-enterprise_{our-version}-debian13_armhf.deb[libcblite-dev-enterprise_{our-version}-debian13_armhf.deb]
+| {source_url}libcblite-dev-enterprise_{our-version}-debian13_armhf.deb.sha256[libcblite-dev-enterprise_{our-version}-debian13_armhf.deb.sha256]
 |
-
-| {source_url}libcblite-enterprise_{our-version}-debian10_arm64.deb[libcblite-enterprise_{our-version}-debian10_arm64.deb]
-| {source_url}libcblite-enterprise_{our-version}-debian10_arm64.deb.sha256[libcblite-enterprise_{our-version}-debian10_arm64.deb.sha256]
-|
-
-| {source_url}libcblite-dev-enterprise_{our-version}-debian10_arm64.deb[libcblite-dev-enterprise_{our-version}-debian10_arm64.deb]
-| {source_url}libcblite-dev-enterprise_{our-version}-debian10_arm64.deb.sha25[libcblite-dev-enterprise_{our-version}-debian10_arm64.deb.sha256]
-|
-
-| {source_url}libcblite-enterprise_{our-version}-debian10_armhf.deb[libcblite-enterprise_{our-version}-debian10_armhf.deb]
-| {source_url}libcblite-enterprise_{our-version}-debian10_armhf.deb.sha256[libcblite-enterprise_{our-version}-debian10_armhf.deb.sha256]
-|
-
-| {source_url}libcblite-dev-enterprise_{our-version}-debian10_armhf.deb[libcblite-dev-enterprise_{our-version}-debian10_armhf.deb]
-| {source_url}libcblite-dev-enterprise_{our-version}-debian10_armhf.deb.sha256[libcblite-dev-enterprise_{our-version}-debian10_armhf.deb.sha256]
-|
-
-
-// Debian 9
-| {source_url}libcblite-enterprise_{our-version}-debian9_amd64.deb[libcblite-enterprise_{our-version}-debian9_amd64.deb]
-| {source_url}libcblite-enterprise_{our-version}-debian9_amd64.deb.sha256[libcblite-enterprise_{our-version}-debian9_amd64.deb.sha256]
-|
-
-| {source_url}libcblite-dev-enterprise_{our-version}-debian9_amd64.deb[libcblite-dev-enterprise_{our-version}-debian9_amd64.deb]
-| {source_url}libcblite-dev-enterprise_{our-version}-debian9_amd64.deb.sha256[libcblite-dev-enterprise_{our-version}-debian9_amd64.deb.sha256]
-|
-
-
-| {source_url}libcblite-enterprise_{our-version}-debian9_armhf.deb[libcblite-enterprise_{our-version}-debian9_armhf.deb]
-| {source_url}libcblite-enterprise_{our-version}-debian9_armhf.deb.sha256[libcblite-enterprise_{our-version}-debian9_armhf.deb.sha256]
-|
-
-| {source_url}libcblite-dev-enterprise_{our-version}-debian9_armhf.deb[libcblite-dev-enterprise_{our-version}-debian9_armhf.deb]
-| {source_url}libcblite-dev-enterprise_{our-version}-debian9_armhf.deb.sha256[libcblite-dev-enterprise_{our-version}-debian9_armhf.deb.sha256]
-|
-
 |===
 --
 
@@ -292,51 +254,13 @@ Community Edition::
 | {source_url}libcblite-dev-community_{our-version}-debian11_armhf.deb.sha256[libcblite-dev-community_{our-version}-debian11_armhf.deb.sha256]
 |
 
-
-// Debian 10
-| {source_url}libcblite-community_{our-version}-debian10_amd64.deb[libcblite-community_{our-version}-debian10_amd64.deb]
-| {source_url}libcblite-community_{our-version}-debian10_amd64.deb.sha256[libcblite-community_{our-version}-debian10_amd64.deb.sha256]
+| {source_url}libcblite-dev-community_{our-version}-debian12_armhf.deb[libcblite-dev-community_{our-version}-debian12_armhf.deb]
+| {source_url}libcblite-dev-community_{our-version}-debian12_armhf.deb.sha256[libcblite-dev-community_{our-version}-debian12_armhf.deb.sha256]
 |
 
-| {source_url}libcblite-dev-community_{our-version}-debian10_amd64.deb[libcblite-dev-community_{our-version}-debian10_amd64.deb]
-| {source_url}libcblite-dev-community_{our-version}-debian10_amd64.deb.sha256[libcblite-dev-community_{our-version}-debian10_amd64.deb.sha256]
+| {source_url}libcblite-dev-community_{our-version}-debian13_armhf.deb[libcblite-dev-community_{our-version}-debian13_armhf.deb]
+| {source_url}libcblite-dev-community_{our-version}-debian13_armhf.deb.sha256[libcblite-dev-community_{our-version}-debian13_armhf.deb.sha256]
 |
-
-| {source_url}libcblite-community_{our-version}-debian10_arm64.deb[libcblite-community_{our-version}-debian10_arm64.deb]
-| {source_url}libcblite-community_{our-version}-debian10_arm64.deb.sha256[libcblite-community_{our-version}-debian10_arm64.deb.sha256]
-|
-
-| {source_url}libcblite-dev-community_{our-version}-debian10_arm64.deb[libcblite-dev-community_{our-version}-debian10_arm64.deb]
-| {source_url}libcblite-dev-community_{our-version}-debian10_arm64.deb.sha256[libcblite-dev-community_{our-version}-debian10_arm64.deb.sha256]
-|
-
-| {source_url}libcblite-community_{our-version}-debian10_armhf.deb[libcblite-community_{our-version}-debian10_armhf.deb]
-| {source_url}libcblite-community_{our-version}-debian10_armhf.deb.sha256[libcblite-community_{our-version}-debian10_armhf.deb.sha256]
-|
-
-| {source_url}libcblite-dev-community_{our-version}-debian10_armhf.deb[libcblite-dev-community_{our-version}-debian10_armhf.deb]
-| {source_url}libcblite-dev-community_{our-version}-debian10_armhf.deb.sha256[libcblite-dev-community_{our-version}-debian10_armhf.deb.sha256]
-|
-
-
-// Debian 9
-| {source_url}libcblite-community_{our-version}-debian9_amd64.deb[libcblite-community_{our-version}-debian9_amd64.deb]
-| {source_url}libcblite-community_{our-version}-debian9_amd64.deb.sha256[libcblite-community_{our-version}-debian9_amd64.deb.sha256]
-|
-
-| {source_url}libcblite-dev-community_{our-version}-debian9_amd64.deb[libcblite-dev-community_{our-version}-debian9_amd64.deb]
-| {source_url}libcblite-dev-community_{our-version}-debian9_amd64.deb.sha256[libcblite-dev-community_{our-version}-debian9_amd64.deb.sha256]
-|
-
-
-| {source_url}libcblite-community_{our-version}-debian9_armhf.deb[libcblite-community_{our-version}-debian9_armhf.deb]
-| {source_url}libcblite-community_{our-version}-debian9_armhf.deb.sha256[libcblite-community_{our-version}-debian9_armhf.deb.sha256]
-|
-
-| {source_url}libcblite-dev-community_{our-version}-debian9_armhf.deb[libcblite-dev-community_{our-version}-debian9_armhf.deb]
-| {source_url}libcblite-dev-community_{our-version}-debian9_armhf.deb.sha256[libcblite-dev-community_{our-version}-debian9_armhf.deb.sha256]
-|
-
 |===
 
 --
@@ -400,33 +324,9 @@ Enterprise Edition::
 | {source_url}libcblite-dev-enterprise_{our-version}-ubuntu22.04_armhf.deb.sha256[libcblite-dev-enterprise_{our-version}-ubuntu22.04_armhf.deb.sha256]
 |
 
-
-// Ubuntu 20.04
-| {source_url}libcblite-enterprise_{our-version}-ubuntu20.04_amd64.deb[libcblite-enterprise_{our-version}-ubuntu20.04_amd64.deb]
-| {source_url}libcblite-enterprise_{our-version}-ubuntu20.04_amd64.deb.sha256[libcblite-enterprise_{our-version}-ubuntu20.04_amd64.deb.sha256]
+| {source_url}libcblite-dev-enterprise_{our-version}-ubuntu24.04_armhf.deb[libcblite-dev-enterprise_{our-version}-ubuntu24.04_armhf.deb]
+| {source_url}libcblite-dev-enterprise_{our-version}-ubuntu24.04_armhf.deb.sha256[libcblite-dev-enterprise_{our-version}-ubuntu24.04_armhf.deb.sha256]
 |
-
-| {source_url}libcblite-dev-enterprise_{our-version}-ubuntu20.04_amd64.deb[libcblite-dev-enterprise_{our-version}-ubuntu20.04_amd64.deb]
-| {source_url}libcblite-dev-enterprise_{our-version}-ubuntu20.04_amd64.deb.sha256[libcblite-dev-enterprise_{our-version}-ubuntu20.04_amd64.deb.sha256]
-|
-
-| {source_url}libcblite-enterprise_{our-version}-ubuntu20.04_arm64.deb[libcblite-enterprise_{our-version}-ubuntu20.04_arm64.deb]
-| {source_url}libcblite-enterprise_{our-version}-ubuntu20.04_arm64.deb.sha256[libcblite-enterprise_{our-version}-ubuntu20.04_arm64.deb.sha256]
-|
-
-| {source_url}libcblite-dev-enterprise_{our-version}-ubuntu20.04_arm64.deb[libcblite-dev-enterprise_{our-version}-ubuntu20.04_arm64.deb]
-| {source_url}libcblite-dev-enterprise_{our-version}-ubuntu20.04_arm64.deb.sha256[libcblite-dev-enterprise_{our-version}-ubuntu20.04_arm64.deb.sha256]
-|
-
-| {source_url}libcblite-enterprise_{our-version}-ubuntu20.04_armhf.deb[libcblite-enterprise_{our-version}-ubuntu20.04_armhf.deb]
-| {source_url}libcblite-enterprise_{our-version}-ubuntu20.04_armhf.deb.sha256[libcblite-enterprise_{our-version}-ubuntu20.04_armhf.deb.sha256]
-|
-
-| {source_url}libcblite-dev-enterprise_{our-version}-ubuntu20.04_armhf.deb[libcblite-dev-enterprise_{our-version}-ubuntu20.04_armhf.deb]
-| {source_url}libcblite-dev-enterprise_{our-version}-ubuntu20.04_armhf.deb.sha256[libcblite-dev-enterprise_{our-version}-ubuntu20.04_armhf.deb.sha256]
-|
-
-
 |===
 --
 
@@ -477,30 +377,8 @@ Community Edition::
 | {source_url}libcblite-dev-community_{our-version}-ubuntu22.04_armhf.deb.sha256[libcblite-dev-community_{our-version}-ubuntu22.04_armhf.deb.sha256]
 |
 
-
-// Ubuntu 20.04
-| {source_url}libcblite-community_{our-version}-ubuntu20.04_amd64.deb[libcblite-community_{our-version}-ubuntu20.04_amd64.deb]
-| {source_url}libcblite-community_{our-version}-ubuntu20.04_amd64.deb.sha256[libcblite-community_{our-version}-ubuntu20.04_amd64.deb.sha256]
-|
-
-| {source_url}libcblite-dev-community_{our-version}-ubuntu20.04_amd64.deb[libcblite-dev-community_{our-version}-ubuntu20.04_amd64.deb]
-| {source_url}libcblite-dev-community_{our-version}-ubuntu20.04_amd64.deb.sha256[libcblite-dev-community_{our-version}-ubuntu20.04_amd64.deb.sha256]
-|
-
-| {source_url}libcblite-community_{our-version}-ubuntu20.04_arm64.deb[libcblite-community_{our-version}-ubuntu20.04_arm64.deb]
-| {source_url}libcblite-community_{our-version}-ubuntu20.04_arm64.deb.sha256[libcblite-community_{our-version}-ubuntu20.04_arm64.deb.sha256]
-|
-
-| {source_url}libcblite-dev-community_{our-version}-ubuntu20.04_arm64.deb[libcblite-dev-community_{our-version}-ubuntu20.04_arm64.deb]
-| {source_url}libcblite-dev-community_{our-version}-ubuntu20.04_arm64.deb.sha256[libcblite-dev-community_{our-version}-ubuntu20.04_arm64.deb.sha256]
-|
-
-| {source_url}libcblite-community_{our-version}-ubuntu20.04_armhf.deb[libcblite-community_{our-version}-ubuntu20.04_armhf.deb]
-| {source_url}libcblite-community_{our-version}-ubuntu20.04_armhf.deb.sha256[libcblite-community_{our-version}-ubuntu20.04_armhf.deb.sha256]
-|
-
-| {source_url}libcblite-dev-community_{our-version}-ubuntu20.04_armhf.deb[libcblite-dev-community_{our-version}-ubuntu20.04_armhf.deb]
-| {source_url}libcblite-dev-community_{our-version}-ubuntu20.04_armhf.deb.sha256[libcblite-dev-community_{our-version}-ubuntu20.04_armhf.deb.sha256]
+| {source_url}libcblite-dev-community_{our-version}-ubuntu24.04_armhf.deb[libcblite-dev-community_{our-version}-ubuntu24.04_armhf.deb]
+| {source_url}libcblite-dev-community_{our-version}-ubuntu24.04_armhf.deb.sha256[libcblite-dev-community_{our-version}-ubuntu24.04_armhf.deb.sha256]
 |
 
 |===


### PR DESCRIPTION
JIRA ticket: https://jira.issues.couchbase.com/browse/DOC-13683

**Summary of Changes:**
- Removed outdated download links for Debian 9/10 and Ubuntu 20.04 in the Couchbase Lite C API documentation.


Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13683-CBL-C-SDK-4.0.0-Download-Links--Couchbase-Docs/couchbase-lite/current/c/gs-downloads.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.