### PR TITLE
update cbl vs for 3.2

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -33,9 +33,9 @@ asciidoc:
     vs-minor: 0
     vs-maintenance-ios: 0
     vs-maintenance-swift: 0
-    vs-maintenance-c: 0
-    vs-maintenance-android: 0
+    vs-maintenance-c: 1
+    vs-maintenance-android: 1
     vs-maintenance-java: 0
-    vs-maintenance-net: 0
+    vs-maintenance-net: 1
     page-toclevels: 2@
 # NB: `preview` config now in preview/HEAD.yml, please update

--- a/modules/android/partials/release-notes/couchbase-mobile-android-vs-release-note.1.0.0-beta.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-vs-release-note.1.0.0-beta.adoc
@@ -1,3 +1,24 @@
+[#vs-maint-1-0-1]
+== 1.0.1 -- December 2025
+
+Version 1.0.1 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+
+None for this release
+
+===  Known Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7734[CBL-7734 -- Support Android 16KB Page Sizes]
+
+=== Deprecations
+
+None for this release
+
 [#vs-maint-1-0-0-beta-1]
 == 1.0.0 -- August 2024
 

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -26,7 +26,7 @@ xref:c:gs-build.adoc[Build and Run]
 <<release-3-2-4>>   |
 <<release-3-2-3>>   |
 <<release-3-2-2>>   |
-<<vs-release-1-0-0>>   |
+<<vs-release-1-0-1>>   |
 // |
 ****
 
@@ -50,8 +50,8 @@ include::partial$downloadslist.adoc[]
 :param-version-hyphenated!:
 
 
-:vs-param-version: 1.0.0
-:vs-param-version-hyphenated: 1-0-0
+:vs-param-version: 1.0.1
+:vs-param-version-hyphenated: 1-0-1
 include::partial$downloadslist.adoc[]
 :vs-param-version!:
 :vs-param-version-hyphenated!:

--- a/modules/c/partials/release-notes/couchbase-mobile-c-vs-release-note.1.0.0-beta.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-vs-release-note.1.0.0-beta.adoc
@@ -1,3 +1,24 @@
+[#vs-maint-1-0-1]
+== 1.0.1 -- December 2025
+
+Version 1.0.1 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+
+None for this release
+
+===  Known Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7734[CBL-7734 -- Support Android 16KB Page Sizes]
+
+=== Deprecations
+
+None for this release
+
 [#vs-maint-1-0-0-beta-3]
 == 1.0.0 -- August 2024
 

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-vs-release-note.1.0.0-beta.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-vs-release-note.1.0.0-beta.adoc
@@ -1,3 +1,24 @@
+[#vs-maint-1-0-1]
+== 1.0.1 -- December 2025
+
+Version 1.0.1 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+
+None for this release
+
+===  Known Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7734[CBL-7734 -- Support Android 16KB Page Sizes]
+
+=== Deprecations
+
+None for this release
+
 [#vs-maint-1-0-0-beta-2]
 == 1.0.0 -- August 2024
 


### PR DESCRIPTION
PR to add CBL vs to 3.2 

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-update-release-cbl-vector-1.0.1

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.