### PR TITLE
DOC-14093-update infra version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: couchbase-lite
-version: '4.0'
-prerelease:
+version: '4.1'
+prerelease: true
 title: Couchbase Lite
 start_page: ROOT:index.adoc
 nav:
@@ -14,20 +14,20 @@ nav:
 - modules/swift/nav-swift.adoc
 asciidoc:
   attributes:
-    prerelease:
-    previous-release:
-    release: '4.0'
+    prerelease: true
+    previous-release: 
+    release: '4.1'
     # releasetag:
     major: 4
     major-net: 4
-    minor: 0
-    minor-net: 0
-    maintenance-ios: 1
+    minor: 1
+    minor-net: 1
+    maintenance-ios: 0
     maintenance-c: 0
     maintenance-android: 0
     maintenance-java: 0
     maintenance-net: 0
-    maintenance-swift: 1
+    maintenance-swift: 0
     base: 0
 
     # Used for Vector Search Extension.

--- a/modules/android/pages/gs-prereqs.adoc
+++ b/modules/android/pages/gs-prereqs.adoc
@@ -53,8 +53,8 @@ Couchbase does not test against, nor guarantee support for, uncertified Android 
 |22
 |===
 
-[#supported-versions-for-vector-search-4-0-0]
-== Supported Versions for Vector Search 4.0.0
+[#supported-versions-for-vector-search-4-1-0]
+== Supported Versions for Vector Search 4.1.0
 
 [IMPORTANT]
 --

--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -22,20 +22,20 @@ xref:c:gs-build.adoc[Build and Run]
 
 .Downloads are available for the following versions:
 ****
-<<release-4-0-0>>   |
-<<vs-release-1-0-0>>   |
+<<release-4-1-0>>   |
+<<vs-release-2-0-0>>   |
 // |
 ****
 
 // This block will always represent the major release version
-:param-version: 4.0.0
-:param-version-hyphenated: 4-0-0
+:param-version: 4.1.0
+:param-version-hyphenated: 4-1-0
 include::partial$downloadslist.adoc[]
 :param-version!:
 :param-version-hyphenated!:
 
-:vs-param-version: 1.0.0
-:vs-param-version-hyphenated: 1-0-0
+:vs-param-version: 2.0.0
+:vs-param-version-hyphenated: 2-0-0
 include::partial$downloadslist.adoc[]
 :vs-param-version!:
 :vs-param-version-hyphenated!:


### PR DESCRIPTION
Docs Issue: [DOC-14093](https://jira.issues.couchbase.com/browse/DOC-14093?atlOrigin=eyJpIjoiNGU0NmQyN2RlYTg0NGVhMTk2MTllNmU2NmVjZWMxZTEiLCJwIjoiaiJ9)

PR to update the infrastructure for CBL 4.1 

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-14093-infra-update

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-14093]: https://couchbasecloud.atlassian.net/browse/DOC-14093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ