### PR TITLE
[DOC-13672]: UNNEST is now available in 3.2

### DIFF
--- a/modules/android/pages/query-n1ql-mobile-querybuilder-diffs.adoc
+++ b/modules/android/pages/query-n1ql-mobile-querybuilder-diffs.adoc
@@ -31,6 +31,8 @@ See xref:android:query-n1ql-mobile-querybuilder-diffs.adoc#tbl-qbldr-diffs[] for
 |Category
 |Components
 
+| Clauses
+|UNNEST
 |Conditional Operator
 |CASE(WHEN ... THEN ... ELSE ..)
 

--- a/modules/android/pages/query-n1ql-mobile-server-diffs.adoc
+++ b/modules/android/pages/query-n1ql-mobile-server-diffs.adoc
@@ -78,13 +78,25 @@ JOIN orders o ON meta(u).id = o.user_id;
 FROM \`user` u
 NEST orders orders
 ON KEYS ARRAY s.order_id FOR s IN u.order_history END;
-| NEST/UNNEST not supported
+| NEST is not supported
 
 | LEFT OUTER NEST
 | SELECT * FROM user u +
 LEFT OUTER NEST orders orders +
 ON KEYS ARRAY s.order_id FOR s IN u.order_history END;
 | NEST/UNNEST not supported
+
+| UNNEST
+| SELECT route.sourceairport, route.destinationairport, sched.flight, sched.utc
+FROM route
+UNNEST schedule sched
+WHERE  sched.day = 1
+
+| SELECT sourceairport, destinationairport, flight, utc
+FROM route, sched
+UNNEST schedule sched
+WHERE  sched.day = 1
+
 
 | ARRAY
 | ARRAY i FOR i IN [1, 2] END


### PR DESCRIPTION

Added details of the UNNEST clause.

> [!NOTE]
> Please check the code examples for correctness.

----

Preview URLs:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13672--4.0--UNNEST-is-now-available-in-3.2/couchbase-lite/current/android/query-n1ql-mobile-server-diffs.html

https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-13672--4.0--UNNEST-is-now-available-in-3.2/couchbase-lite/current/android/query-n1ql-mobile-querybuilder-diffs.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.