### PR TITLE
update the logging api for android

### DIFF
--- a/modules/android/examples/kotlin_snippets/app/src/main/kotlin/com/couchbase/codesnippets/BasicExamples.kt
+++ b/modules/android/examples/kotlin_snippets/app/src/main/kotlin/com/couchbase/codesnippets/BasicExamples.kt
@@ -207,10 +207,12 @@ class BasicExamples(private val context: Context) {
 
     fun newFileLoggingExample() {
         // tag::new-file-logging[]
-        FileLogSinkFactory.install(
+       FileLogSinkFactory.install(
+            level = LogLevel.VERBOSE,
             directory = "/tmp/logs",
             maxKeptFiles = 12,
-            isPlainText = true)
+            isPlainText = true
+        )
         // end::new-file-logging[]
     }
 

--- a/modules/java/examples/snippets/common/main/java/com/couchbase/codesnippets/Examples.java
+++ b/modules/java/examples/snippets/common/main/java/com/couchbase/codesnippets/Examples.java
@@ -155,7 +155,8 @@ public class Examples {
 
     public void newFileLoggingExample() {
         // tag::new-file-logging[]
-        LogSinks.get().setFile(new FileLogSink.Builder()
+       LogSinks.get().setFile(new FileLogSink.Builder()
+            .setLevel(LogLevel.VERBOSE)
             .setDirectory("/tmp/logs")
             .setMaxKeptFiles(12)
             .setPlainText(false)


### PR DESCRIPTION
PR to update the Android/Java code snippet to include the verbose log level in the FileLogSink

Docs Issue: [DOC-13900](https://jira.issues.couchbase.com/browse/DOC-13900?atlOrigin=eyJpIjoiMTMzZDRkNGQ3Y2ExNDhiMDkxNjNhZjZlZjJkZGRlYTkiLCJwIjoiaiJ9)


Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13900-fix-logging-api-android

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-13900]: https://couchbasecloud.atlassian.net/browse/DOC-13900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ