### PR TITLE
[DOC-13701]: Feedback on Couchbase Lite on Swift | Couchbase Docs

### DIFF
--- a/modules/c/pages/quickstart.adoc
+++ b/modules/c/pages/quickstart.adoc
@@ -1,6 +1,7 @@
 = Couchbase Lite on C
 :page-aliases: c.adoc, c:index.adoc
-:page-layout: landing-page-core-concept
+:page-layout: landing-page-capella
+:!sectids:
 :page-role: tiles, -toc
 :description: Start your Couchbase for Mobile and Edge adventure, get up and running with Couchbase Lite
 
@@ -10,110 +11,57 @@
 :source-language: c
 :url-api-references-classes: https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-c}{empty}/couchbase-lite-c/C/html/group__
 
-
-= Couchbase Lite on C
-// ++++
-// <div class="card-row">
-// ++++
-// // DO NOT EDIT
-// // include::ROOT:partial$block-related-howto-p2psync-ws.adoc[]
-// // include::ROOT:partial$_show_page_header_block.adoc[]
-// // DO NOT EDIT
-
-// [.column]
-// ====== {empty}
-// [.content]
-// Some random text goes here
-
-// [.column]
-// ====== {empty}
-// [.media-left]
-// image::https://docs.couchbase.com/home/_images/get-the-agility-of-sql-and-the-flexibility-of-json.svg[,200]
-
-// ++++
-// </div>
-// ++++
-
-// == {empty}
-// ++++
-// <div class="card-row three-column-row">
-// ++++
-
-++++
-<div class="card-row">
-++++
-
-[.column]
-== {empty}
-[.content]
 Couchbase Lite is an embedded, NoSQL JSON Document Style database for your mobile apps.
 
 You can use Couchbase Lite as a standalone embedded database within your mobile apps, or with Sync Gateway and Couchbase Server to provide a complete cloud to edge synchronized solution
-[.column]
-== {empty}
-[.media-left]
-image::ROOT:manage-and-store-data-locally.svg[,250]
-++++
-</div>
-++++
-== C Resources
-++++
-<div class="card-row three-column-row">
-++++
 
-[.column]
-=== {empty}
-[.content]
-.Get Started
+[.centered.card-container]
+== How Do You Want To Start Building Today?
+
+[.card-box]
+=== icon:rocket[] Get Started with C
+
+Get set up with an account and deploy a free tier operational cluster.
+
 * xref:c:gs-downloads.adoc[Download]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build]
-* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-c}{empty}/couchbase-lite-c/C/html[Browse API References ...]
+* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-c}/couchbase-lite-c/C/html/modules.html[Browse API References]
 
-[.column]
-=== {empty}
-[.content]
-.Do More
+[.card-box]
+=== icon:tools[] Do More
+
+Explore advanced features and capabilities.
+
 * xref:c:replication.adoc[Data Sync]
 * xref:c:query-n1ql-mobile.adoc[{sqlpp} for Mobile]
 * xref:c:query-live.adoc[Live Query]
 
+[.card-box]
+=== icon:book[] Learn More
 
-[.column]
-=== {empty}
-[.content]
-.Learn More
+Dive deeper into core concepts and components.
+
 * xref:c:database.adoc[Database]
 * xref:c:document.adoc[Document]
 * xref:c:blob.adoc[Blob]
 
-[.column]
-=== {empty}
-[.content]
-.Key Concepts
+[.card-box]
+=== icon:lightbulb[] Key Concepts
+
+Understand fundamental principles and best practices.
+
 * xref:c:conflict.adoc[Conflicts]
 * xref:c:indexing.adoc[Indexing]
 
-[.column]
-=== {empty}
-[.content]
-.Product Notes
+[.card-box]
+=== icon:file-text[] Product Notes
+
+Stay updated with the latest releases and platform support.
+
 * xref:ROOT:cbl-whatsnew.adoc[New in {release}]
 * xref:c:releasenotes.adoc[Couchbase Lite Release Notes]
 * xref:c:vs-releasenotes.adoc[Vector Search Release Notes]
 * xref:c:supported-os.adoc[Supported Platforms]
 
-[.column]
-=== {empty}
-[.content]
-
-++++
-</div>
-++++
-
-
 // include::ROOT:partial$block-related-content-p2psync.adoc[]
-
-
-== Start Here!
-

--- a/modules/csharp/pages/quickstart.adoc
+++ b/modules/csharp/pages/quickstart.adoc
@@ -1,5 +1,6 @@
 :page-aliases: csharp.adoc
-:page-layout: landing-page-core-concept
+:page-layout: landing-page-capella
+:!sectids:
 :page-role: tiles, -toc
 :description: Start your Couchbase for Mobile and Edge adventure, get up and running with Couchbase Lite
 
@@ -9,80 +10,56 @@
 
 = Couchbase Lite on C#.Net
 
-++++
-<div class="card-row">
-++++
-
-[.column]
-== {empty}
-[.content]
 Couchbase Lite is an embedded, NoSQL JSON Document Style database for your mobile apps.
 
 You can use Couchbase Lite as a standalone embedded database within your mobile apps, or with Sync Gateway and Couchbase Server to provide a complete cloud to edge synchronized solution
-[.column]
-== {empty}
-[.media-left]
-image::ROOT:manage-and-store-data-locally.svg[,250]
-++++
-</div>
-++++
-== C#.Net Resources
-++++
-<div class="card-row three-column-row">
-++++
 
-[.column]
-=== {empty}
-[.content]
-.Get Started
+[.centered.card-container]
+== How Do You Want To Start Building Today?
+
+[.card-box]
+=== icon:rocket[] Get Started with C#.Net
+
+Get set up with an account and deploy a free tier operational cluster.
+
 * xref:csharp:gs-install.adoc[Install]
 * xref:csharp:gs-build.adoc[Build]
-* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}{empty}/couchbase-lite-net[Browse API References ...]
+// * https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-net}/couchbase-lite-net[Browse API References]
 
-[.column]
-=== {empty}
-[.content]
-.Do More
+[.card-box]
+=== icon:tools[] Do More
+
+Explore advanced features and capabilities.
+
 * xref:csharp:replication.adoc[Data Sync]
 * xref:csharp:query-n1ql-mobile.adoc[{sqlpp} for Mobile]
 * xref:csharp:query-live.adoc[Live Query]
 
+[.card-box]
+=== icon:book[] Learn More
 
-[.column]
-=== {empty}
-[.content]
-.Learn More
+Dive deeper into core concepts and components.
+
 * xref:csharp:database.adoc[Database]
 * xref:csharp:document.adoc[Document]
 * xref:csharp:blob.adoc[Blob]
 
-[.column]
-=== {empty}
-[.content]
-.Key Concepts
+[.card-box]
+=== icon:lightbulb[] Key Concepts
+
+Understand fundamental principles and best practices.
+
 * xref:csharp:conflict.adoc[Conflicts]
 * xref:csharp:indexing.adoc[Indexing]
 
-[.column]
-=== {empty}
-[.content]
-.Product Notes
+[.card-box]
+=== icon:file-text[] Product Notes
+
+Stay updated with the latest releases and platform support.
+
 * xref:ROOT:cbl-whatsnew.adoc[New in {release}]
 * xref:csharp:releasenotes.adoc[Couchbase Lite Release Notes]
 * xref:csharp:vs-releasenotes.adoc[Vector Search Release Notes]
 * xref:csharp:supported-os.adoc[Supported Platforms]
 
-[.column]
-=== {empty}
-[.content]
-
-++++
-</div>
-++++
-
-
 // include::ROOT:partial$block-related-content-p2psync.adoc[]
-
-
-== Start Here!
-

--- a/modules/java/pages/quickstart.adoc
+++ b/modules/java/pages/quickstart.adoc
@@ -1,88 +1,64 @@
 :page-aliases: java-platform.adoc
-:page-layout: landing-page-core-concept
+:page-layout: landing-page-capella
+:!sectids:
 :page-role: tiles, -toc
 :description: Start your Couchbase for Mobile and Edge adventure, get up and running with Couchbase Lite
 
 
 :source-language: Java
 
-
 = Couchbase Lite on Java
 
-++++
-<div class="card-row">
-++++
-
-[.column]
-== {empty}
-[.content]
 Couchbase Lite is an embedded, NoSQL JSON Document Style database for your mobile apps.
 
 You can use Couchbase Lite as a standalone embedded database within your mobile apps, or with Sync Gateway and Couchbase Server to provide a complete cloud to edge synchronized solution
-[.column]
-== {empty}
-[.media-left]
-image::ROOT:manage-and-store-data-locally.svg[,250]
-++++
-</div>
-++++
-== Java Resources
-++++
-<div class="card-row three-column-row">
-++++
 
-[.column]
-=== {empty}
-[.content]
-.Get Started
+[.centered.card-container]
+== How Do You Want To Start Building Today?
+
+[.card-box]
+=== icon:rocket[] Get Started with Java
+
+Get set up with an account and deploy a free tier operational cluster.
+
 * xref:java:gs-install.adoc[Install]
 * xref:java:gs-build.adoc[Build]
-* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-java}{empty}/couchbase-lite-java/[Browse API References ...]
+* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-java}/couchbase-lite-java/[Browse API References]
 
-[.column]
-=== {empty}
-[.content]
-.Do More
+[.card-box]
+=== icon:tools[] Do More
+
+Explore advanced features and capabilities.
+
 * xref:java:replication.adoc[Data Sync]
 * xref:java:query-n1ql-mobile.adoc[{sqlpp} for Mobile]
 * xref:java:query-live.adoc[Live Query]
 
+[.card-box]
+=== icon:book[] Learn More
 
-[.column]
-=== {empty}
-[.content]
-.Learn More
+Dive deeper into core concepts and components.
+
 * xref:java:database.adoc[Database]
 * xref:java:document.adoc[Document]
 * xref:java:blob.adoc[Blob]
 
-[.column]
-=== {empty}
-[.content]
-.Key Concepts
+[.card-box]
+=== icon:lightbulb[] Key Concepts
+
+Understand fundamental principles and best practices.
+
 * xref:java:conflict.adoc[Conflicts]
 * xref:java:indexing.adoc[Indexing]
 
-[.column]
-=== {empty}
-[.content]
-.Product Notes
+[.card-box]
+=== icon:file-text[] Product Notes
+
+Stay updated with the latest releases and platform support.
+
 * xref:ROOT:cbl-whatsnew.adoc[New in {release}]
 * xref:java:releasenotes.adoc[Couchbase Lite Release Notes]
 * xref:java:vs-releasenotes.adoc[Vector Search Release Notes]
 * xref:java:supported-os.adoc[Supported Platforms]
 
-[.column]
-=== {empty}
-[.content]
-
-++++
-</div>
-++++
-
-
 // include::ROOT:partial$block-related-content-p2psync.adoc[]
-
-
-== Start Here!
-

--- a/modules/javascript/pages/quickstart.adoc
+++ b/modules/javascript/pages/quickstart.adoc
@@ -1,71 +1,33 @@
-= Couchbase Lite on Javascript
-:page-role: tiles, -toc
-:page-layout: landing-page-core-concept
+:page-aliases: java-platform.adoc
+:page-layout: landing-page-capella
 :!sectids:
-ifdef::show_edition[:page-edition: {release}]
-ifdef::prerelease[:page-status: {prerelease}]
+:page-role: tiles, -toc
+:description: Start your Couchbase for Mobile and Edge adventure, get up and running with Couchbase Lite
 
-= Couchbase Lite on Javascript
 
-++++
-<div class="card-row">
-++++
+= Couchbase Lite on JavaScript
 
-[.column]
-====== {empty}
-[.content]
 Couchbase Lite is an embedded, NoSQL JSON Document Style database for your mobile apps.
 
 You can use Couchbase Lite as a standalone embedded database within your mobile apps, or with Sync Gateway and Couchbase Server to provide a complete cloud to edge synchronized solution
-[.column]
-====== {empty}
-[.media-left]
-image::ROOT:manage-and-store-data-locally.svg[,250]
-++++
-</div>
-++++
-== Javascript Resources
-++++
-<div class="card-row three-column-row">
-++++
 
-[.column]
-====== {empty}
-[.content]
-.xref:javascript:ionic.adoc[Ionic]
+[.centered.card-container]
+== How Do You Want To Start Building Today?
 
+[.card-box]
+=== icon:rocket[] Get started with Ionic
+
+* xref:javascript:ionic.adoc[Ionic]
 * https://capacitorjs.com/docs/plugins[Capacitor]
-
 * https://cbl-ionic.dev[Plugin{nbsp}Documentation]
-
 * https://ionic.io/docs/couchbase-lite/tutorials/hotel-search[Tutorial]
 
-[.column]
-====== {empty}
-[.content]
-.xref:javascript:react.adoc[React]
+[.card-box]
+=== icon:tools[] Get started with React
 
+* xref:javascript:react.adoc[React]
 * https://reactnative.dev/docs/native-modules-intro[React Native Modules]
-
-* https://cbl-reactnative.dev[Plugin Documentation]
-
 * https://github.com/couchbase-examples/expo-cbl-travel[Example Project]
 
 
-[.column]
-====== {empty}
-[.content]
-.Key Concepts
 
-[.column]
-====== {empty}
-[.content]
-.Product Notes
-
-[.column]
-====== {empty}
-[.content]
-
-++++
-</div>
-++++

--- a/modules/swift/pages/quickstart.adoc
+++ b/modules/swift/pages/quickstart.adoc
@@ -1,5 +1,6 @@
 :page-aliases: swift.adoc
-:page-layout: landing-page-core-concept
+:page-layout: landing-page-capella
+:!sectids:
 :page-role: tiles, -toc
 :description: Start your Couchbase for Mobile and Edge adventure, get up and running with Couchbase Lite
 
@@ -10,107 +11,49 @@
 
 
 = Couchbase Lite on Swift
-// ++++
-// <div class="card-row">
-// ++++
-// // DO NOT EDIT
-// // include::ROOT:partial$block-related-howto-p2psync-ws.adoc[]
-// // include::ROOT:partial$_show_page_header_block.adoc[]
-// // DO NOT EDIT
 
-// [.column]
-// ====== {empty}
-// [.content]
-// Some random text goes here
-
-// [.column]
-// ====== {empty}
-// [.media-left]
-// image::https://docs.couchbase.com/home/_images/get-the-agility-of-sql-and-the-flexibility-of-json.svg[,200]
-
-// ++++
-// </div>
-// ++++
-
-// == {empty}
-// ++++
-// <div class="card-row three-column-row">
-// ++++
-
-++++
-<div class="card-row">
-++++
-
-[.column]
-== {empty}
-[.content]
 Couchbase Lite is an embedded, NoSQL JSON Document Style database for your mobile apps.
 
 You can use Couchbase Lite as a standalone embedded database within your mobile apps, or with Sync Gateway and Couchbase Server to provide a complete cloud to edge synchronized solution
-[.column]
-== {empty}
-[.media-left]
-image::ROOT:manage-and-store-data-locally.svg[,250]
-++++
-</div>
-++++
-== Swift Resources
-++++
-<div class="card-row three-column-row">
-++++
 
-[.column]
-=== {empty}
-[.content]
-.Get Started
+[.centered.card-container]
+== How Do You Want To Start Building Today?
+
+[.card-box]
+=== icon:rocket[] Get Started with Swift
+
+Get set up with an account and deploy a free tier operational cluster.
+
 * xref:swift:gs-install.adoc[Install]
 * xref:swift:gs-build.adoc[Build]
-* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{empty}/couchbase-lite-swift[Browse API References ...]
+* https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-ios}{empty}/couchbase-lite-swift[Browse API References]
 
-[.column]
-=== {empty}
-[.content]
-.Do More
+[.card-box]
+=== icon:tools[] Do More
+
+Explore advanced features and capabilities.
+
 * xref:swift:replication.adoc[Data Sync]
 * xref:swift:query-n1ql-mobile.adoc[{sqlpp} for Mobile]
 * xref:swift:query-live.adoc[Live Query]
 
+[.card-box]
+=== icon:book[] Learn More
 
-[.column]
-=== {empty}
-[.content]
-.Learn More
+Dive deeper into core concepts and components.
+
 * xref:swift:database.adoc[Database]
 * xref:swift:document.adoc[Document]
 * xref:swift:blob.adoc[Blob]
 
-[.column]
-=== {empty}
-[.content]
-.Key Concepts
-* xref:swift:conflict.adoc[Conflicts]
-* xref:swift:indexing.adoc[Indexing]
+[.card-box]
+=== icon:file-text[] Product Notes
 
-[.column]
-=== {empty}
-[.content]
-.Product Notes
+Stay updated with the latest releases and platform support.
+
 * xref:ROOT:cbl-whatsnew.adoc[New in {release}]
 * xref:swift:releasenotes.adoc[Couchbase Lite Release Notes]
 * xref:swift:vs-releasenotes.adoc[Vector Search Release Notes]
 * xref:swift:supported-os.adoc[Supported Platforms]
 
-[.column]
-=== {empty}
-[.content]
-
-++++
-</div>
-++++
-
-
 // include::ROOT:partial$block-related-content-p2psync.adoc[]
-
-
-== Start Here!
-


### PR DESCRIPTION
Changing the quick start pages so they all use the same layout.

Note that there is no API docs for C# version 4.0, so the link has been commented out temporarily.

----
Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13701--Feedback-on-Couchbase-Lite-on-Swift--Couchbase-Docs

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.