### PR TITLE
DOC-13871-update minimum api level for android and C

### DIFF
--- a/modules/ROOT/pages/_partials/supported-versions.adoc
+++ b/modules/ROOT/pages/_partials/supported-versions.adoc
@@ -14,19 +14,19 @@ Couchbase does not test against, nor guarantee support for, uncertified Android 
 
 |Android
 |armeabi-v7a
-|22+
+|22
 
 |Android
 |arm64-v8a
-|22+
+|22
 
 |Android
 |x86
-|22+
+|22
 
 |Android
 |x86_64
-|22+
+|22
 |===
 
 // end::android[]
@@ -58,7 +58,7 @@ Couchbase recommends you migrate your apps to use an appropriate alternative ver
 |===
 .>| API | x86 | x64 .>| ARM 32 .>| ARM 64
 
-| 22+ | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
+| 22 | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
 |===
 
@@ -69,7 +69,7 @@ Couchbase recommends you migrate your apps to use an appropriate alternative ver
 |===
 .>| Version | x86 | x64 | ARM 32 | ARM 64
 
-| 12+
+| 12
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -108,7 +108,7 @@ Couchbase recommends you migrate your apps to use an appropriate alternative ver
 | Raspberry Pi OS | 10	|  	| image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | Raspbian | 9	|  | image:ROOT:yes.png[] |
 
-.2+| Ubuntu 
+.2+| Ubuntu
 | 20.04 LTS	| image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 22.04 LTS	| image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
@@ -130,7 +130,7 @@ Couchbase recommends you migrate your apps to use an appropriate alternative ver
 | Raspberry Pi OS | 10	|  	| image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | Raspbian | 9	|  | image:ROOT:yes.png[] |
 
-.2+| Ubuntu 
+.2+| Ubuntu
 | 20.04 LTS	| image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 22.04 LTS	| image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
@@ -202,18 +202,18 @@ a| MacOS 12
 
 |.NET iOS
 |8.0
-|12+ (14+ for MAUI support)
+|12 (14 for MAUI support)
 
 |.NET Android
-|8.0 
-|API 22+
+|8.0
+|API 22
 
 |Xamarin Android
-|10+ 
+|10
 |API 22
 
 |Xamarin iOS
-|10+
+|10
 |10
 
 |===
@@ -250,7 +250,7 @@ The following table identifies the <<supported-os-versions,supported platforms>>
 |Platform |Minimum OS version
 
 |iOS
-|12.0+
+|12.0
 
 |macOS
 | 13 (Ventura), 14 (Sonoma)
@@ -340,7 +340,7 @@ Couchbase recommends you migrate your apps to use an appropriate alternative ver
 | OS|Version|Type
 
 |RedHat
-|8+
+|8
 |ALL
 
 |RockyLinux

--- a/modules/android/pages/gs-prereqs.adoc
+++ b/modules/android/pages/gs-prereqs.adoc
@@ -26,7 +26,7 @@ _Abstract -- Laying out some of the pre-requisites and preparatory steps to be c
 The requirements listed below are for the *Java/Kotlin SDK* on Android (Minimum API Level *22*).
 
 If you're developing with the *C/{cpp} SDK* on Android, the minimum API Level is *24*.
-For C/C++ SDK requirements, see xref:c:supported-os.adoc#android[Couchbase Lite for C - Android Requirements].
+For C/{cpp} SDK requirements, see xref:c:supported-os.adoc#android[Couchbase Lite for C - Android Requirements].
 --
 
 The xref:android:supported-os.adoc#supported-os-versions[Supported OS Versions] lists certified Android versions.

--- a/modules/android/pages/gs-prereqs.adoc
+++ b/modules/android/pages/gs-prereqs.adoc
@@ -25,7 +25,7 @@ _Abstract -- Laying out some of the pre-requisites and preparatory steps to be c
 --
 The requirements listed below are for the *Java/Kotlin SDK* on Android (Minimum API Level *22*).
 
-If you're developing with the *C/C++ SDK* on Android, the minimum API Level is *24*.
+If you're developing with the *C/{cpp} SDK* on Android, the minimum API Level is *24*.
 For C/C++ SDK requirements, see xref:c:supported-os.adoc#android[Couchbase Lite for C - Android Requirements].
 --
 

--- a/modules/android/pages/gs-prereqs.adoc
+++ b/modules/android/pages/gs-prereqs.adoc
@@ -21,7 +21,15 @@ _Abstract -- Laying out some of the pre-requisites and preparatory steps to be c
 [#supported-versions]
 == Supported Versions
 
-The operating systems listed refer to supported versions of Android.
+[IMPORTANT]
+--
+The requirements listed below are for the *Java/Kotlin SDK* on Android (Minimum API Level *22+*).
+
+If you're developing with the *C/C++ SDK* on Android, the minimum API Level is *24+*.
+For C/C++ SDK requirements, see xref:c:supported-os.adoc#android[Couchbase Lite for C - Android Requirements].
+--
+
+The operating systems listed see supported versions of Android.
 Couchbase does not test against, nor guarantee support for, uncertified Android versions such as versions built from source.
 
 [%autowidth.stretch]

--- a/modules/android/pages/gs-prereqs.adoc
+++ b/modules/android/pages/gs-prereqs.adoc
@@ -23,13 +23,13 @@ _Abstract -- Laying out some of the pre-requisites and preparatory steps to be c
 
 [IMPORTANT]
 --
-The requirements listed below are for the *Java/Kotlin SDK* on Android (Minimum API Level *22+*).
+The requirements listed below are for the *Java/Kotlin SDK* on Android (Minimum API Level *22*).
 
-If you're developing with the *C/C++ SDK* on Android, the minimum API Level is *24+*.
+If you're developing with the *C/C++ SDK* on Android, the minimum API Level is *24*.
 For C/C++ SDK requirements, see xref:c:supported-os.adoc#android[Couchbase Lite for C - Android Requirements].
 --
 
-The operating systems listed see supported versions of Android.
+The xref:android:supported-os.adoc#supported-os-versions[Supported OS Versions] lists certified Android versions.
 Couchbase does not test against, nor guarantee support for, uncertified Android versions such as versions built from source.
 
 [%autowidth.stretch]
@@ -38,19 +38,19 @@ Couchbase does not test against, nor guarantee support for, uncertified Android 
 
 |Android
 |armeabi-v7a
-|22+
+|22
 
 |Android
 |arm64-v8a
-|22+
+|22
 
 |Android
 |x86
-|22+
+|22
 
 |Android
 |x86_64
-|22+
+|22
 |===
 
 [#supported-versions-for-vector-search-4-0-0]

--- a/modules/android/pages/supported-os.adoc
+++ b/modules/android/pages/supported-os.adoc
@@ -20,8 +20,16 @@ Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:android:releaseno
 [#officially-supported-versions]
 == Officially Supported Versions
 
-The operating systems listed in xref:android:supported-os.adoc#supported-os-versions[] refer to "Certified" versions of Android. +
-We do not test against, nor guarantee support for, uncertified Android versions such as versions built from source.
+[IMPORTANT]
+--
+The requirements listed below are for the *Java/Kotlin SDK* on Android.
+
+If you're developing with the *C/C++ SDK* on Android, the minimum API Level is *24+*.
+For C/C++ SDK requirements, see xref:c:supported-os.adoc#android[Couchbase Lite for C - Android Requirements].
+--
+
+The operating systems listed in xref:android:supported-os.adoc#supported-os-versions[] are certified Android versions.
+Couchbase does not test against, nor guarantee support for, uncertified Android versions such as versions built from source.
 
 .Supported versions
 [#supported-os-versions]

--- a/modules/android/pages/supported-os.adoc
+++ b/modules/android/pages/supported-os.adoc
@@ -24,7 +24,7 @@ Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:android:releaseno
 --
 The requirements listed below are for the *Java/Kotlin SDK* on Android.
 
-If you're developing with the *C/C++ SDK* on Android, the minimum API Level is *24+*.
+If you're developing with the *C/C++ SDK* on Android, the minimum API Level is *24*.
 For C/C++ SDK requirements, see xref:c:supported-os.adoc#android[Couchbase Lite for C - Android Requirements].
 --
 
@@ -39,19 +39,19 @@ Couchbase does not test against, nor guarantee support for, uncertified Android 
 
 |Android
 |armeabi-v7a
-|24+
+|24
 
 |Android
 |arm64-v8a
-|24+
+|24
 
 |Android
 |x86
-|24+
+|24
 
 |Android
 |x86_64
-|24+
+|24
 |===
 
 

--- a/modules/android/pages/supported-os.adoc
+++ b/modules/android/pages/supported-os.adoc
@@ -24,7 +24,7 @@ Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:android:releaseno
 --
 The requirements listed below are for the *Java/Kotlin SDK* on Android.
 
-If you're developing with the *C/C++ SDK* on Android, the minimum API Level is *24*.
+If you're developing with the *C/{cpp} SDK* on Android, the minimum API Level is *24*.
 For C/C++ SDK requirements, see xref:c:supported-os.adoc#android[Couchbase Lite for C - Android Requirements].
 --
 

--- a/modules/android/pages/supported-os.adoc
+++ b/modules/android/pages/supported-os.adoc
@@ -25,7 +25,7 @@ Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:android:releaseno
 The requirements listed below are for the *Java/Kotlin SDK* on Android.
 
 If you're developing with the *C/{cpp} SDK* on Android, the minimum API Level is *24*.
-For C/C++ SDK requirements, see xref:c:supported-os.adoc#android[Couchbase Lite for C - Android Requirements].
+For C/{cpp} SDK requirements, see xref:c:supported-os.adoc#android[Couchbase Lite for C - Android Requirements].
 --
 
 The operating systems listed in xref:android:supported-os.adoc#supported-os-versions[] are certified Android versions.

--- a/modules/c/pages/gs-install.adoc
+++ b/modules/c/pages/gs-install.adoc
@@ -550,15 +550,15 @@ Please plan to migrate your apps to use an appropriate alternative version.
 [#linux]
 === Linux
 
-[cols="^1,^1,^1,^1^,^1,^1",options="header"]
+[cols="^1,^1,^1,^1,^1",options="header"]
 |===
 .>| Distro	| Version .>| x64 .>| ARM 32 .>| ARM 64
 
-.4+| Debian
+.2+| Debian
 | 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
-.4+| Raspberry Pi OS
+.2+| Raspberry Pi OS
 | 11 (Bullseye) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
@@ -571,15 +571,15 @@ Please plan to migrate your apps to use an appropriate alternative version.
 [#embedded-linux]
 === Embedded Linux
 
-[cols="^1,^1,^1,^1^,^1,^1",options="header"]
+[cols="^1,^1,^1,^1,^1",options="header"]
 |===
 .>| Distro	| Version .>| x64 .>| ARM 32 .>| ARM 64
 
-.4+| Debian
+.2+| Debian
 | 11 (Bullseye) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) | image:ROOT:yes.png[] | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 
-.4+| Raspberry Pi OS
+.2+| Raspberry Pi OS
 | 11 (Bullseye) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 | 12 (Bookworm) |  | image:ROOT:yes.png[] | image:ROOT:yes.png[]
 

--- a/modules/c/pages/gs-install.adoc
+++ b/modules/c/pages/gs-install.adoc
@@ -266,11 +266,11 @@ To install the Couchbase for C libraries on Windows from a downloaded release bi
 . From within the root directory, {release-dir-ce}, deploy the `lib`, `include` and `bin` libraries to a location accessible to your compiler.
 
 . Within  _Visual Studio_:
-.. *Create* a new C++ project
+.. *Create* a new {cpp} project
 +
 Be sure to select x64 for 64-bit builds
-.. Within *Project Properties* -> *C++ directories* -> *Library Directories*, *Add* `<path-to-deployed-directories>/lib`
-.. Within *Project Properties* -> *C++ directories* -> *Include Directories*, *Add* `<path-to-deployed-directories>/include`
+.. Within *Project Properties* -> *{cpp} directories* -> *Library Directories*, *Add* `<path-to-deployed-directories>/lib`
+.. Within *Project Properties* -> *{cpp} directories* -> *Include Directories*, *Add* `<path-to-deployed-directories>/include`
 .. Within *Project Properties* -> *Linker* -> *Input* -> *Additional Dependencies*, *Add* `cblite.lib`
 . *Copy* `<path-to-deployed-directories>/bin/cblite.dll` to your build location
 +

--- a/modules/c/pages/p2psync-websocket.adoc
+++ b/modules/c/pages/p2psync-websocket.adoc
@@ -384,7 +384,7 @@ a|https://learn.microsoft.com/en-us/windows/win32/seccng/key-storage-and-retriev
 Linux / Android::
 +
 --
-As Linux-based operating systems do not have a standard or common secure key storage, and Android doesn't support native C/C++ API access to the default Keystore, Couchbase Lite C does not support persisting generated identities with the specified label on these platforms.
+As Linux-based operating systems do not have a standard or common secure key storage, and Android doesn't support native C/{cpp} API access to the default Keystore, Couchbase Lite C does not support persisting generated identities with the specified label on these platforms.
 
 As an alternative, Couchbase Lite C enables developers to implement their own cryptographic operations through a set of callbacks, enabling certificate signing and other cryptographic tasks during the TLS handshake using a private key stored in their preferred secure key storage.
 These callbacks allow operations like signing data, with the private key remaining securely stored and never exposed.

--- a/modules/c/pages/supported-os.adoc
+++ b/modules/c/pages/supported-os.adoc
@@ -38,8 +38,8 @@ Please plan to migrate your apps to use an appropriate alternative version.
 
 [IMPORTANT]
 --
-These requirements are for the *C/C++ SDK* on Android.
-Use the C/C++ SDK when using Qt or other C++ frameworks.
+These requirements are for the *C/{cpp} SDK* on Android.
+Use the C/{cpp} SDK when using Qt or other {cpp} frameworks.
 
 If you're developing with the *Java/Kotlin SDK* on Android, see xref:android:supported-os.adoc#officially-supported-versions[Couchbase Lite for Android - Supported OS Versions].
 --

--- a/modules/c/pages/supported-os.adoc
+++ b/modules/c/pages/supported-os.adoc
@@ -38,10 +38,10 @@ Please plan to migrate your apps to use an appropriate alternative version.
 
 [IMPORTANT]
 --
-These requirements are for the *C/C++ SDK* on Android. 
+These requirements are for the *C/C++ SDK* on Android.
 Use the C/C++ SDK when using Qt or other C++ frameworks.
 
-If you're developing with the *Java/Kotlin SDK* on Android, see xref:android:supported-os.adoc[Couchbase Lite for Android - Supported OS Versions].
+If you're developing with the *Java/Kotlin SDK* on Android, see xref:android:supported-os.adoc#officially-supported-versions[Couchbase Lite for Android - Supported OS Versions].
 --
 
 [cols="^1,^1,^1,^1,^1",options="header"]

--- a/modules/c/pages/supported-os.adoc
+++ b/modules/c/pages/supported-os.adoc
@@ -36,6 +36,13 @@ Please plan to migrate your apps to use an appropriate alternative version.
 [#android]
 === Android
 
+[IMPORTANT]
+--
+These requirements are for the *C/C++ SDK* on Android (e.g., when using Qt or other C++ frameworks).
+
+If you're developing with the *Java/Kotlin SDK* on Android, see xref:android:supported-os.adoc[Couchbase Lite for Android - Supported OS Versions].
+--
+
 [cols="^1,^1,^1,^1,^1",options="header"]
 |===
 .>| API | x86 | x64 .>| ARM 32 .>| ARM 64

--- a/modules/c/pages/supported-os.adoc
+++ b/modules/c/pages/supported-os.adoc
@@ -38,7 +38,8 @@ Please plan to migrate your apps to use an appropriate alternative version.
 
 [IMPORTANT]
 --
-These requirements are for the *C/C++ SDK* on Android (e.g., when using Qt or other C++ frameworks).
+These requirements are for the *C/C++ SDK* on Android. 
+Use the C/C++ SDK when using Qt or other C++ frameworks.
 
 If you're developing with the *Java/Kotlin SDK* on Android, see xref:android:supported-os.adoc[Couchbase Lite for Android - Supported OS Versions].
 --

--- a/modules/csharp/pages/supported-os.adoc
+++ b/modules/csharp/pages/supported-os.adoc
@@ -56,11 +56,11 @@ a| MacOS 13
 
 |.NET iOS
 |9.0
-|15+
+|15
 
 |.NET Android
 |9.0
-|API 24+
+|API 24
 
 |===
 

--- a/modules/java/pages/supported-os.adoc
+++ b/modules/java/pages/supported-os.adoc
@@ -37,7 +37,7 @@ Please plan to migrate your apps to use an appropriate alternative version.
 | OS|Version|Type
 
 |RedHat
-|9+
+|9
 |ALL
 
 |RockyLinux


### PR DESCRIPTION
Docs Issue: [DOC-13871](https://jira.issues.couchbase.com/browse/DOC-13871)

PR to update the minimum API levels for Android and C

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13871-fix-android-minimum-api/couchbase-lite/current/c/gs-install.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-13871]: https://couchbasecloud.atlassian.net/browse/DOC-13871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ