### PR TITLE
update vs release note

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -37,9 +37,10 @@ asciidoc:
     vs-minor: 0
     vs-maintenance-ios: 0
     vs-maintenance-swift: 0
-    vs-maintenance-c: 1
+    vs-maintenance-c: 0
+    vs-maintenance-c-android: 1
     vs-maintenance-android: 1
-    vs-maintenance-java: 1
+    vs-maintenance-java: 0
     vs-maintenance-net: 1
 
     page-toclevels: 2@

--- a/antora.yml
+++ b/antora.yml
@@ -37,10 +37,10 @@ asciidoc:
     vs-minor: 0
     vs-maintenance-ios: 0
     vs-maintenance-swift: 0
-    vs-maintenance-c: 0
-    vs-maintenance-android: 0
-    vs-maintenance-java: 0
-    vs-maintenance-net: 0
+    vs-maintenance-c: 1
+    vs-maintenance-android: 1
+    vs-maintenance-java: 1
+    vs-maintenance-net: 1
 
     page-toclevels: 2@
 # NB: `preview` config now in preview/HEAD.yml, please update

--- a/modules/android/partials/release-notes/couchbase-mobile-android-vs-release-note.1.0.0-beta.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-vs-release-note.1.0.0-beta.adoc
@@ -1,3 +1,24 @@
+[#vs-maint-1-0-1]
+== 1.0.1 -- December 2025
+
+Version 1.0.1 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+
+None for this release
+
+===  Known Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7734[CBL-7734 -- Support Android 16KB Page Sizes]
+
+=== Deprecations
+
+None for this release
+
 [#vs-maint-1-0-0-beta-1]
 == 1.0.0 -- August 2024
 

--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -660,9 +660,9 @@ Enterprise::
 
 .4+| Linux
 
-| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-aarch64.zip[couchbase-lite-vector-search-{our-vs-version}-linux-aarch64.zip]
-| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-aarch64.zip.sha256[couchbase-lite-vector-search-{our-vs-version}-linux-aarch64.zip.sha256]
-| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-aarch64-symbols.zip[couchbase-lite-vector-search-{our-vs-version}-linux-aarch64-symbols.zip]
+| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-arm64.zip[couchbase-lite-vector-search-{our-vs-version}-linux-arm64.zip]
+| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-arm64.zip.sha256[couchbase-lite-vector-search-{our-vs-version}-linux-arm64.zip.sha256]
+| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-arm64-symbols.zip[couchbase-lite-vector-search-{our-vs-version}-linux-arm64-symbols.zip]
 | {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-x86_64.zip[couchbase-lite-vector-search-{our-vs-version}-linux-x86_64.zip]
 | {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-x86_64.zip.sha256[couchbase-lite-vector-search-{our-vs-version}-linux-x86_64.zip.sha256]
 | {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-linux-x86_64-symbols.zip[couchbase-lite-vector-search-{our-vs-version}-linux-x86_64-symbols.zip]

--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -19,18 +19,11 @@ endif::[]
 ifdef::vs-param-version-hyphenated[]
 :our-vs-version-hyphenated: {vs-param-version-hyphenated}
 endif::[]
-ifdef::vs-param-version-android[]
-:our-vs-version-android: {vs-param-version-android}
-endif::[]
-ifdef::vs-param-version-android-hyphenated[]
-:our-vs-version-android-hyphenated: {vs-param-version-android-hyphenated}
-endif::[]
 
 
 :download-path: {url-downloads-mobile}
 :source_url: https://packages.couchbase.com/releases/couchbase-lite-c/{our-version}/
 :vs_source_url: https://packages.couchbase.com/releases/couchbase-lite-vector-search/{our-vs-version}/
-:vs_source_url_android: https://packages.couchbase.com/releases/couchbase-lite-vector-search/{our-vs-version-android}/
 
 :release-dir-ee: pass:q,a[libcblite-{our-version}]
 :release-dir: pass:q,a[libcblite-community-{our-version}]
@@ -539,7 +532,7 @@ page for instructions on how to get the software using a package manager.
 
 .Available platforms are:
 ****
-<<android-{our-vs-version-android-hyphenated}>> |
+<<android-{our-vs-version-hyphenated}>> |
 <<macos-{our-vs-version-hyphenated}>>  |
 <<ios-{our-vs-version-hyphenated}>> |
 <<windows-{our-vs-version-hyphenated}>> |
@@ -553,10 +546,10 @@ Vector Search is available only for 64-bit architectures.
 The Vector Search extension is an *Enterprise-only* feature.
 --
 
-[id=android-{our-vs-version-android-hyphenated}]
-=== Android ({our-vs-version-android})
+[id=android-{our-vs-version-hyphenated}]
+=== Android
 
-[#tbl-downloads-{our-vs-version-android}]
+[#tbl-downloads-{our-vs-version}]
 .Download link table
 [tabs]
 =====
@@ -570,10 +563,10 @@ Enterprise::
 
 .4+| Android
 
-| {vs_source_url_android}couchbase-lite-vector-search-{our-vs-version-android}-android-arm64-v8a.zip[couchbase-lite-vector-search-{our-vs-version-android}-android-arm64-v8a.zip]
-| {vs_source_url_android}couchbase-lite-vector-search-{our-vs-version-android}-android-arm64-v8a.zip.sha256[couchbase-lite-vector-search-{our-vs-version-android}-android-arm64-v8a.zip.sha256]
-| {vs_source_url_android}couchbase-lite-vector-search-{our-vs-version-android}-android-x86_64.zip[couchbase-lite-vector-search-{our-vs-version-android}-android-x86_64.zip]
-| {vs_source_url_android}couchbase-lite-vector-search-{our-vs-version-android}-android-x86_64.zip.sha256[couchbase-lite-vector-search-{our-vs-version-android}-android-x86_64.zip.sha256]
+| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-android-arm64-v8a.zip[couchbase-lite-vector-search-{our-vs-version}-android-arm64-v8a.zip]
+| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-android-arm64-v8a.zip.sha256[couchbase-lite-vector-search-{our-vs-version}-android-arm64-v8a.zip.sha256]
+| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-android-x86_64.zip[couchbase-lite-vector-search-{our-vs-version}-android-x86_64.zip]
+| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-android-x86_64.zip.sha256[couchbase-lite-vector-search-{our-vs-version}-android-x86_64.zip.sha256]
 
 |===
 --

--- a/modules/c/pages/_partials/downloadslist.adoc
+++ b/modules/c/pages/_partials/downloadslist.adoc
@@ -19,11 +19,18 @@ endif::[]
 ifdef::vs-param-version-hyphenated[]
 :our-vs-version-hyphenated: {vs-param-version-hyphenated}
 endif::[]
+ifdef::vs-param-version-android[]
+:our-vs-version-android: {vs-param-version-android}
+endif::[]
+ifdef::vs-param-version-android-hyphenated[]
+:our-vs-version-android-hyphenated: {vs-param-version-android-hyphenated}
+endif::[]
 
 
 :download-path: {url-downloads-mobile}
 :source_url: https://packages.couchbase.com/releases/couchbase-lite-c/{our-version}/
 :vs_source_url: https://packages.couchbase.com/releases/couchbase-lite-vector-search/{our-vs-version}/
+:vs_source_url_android: https://packages.couchbase.com/releases/couchbase-lite-vector-search/{our-vs-version-android}/
 
 :release-dir-ee: pass:q,a[libcblite-{our-version}]
 :release-dir: pass:q,a[libcblite-community-{our-version}]
@@ -532,7 +539,7 @@ page for instructions on how to get the software using a package manager.
 
 .Available platforms are:
 ****
-<<android-{our-vs-version-hyphenated}>> |
+<<android-{our-vs-version-android-hyphenated}>> |
 <<macos-{our-vs-version-hyphenated}>>  |
 <<ios-{our-vs-version-hyphenated}>> |
 <<windows-{our-vs-version-hyphenated}>> |
@@ -546,10 +553,10 @@ Vector Search is available only for 64-bit architectures.
 The Vector Search extension is an *Enterprise-only* feature.
 --
 
-[id=android-{our-vs-version-hyphenated}]
-=== Android
+[id=android-{our-vs-version-android-hyphenated}]
+=== Android ({our-vs-version-android})
 
-[#tbl-downloads-{our-vs-version}]
+[#tbl-downloads-{our-vs-version-android}]
 .Download link table
 [tabs]
 =====
@@ -563,10 +570,10 @@ Enterprise::
 
 .4+| Android
 
-| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-android-arm64-v8a.zip[couchbase-lite-vector-search-{our-vs-version}-android-arm64-v8a.zip]
-| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-android-arm64-v8a.zip.sha256[couchbase-lite-vector-search-{our-vs-version}-android-arm64-v8a.zip.sha256]
-| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-android-x86_64.zip[couchbase-lite-vector-search-{our-vs-version}-android-x86_64.zip]
-| {vs_source_url}couchbase-lite-vector-search-{our-vs-version}-android-x86_64.zip.sha256[couchbase-lite-vector-search-{our-vs-version}-android-x86_64.zip.sha256]
+| {vs_source_url_android}couchbase-lite-vector-search-{our-vs-version-android}-android-arm64-v8a.zip[couchbase-lite-vector-search-{our-vs-version-android}-android-arm64-v8a.zip]
+| {vs_source_url_android}couchbase-lite-vector-search-{our-vs-version-android}-android-arm64-v8a.zip.sha256[couchbase-lite-vector-search-{our-vs-version-android}-android-arm64-v8a.zip.sha256]
+| {vs_source_url_android}couchbase-lite-vector-search-{our-vs-version-android}-android-x86_64.zip[couchbase-lite-vector-search-{our-vs-version-android}-android-x86_64.zip]
+| {vs_source_url_android}couchbase-lite-vector-search-{our-vs-version-android}-android-x86_64.zip.sha256[couchbase-lite-vector-search-{our-vs-version-android}-android-x86_64.zip.sha256]
 
 |===
 --

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -26,7 +26,7 @@ xref:c:gs-build.adoc[Build and Run]
 .Downloads are available for the following versions:
 ****
 <<release-3-2-4>>   |
-<<vs-release-1-0-0>>   |
+<<vs-release-1-0-1>>   |
 // |
 ****
 
@@ -38,15 +38,11 @@ include::partial$downloadslist.adoc[]
 :param-version!:
 :param-version-hyphenated!:
 
-:vs-param-version: 1.0.0
-:vs-param-version-hyphenated: 1-0-0
-:vs-param-version-android: 1.0.1
-:vs-param-version-android-hyphenated: 1-0-1
+:vs-param-version: 1.0.1
+:vs-param-version-hyphenated: 1-0-1
 include::partial$downloadslist.adoc[]
 :vs-param-version!:
 :vs-param-version-hyphenated!:
-:vs-param-version-android!:
-:vs-param-version-android-hyphenated!:
 
 
 [#related-content]

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -26,7 +26,7 @@ xref:c:gs-build.adoc[Build and Run]
 .Downloads are available for the following versions:
 ****
 <<release-3-2-4>>   |
-<<vs-release-1-0-0>>   |
+<<vs-release-1-0-1>>   |
 // |
 ****
 
@@ -38,8 +38,8 @@ include::partial$downloadslist.adoc[]
 :param-version!:
 :param-version-hyphenated!:
 
-:vs-param-version: 1.0.0
-:vs-param-version-hyphenated: 1-0-0
+:vs-param-version: 1.0.1
+:vs-param-version-hyphenated: 1-0-1
 include::partial$downloadslist.adoc[]
 :vs-param-version!:
 :vs-param-version-hyphenated!:

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -26,7 +26,7 @@ xref:c:gs-build.adoc[Build and Run]
 .Downloads are available for the following versions:
 ****
 <<release-3-2-4>>   |
-<<vs-release-1-0-1>>   |
+<<vs-release-1-0-0>>   |
 // |
 ****
 
@@ -38,11 +38,15 @@ include::partial$downloadslist.adoc[]
 :param-version!:
 :param-version-hyphenated!:
 
-:vs-param-version: 1.0.1
-:vs-param-version-hyphenated: 1-0-1
+:vs-param-version: 1.0.0
+:vs-param-version-hyphenated: 1-0-0
+:vs-param-version-android: 1.0.1
+:vs-param-version-android-hyphenated: 1-0-1
 include::partial$downloadslist.adoc[]
 :vs-param-version!:
 :vs-param-version-hyphenated!:
+:vs-param-version-android!:
+:vs-param-version-android-hyphenated!:
 
 
 [#related-content]

--- a/modules/c/partials/release-notes/couchbase-mobile-c-vs-release-note.1.0.0-beta.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-vs-release-note.1.0.0-beta.adoc
@@ -1,3 +1,25 @@
+[#vs-maint-1-0-1]
+== 1.0.1 -- December 2025
+
+Version 1.0.1 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+
+None for this release
+
+===  Known Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7734[CBL-7734 -- Support Android 16KB Page Sizes]
+
+=== Deprecations
+
+None for this release
+
+
 [#vs-maint-1-0-0-beta-3]
 == 1.0.0 -- August 2024
 

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-vs-release-note.1.0.0-beta.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-vs-release-note.1.0.0-beta.adoc
@@ -1,3 +1,25 @@
+[#vs-maint-1-0-1]
+== 1.0.1 -- December 2025
+
+Version 1.0.1 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+
+None for this release
+
+===  Known Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7734[CBL-7734 -- Support Android 16KB Page Sizes]
+
+=== Deprecations
+
+None for this release
+
+
 [#vs-maint-1-0-0-beta-2]
 == 1.0.0 -- August 2024
 

--- a/modules/java/partials/release-notes/couchbase-mobile-java-vs-release-note.1.0.0-beta.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-vs-release-note.1.0.0-beta.adoc
@@ -1,24 +1,3 @@
-[#vs-maint-1-0-1]
-== 1.0.1 -- December 2025
-
-Version 1.0.1 for {param-title} delivers the following features and enhancements:
-
-=== Enhancements
-
-None for this release
-
-=== Issues and Resolutions
-
-None for this release
-
-===  Known Issues
-
-* https://jira.issues.couchbase.com/browse/CBL-7734[CBL-7734 -- Support Android 16KB Page Sizes]
-
-=== Deprecations
-
-None for this release
-
 [#vs-maint-1-0-0-beta-2]
 == 1.0.0 -- August 2024
 

--- a/modules/java/partials/release-notes/couchbase-mobile-java-vs-release-note.1.0.0-beta.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-vs-release-note.1.0.0-beta.adoc
@@ -1,3 +1,24 @@
+[#vs-maint-1-0-1]
+== 1.0.1 -- December 2025
+
+Version 1.0.1 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+
+None for this release
+
+===  Known Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7734[CBL-7734 -- Support Android 16KB Page Sizes]
+
+=== Deprecations
+
+None for this release
+
 [#vs-maint-1-0-0-beta-2]
 == 1.0.0 -- August 2024
 


### PR DESCRIPTION
Docs Issue: [DOC-13852](https://jira.issues.couchbase.com/browse/DOC-13852?atlOrigin=eyJpIjoiZWI4NjcwNzRjZWJmNDQwZGE2YjYzMjRmNGJmOTkxNjgiLCJwIjoiaiJ9)

PR to add the Vector Search to the release 3.3

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13852-cbl-vector-search-1.0.1

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.


[DOC-13852]: https://couchbasecloud.atlassian.net/browse/DOC-13852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ