### PR TITLE
DOC-13776 remove the prereqs from cbl -c page

### DIFF
--- a/modules/c/pages/blob.adoc
+++ b/modules/c/pages/blob.adoc
@@ -101,7 +101,6 @@ image::ROOT:attach-replicated.png[]
 [.column]
 === {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/c_fleece.adoc
+++ b/modules/c/pages/c_fleece.adoc
@@ -336,7 +336,6 @@ https://github.com/couchbaselabs/fleece/wiki/Advanced-Fleece#for-memory-manageme
 [.column]
 === {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/database.adoc
+++ b/modules/c/pages/database.adoc
@@ -349,7 +349,6 @@ Note that the `cblite` tool is not supported by the https://www.couchbase.com/su
 [.column]
 === {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/document.adoc
+++ b/modules/c/pages/document.adoc
@@ -666,7 +666,6 @@ If your query selects a sub-set of available properties then the JSON format wil
 [.column]
 === {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 
@@ -709,7 +708,6 @@ https://docs.couchbase.com/tutorials/[Tutorials]
 [.column]
 === {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/field-level-encryption.adoc
+++ b/modules/c/pages/field-level-encryption.adoc
@@ -321,7 +321,6 @@ CBLEncryptable_Release(nonce);
 [.column]
 === {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/gs-build.adoc
+++ b/modules/c/pages/gs-build.adoc
@@ -50,7 +50,6 @@ include::c:example$code_snippets/main.cpp[tag=getting-started,indent=0]
 [.column]
 ====== {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -50,7 +50,6 @@ include::partial$downloadslist.adoc[]
 [.column]
 ====== {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/gs-install.adoc
+++ b/modules/c/pages/gs-install.adoc
@@ -558,7 +558,7 @@ Please plan to migrate your apps to use an appropriate alternative version.
 | 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
-.4+| Raspberry Pi OS 
+.4+| Raspberry Pi OS
 | 11 (Bullseye) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
@@ -579,7 +579,7 @@ Please plan to migrate your apps to use an appropriate alternative version.
 | 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
-.4+| Raspberry Pi OS 
+.4+| Raspberry Pi OS
 | 11 (Bullseye) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
@@ -1264,7 +1264,6 @@ Enterprise::
 [.column]
 ====== {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/indexing.adoc
+++ b/modules/c/pages/indexing.adoc
@@ -301,7 +301,6 @@ Attempting to create a query with array literals will return an error.
 [.column]
 === {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/prebuilt-database.adoc
+++ b/modules/c/pages/prebuilt-database.adoc
@@ -174,7 +174,6 @@ include::c:example$code_snippets/main.cpp[tags="prebuilt-database", indent=0]
 [.column]
 === {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/query-n1ql-mobile-server-diffs.adoc
+++ b/modules/c/pages/query-n1ql-mobile-server-diffs.adoc
@@ -338,7 +338,6 @@ You can force this behavior in Couchbase Lite by using the `ROUND_EVEN()` functi
 [.column]
 ====== {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/query-n1ql-mobile.adoc
+++ b/modules/c/pages/query-n1ql-mobile.adoc
@@ -2330,7 +2330,6 @@ include::c:example$code_snippets/main.cpp[tags="query-syntax-n1ql-params", inden
 [.column]
 ====== {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/query-resultsets.adoc
+++ b/modules/c/pages/query-resultsets.adoc
@@ -177,7 +177,6 @@ If your query selects a sub-set of available properties then the JSON format wil
 [.column]
 ====== {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/replication.adoc
+++ b/modules/c/pages/replication.adoc
@@ -1184,7 +1184,6 @@ CouchbaseLite Replicator ERROR: {Repl#2} Got LiteCore error: Network error 11 "s
 [.column]
 ====== {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/upgrade.adoc
+++ b/modules/c/pages/upgrade.adoc
@@ -114,7 +114,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 [.column]
 === {empty}
 .How to
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 

--- a/modules/c/pages/version-vectors.adoc
+++ b/modules/c/pages/version-vectors.adoc
@@ -257,7 +257,6 @@ assert(updatedTimestamp > originalTimestamp);
 [.column]
 === {empty}
 .How to . . .
-* xref:c:gs-prereqs.adoc[Prerequisites]
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 


### PR DESCRIPTION
Docs Issue: [DOC_13776](https://jira.issues.couchbase.com/browse/DOC-13776?atlOrigin=eyJpIjoiYmJiOTQ2NmFmOGNlNDUwZmEzOGQxOThhZDFkYWI1ZjEiLCJwIjoiaiJ9)

PR to update the prerequisites page for CBL C platform. The C platform doesn't have a prereqs page so removed and updated across the directory/platform.

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13776-fix-url-prereqs-cbl-c

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

