### PR TITLE
update p2p data sync url

### DIFF
--- a/modules/objc/pages/dbreplica.adoc
+++ b/modules/objc/pages/dbreplica.adoc
@@ -22,7 +22,7 @@ Description -- _{description}_ +
 [abstract]
 --
 Description -- _{description}_ +
-Related Content -- xref:objc:replication.adoc[Remote Sync Gateway] | xref:objc:landing-p2psync.adoc[Peer-to-Peer Sync]
+Related Content -- xref:objc:replication.adoc[Remote Sync Gateway] | xref:objc:p2psync-websocket.adoc[Peer-to-Peer Sync]
 --
 
 [#overview]
@@ -31,7 +31,7 @@ Related Content -- xref:objc:replication.adoc[Remote Sync Gateway] | xref:objc:l
 
 Couchbase Lite supports replication between two local databases at the database, scope, or collection level.
 This allows a Couchbase Lite replicator to store data on secondary storage.
-It is useful in scenarios when a user's device is damaged and its data is moved to a different device.
+It's useful in scenarios when a user's device is damaged and its data is moved to a different device.
 
 .Replication between Local Databases
 


### PR DESCRIPTION
Docs Issue: [DOC-12638](https://jira.issues.couchbase.com/browse/DOC-12638?atlOrigin=eyJpIjoiN2E0YWEyYjMyYjQ3NDQ2ZmEwYTU1M2NhNTFkMTFkMjkiLCJwIjoiaiJ9)

PR to update the p2p data sync URL 

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-12638-data-sync-broken-link/couchbase-lite/current/objc/dbreplica.html
You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-12638]: https://couchbasecloud.atlassian.net/browse/DOC-12638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ