### PR TITLE
update the new logging api for 3.2 android

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent none
     options {
-        timeout(time: 10, unit: 'MINUTES') 
+        timeout(time: 10, unit: 'MINUTES')
     }
     stages {
         stage("Validate Build") {
@@ -9,19 +9,19 @@ pipeline {
                 stage("Validate C#") {
                     agent { label 's61113u16 (litecore)' }
                     steps {
-                        sh 'jenkins/dotnet_build.sh 3.2.3 1.0.0'
+                        sh 'jenkins/dotnet_build.sh 3.2.4 1.0.0'
                     }
                 }
                 stage("Validate C") {
                     agent { label 's61113u16 (litecore)' }
                     steps {
-                        sh 'jenkins/c_build.sh 3.2.3'
+                        sh 'jenkins/c_build.sh 3.2.4'
                     }
                 }
                 stage("Validate iOS") {
                     agent { label 'mobile-builder-ios-pull-request' }
                     steps {
-                        sh 'jenkins/ios.sh 3.2.3 1.0.0'
+                        sh 'jenkins/ios.sh 3.2.4 1.0.0'
                     }
                 }
             }

--- a/modules/android/examples/kotlin_snippets/app/src/main/kotlin/com/couchbase/codesnippets/BasicExamples.kt
+++ b/modules/android/examples/kotlin_snippets/app/src/main/kotlin/com/couchbase/codesnippets/BasicExamples.kt
@@ -206,9 +206,11 @@ class BasicExamples(private val context: Context) {
     fun newFileLoggingExample() {
         // tag::new-file-logging[]
         FileLogSinkFactory.install(
+            level = LogLevel.VERBOSE,
             directory = "/tmp/logs",
             maxKeptFiles = 12,
-            isPlainText = true)
+            isPlainText = true
+        )
         // end::new-file-logging[]
     }
 

--- a/modules/java/examples/snippets/common/main/java/com/couchbase/codesnippets/Examples.java
+++ b/modules/java/examples/snippets/common/main/java/com/couchbase/codesnippets/Examples.java
@@ -153,7 +153,8 @@ public class Examples {
 
     public void newFileLoggingExample() {
         // tag::new-file-logging[]
-        LogSinks.get().setFile(new FileLogSink.Builder()
+         LogSinks.get().setFile(new FileLogSink.Builder()
+            .setLevel(LogLevel.VERBOSE)
             .setDirectory("/tmp/logs")
             .setMaxKeptFiles(12)
             .setPlainText(false)


### PR DESCRIPTION
PR to update the Android/Java code snippet to include the verbose log level in the FileLogSink

Docs Issue: [DOC-13900](https://jira.issues.couchbase.com/browse/DOC-13900?atlOrigin=eyJpIjoiMTMzZDRkNGQ3Y2ExNDhiMDkxNjNhZjZlZjJkZGRlYTkiLCJwIjoiaiJ9)

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13900-update-android-verbose-log-level/couchbase-lite/current/android/new-logging-api.html
You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-13900]: https://couchbasecloud.atlassian.net/browse/DOC-13900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ