### PR TITLE
DOC-14095 upgrade instructions

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: couchbase-lite
-version: '4.0'
-prerelease:
+version: '4.1'
+prerelease: true
 title: Couchbase Lite
 start_page: ROOT:index.adoc
 nav:
@@ -14,20 +14,20 @@ nav:
 - modules/swift/nav-swift.adoc
 asciidoc:
   attributes:
-    prerelease:
-    previous-release:
-    release: '4.0'
+    prerelease: true
+    previous-release: 
+    release: '4.1'
     # releasetag:
     major: 4
     major-net: 4
-    minor: 0
-    minor-net: 0
-    maintenance-ios: 1
+    minor: 1
+    minor-net: 1
+    maintenance-ios: 0
     maintenance-c: 0
     maintenance-android: 0
     maintenance-java: 0
     maintenance-net: 0
-    maintenance-swift: 1
+    maintenance-swift: 0
     base: 0
 
     # Used for Vector Search Extension.

--- a/modules/android/pages/upgrade.adoc
+++ b/modules/android/pages/upgrade.adoc
@@ -1,33 +1,62 @@
-
 = Upgrade
 :page-aliases: advance/java-android-dep-upgrade.adoc, dep-upgrade.adoc
 :page-role:
 
-
 :source-language: Java
-
 
 :source-language: Kotlin
 
 
-// The admonition does not apply to C as it references upgrading from versions 2.x.
-// CBL-C started at version 3.0
 [IMPORTANT]
 --
 On upgrading from a 2.x release, all Couchbase Lite databases automatically re-index on initial database open. +
 This can result in a delay before the database is usable.
 --
 
-[#4-0-0-upgrade]
+[#4-1-0-upgrade]
 == {major}.{minor}.{base}{empty} Upgrade
+
+Couchbase Lite {major}.{minor} is a non-breaking upgrade from 4.0.
+Update your Couchbase Lite dependency to {major}.{minor} -- no API or configuration changes are required.
+Existing `MultipeerReplicatorConfiguration` setups continue to work without modification.
+The default transport remains Wi-Fi only.
+
+=== Enabling Bluetooth Transport (Optional)
+
+To enable Bluetooth Low Energy transport alongside Wi-Fi, set the `transports` property on your `MultipeerReplicatorConfiguration`:
+
+[source, Kotlin]
+----
+val config = MultipeerReplicatorConfiguration(
+    peerGroupID = "myGroup",
+    identity = identity,
+    authenticator = authenticator,
+    collections = collections)
+config.transports = EnumSet.of(MultipeerTransport.WIFI, MultipeerTransport.BLUETOOTH)
+----
+
+[source, Java]
+----
+MultipeerReplicatorConfiguration config = new MultipeerReplicatorConfiguration(
+    "myGroup",
+    identity,
+    authenticator,
+    collections);
+config.setTransports(EnumSet.of(MultipeerTransport.WIFI, MultipeerTransport.BLUETOOTH));
+----
+
+Bluetooth transport requires Android API 29 or later.
+For full configuration options, see xref:android:p2psync-multipeer-transports.adoc[Configure Transports].
+
+[#4-0-0-upgrade]
+== 4.0.0 Upgrade
 
 Couchbase Lite 4.0 introduces significant architectural changes, most notably the migration from revision trees to version vectors for document versioning.
 
-
-=== Major Changes in {major}.{minor}.{base}{empty}
+=== Major Changes in 4.0.0
 
 **Version Vector Architecture**:
-CBL {major}.{minor}.{base}{empty} replaces the revision tree system with version vectors, providing improved performance, scalability, and conflict resolution.
+CBL 4.0 replaces the revision tree system with version vectors, providing improved performance, scalability, and conflict resolution.
 Documents now use version-based revision IDs in the format `<timestamp>@<source-id>` instead of the previous `<generation>-<document-hash>` format.
 
 **Enhanced Conflict Resolution**: The default conflict resolution strategy changes from `most active wins` to `last write wins` based on hybrid logical timestamps, providing more intuitive and predictable conflict resolution behavior.
@@ -35,27 +64,25 @@ Documents now use version-based revision IDs in the format `<timestamp>@<source-
 **New Document Properties**:
 a new `timestamp` property is available on Document objects, providing direct access to the document's logical timestamp as a `long` value representing nanoseconds since the Unix epoch.
 
-
 [#database-compatibility-40]
 === Database Compatibility
 
 **Automatic Upgrade from 3.x**:
-CBL {major}.{minor}.{base}{empty} databases are compatible with CBL 3.1 and 3.2 databases.
-When opening a 3.1 or 3.2 database with CBL {major}.{minor}.{base}{empty}, documents are automatically upgraded to use version vectors when they're updated and saved.
+CBL 4.0 databases are compatible with CBL 3.1 and 3.2 databases.
+When opening a 3.1 or 3.2 database with CBL 4.0, documents are automatically upgraded to use version vectors when they're updated and saved.
 
 **No Configuration Required**:
-CBL {major}.{minor}.{base}{empty} enables version vectors by default - the feature requires no API configuration.
+CBL 4.0 enables version vectors by default - the feature requires no API configuration.
 
 [#synchronization-compatibility-40]
 === Synchronization Compatibility
 
 **Sync Gateway Requirements**:
-CBL {major}.{minor}.{base}{empty} requires Sync Gateway 4.x or later for synchronization.
+CBL 4.0 requires Sync Gateway 4.x or later for synchronization.
 Attempting to sync with Sync Gateway versions prior to 4.x results in replication errors with appropriate error messages indicating the incompatibility.
 
-**Peer-to-Peer Compatibility**: CBL {major}.{minor}.{base}{empty} can only perform peer-to-peer synchronization with other CBL 4.x instances using either `URLEndpointListener` or `URLMessageEndpointListener`.
+**Peer-to-Peer Compatibility**: CBL 4.0 can only perform peer-to-peer synchronization with other CBL 4.x instances using either `URLEndpointListener` or `URLMessageEndpointListener`.
 Sync attempts with CBL 3.x peers fail with appropriate error messages.
-
 
 [#downgrading-couchbase-lite]
 == Downgrading Couchbase Lite
@@ -83,9 +110,7 @@ Users can safely downgrade between different patch versions within the same mino
 
 For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3.1.3 without issues.
 
-
 // Include standard footer
-
 
 [#related-content]
 == Related Content
@@ -100,7 +125,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 * xref:android:gs-install.adoc[Install]
 * xref:android:gs-build.adoc[Build and Run]
 
-
 .
 
 [.column]
@@ -111,21 +135,20 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 * xref:android:blob.adoc[Blobs]
 * xref:android:replication.adoc[Remote Sync Gateway]
 * xref:android:conflict.adoc[Handling Data Conflicts]
+// TODO: Uncomment when DOC-14098 pages are merged
+// * xref:android:p2psync-multipeer-transports.adoc[Configure Transports]
 
 .
 
-
 [.column]
 === {empty}
-.Dive Deeper 
+.Dive Deeper
 https://forums.couchbase.com/c/mobile/14[Mobile Forum] |
 https://blog.couchbase.com/[Blog] |
 https://docs.couchbase.com/tutorials/[Tutorials]
 
 .
 
-
 ++++
 </div>
 ++++
-

--- a/modules/c/pages/upgrade.adoc
+++ b/modules/c/pages/upgrade.adoc
@@ -2,14 +2,10 @@
 :page-aliases:
 :page-role:
 
-
 :source-language: c
 
 :url-api-references-classes: https://docs.couchbase.com/mobile/{major}.{minor}.{maintenance-c}{empty}/couchbase-lite-c/C/html/group__
 
-
-// The admonition does not apply to C as it references upgrading from versions 2.x.
-// CBL-C started at version 3.0
 
 [IMPORTANT]
 --
@@ -17,26 +13,29 @@ On upgrading from a 2.x release, all Couchbase Lite databases automatically re-i
 This can result in a delay before the database is usable.
 --
 
-[#4-0-0-upgrade]
+[#4-1-0-upgrade]
 == {major}.{minor}.{base}{empty} Upgrade
+
+Couchbase Lite {major}.{minor} is a non-breaking upgrade from 4.0.
+Update your Couchbase Lite dependency to {major}.{minor} -- no API or configuration changes are required.
+
+[#4-0-0-upgrade]
+== 4.0.0 Upgrade
 
 Couchbase Lite 4.0 introduces significant architectural changes, most notably the migration from revision trees to version vectors for document versioning.
 This upgrade requires understanding of the compatibility requirements.
 
 The action takes place automatically and can lead to some delay in the database becoming available for use in your application.
 
-In addition, if you're syncing with a {major}.{minor}.{base}{empty} Sync Gateway, you should be aware of the significant configuration enhancements introduced and their effects.
+In addition, if you're syncing with a 4.0 Sync Gateway, you should be aware of the significant configuration enhancements introduced and their effects.
 See xref:sync-gateway::upgrading.adoc[Upgrading Sync Gateway] for more details.
 This is a one-way conversion.
 
-// All API and other listed changes included in the other platforms do not apply to CBL-C for the following reasons
-// The changes apply to pre 3.x versions (CBL-C started at 3.0)
-// Or they relate to Querybuilder functionality - CBL-C doesn't have Querybuilder.
 
-=== Major Changes in {major}.{minor}.{base}{empty}
+=== Major Changes in 4.0.0
 
 **Version Vector Architecture**:
-CBL {major}.{minor}.{base}{empty} replaces the revision tree system with version vectors, providing improved performance, scalability, and conflict resolution.
+CBL 4.0 replaces the revision tree system with version vectors, providing improved performance, scalability, and conflict resolution.
 Documents now use version-based revision IDs in the format `<timestamp>@<source-id>` instead of the previous `<generation>-<document-hash>` format.
 
 **Enhanced Conflict Resolution**: The default conflict resolution strategy changes from `most active wins` to `last write wins` based on hybrid logical timestamps, providing more intuitive and predictable conflict resolution behavior.
@@ -48,20 +47,20 @@ Access to document timestamps is available through the `c4rev_getTimestamp()` fu
 === Database Compatibility
 
 **Automatic Upgrade from 3.x**:
-CBL {major}.{minor}.{base}{empty} databases are compatible with CBL 3.1 and 3.2 databases.
-When opening a 3.1 or 3.2 database with CBL {major}.{minor}.{base}{empty}, documents are automatically upgraded to use version vectors when they're updated and saved.
+CBL 4.0 databases are compatible with CBL 3.1 and 3.2 databases.
+When opening a 3.1 or 3.2 database with CBL 4.0, documents are automatically upgraded to use version vectors when they're updated and saved.
 
 **No Configuration Required**:
-CBL {major}.{minor}.{base}{empty} enables version vectors by default - the feature requires no API configuration.
+CBL 4.0 enables version vectors by default - the feature requires no API configuration.
 
 [#synchronization-compatibility-40]
 === Synchronization Compatibility
 
 **Sync Gateway Requirements**:
-CBL {major}.{minor}.{base}{empty} requires Sync Gateway 4.x or later for synchronization.
+CBL 4.0 requires Sync Gateway 4.x or later for synchronization.
 Attempting to sync with Sync Gateway versions prior to 4.x results in replication errors with appropriate error messages indicating the incompatibility.
 
-**Peer-to-Peer Compatibility**: CBL {major}.{minor}.{base}{empty} can only perform peer-to-peer synchronization with other CBL 4.x instances using either `CBLURLEndpointListener` or `CBLMessageEndpointListener`.
+**Peer-to-Peer Compatibility**: CBL 4.0 can only perform peer-to-peer synchronization with other CBL 4.x instances using either `CBLURLEndpointListener` or `CBLMessageEndpointListener`.
 Sync attempts with CBL 3.x peers fail with appropriate error messages.
 
 [#replication-compatibility]
@@ -103,7 +102,6 @@ Users can downgrade between different patch versions within the same minor relea
 
 For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3.1.3 without issues.
 
-// Include standard footer
 
 [#related-content]
 == Related Content

--- a/modules/csharp/pages/upgrade.adoc
+++ b/modules/csharp/pages/upgrade.adoc
@@ -2,12 +2,9 @@
 :page-aliases: advance/csharp-dep-upgrade.adoc, dep-upgrade.adoc
 :page-role:
 
-
 :source-language: c#
 
 
-// The admonition does not apply to C as it references upgrading from versions 2.x.
-// CBL-C started at version 3.0
 [IMPORTANT]
 --
 On upgrading from a 3.x release, all Couchbase Lite databases automatically re-index on initial database open. +

--- a/modules/java/pages/upgrade.adoc
+++ b/modules/java/pages/upgrade.adoc
@@ -3,27 +3,47 @@
 :page-role:
 :description:
 
-
 :source-language: Java
 
-
-// The admonition does not apply to C as it references upgrading from versions 2.x.
-// CBL-C started at version 3.0
 [IMPORTANT]
 --
 On upgrading from a 2.x release, all Couchbase Lite databases automatically re-index on initial database open. +
 This can result in a delay before the database is usable.
 --
 
-[#4-0-0-upgrade]
+[#4-1-0-upgrade]
 == {major}.{minor}.{base}{empty} Upgrade
+
+Couchbase Lite {major}.{minor} is a non-breaking upgrade from 4.0.
+Update your Couchbase Lite dependency to {major}.{minor} -- no API or configuration changes are required.
+Existing `MultipeerReplicatorConfiguration` setups continue to work without modification.
+The default transport remains Wi-Fi only.
+
+=== Enabling Bluetooth Transport (Optional)
+
+To enable Bluetooth Low Energy transport alongside Wi-Fi, set the `transports` property on your `MultipeerReplicatorConfiguration`:
+
+[source, Java]
+----
+MultipeerReplicatorConfiguration config = new MultipeerReplicatorConfiguration(
+    "myGroup",
+    identity,
+    authenticator,
+    collections);
+config.setTransports(EnumSet.of(MultipeerTransport.WIFI, MultipeerTransport.BLUETOOTH));
+----
+
+Bluetooth transport requires Android API 29 or later.
+
+[#4-0-0-upgrade]
+== 4.0.0 Upgrade
 
 Couchbase Lite 4.0 introduces significant architectural changes, most notably the migration from revision trees to version vectors for document versioning.
 
-=== Major Changes in {major}.{minor}.{base}{empty}
+=== Major Changes in 4.0.0
 
 **Version Vector Architecture**:
-CBL {major}.{minor}.{base}{empty} replaces the revision tree system with version vectors, providing improved performance, scalability, and conflict resolution.
+CBL 4.0 replaces the revision tree system with version vectors, providing improved performance, scalability, and conflict resolution.
 Documents now use version-based revision IDs in the format `<timestamp>@<source-id>` instead of the previous `<generation>-<document-hash>` format.
 
 **Enhanced Conflict Resolution**: The default conflict resolution strategy changes from `most active wins` to `last write wins` based on hybrid logical timestamps, providing more intuitive and predictable conflict resolution behavior.
@@ -35,20 +55,20 @@ a new `getTimestamp()` method is available on Document objects, providing direct
 === Database Compatibility
 
 **Automatic Upgrade from 3.x**:
-CBL {major}.{minor}.{base}{empty} databases are compatible with CBL 3.1 and 3.2 databases.
-When opening a 3.1 or 3.2 database with CBL {major}.{minor}.{base}{empty}, documents are automatically upgraded to use version vectors when they're updated and saved.
+CBL 4.0 databases are compatible with CBL 3.1 and 3.2 databases.
+When opening a 3.1 or 3.2 database with CBL 4.0, documents are automatically upgraded to use version vectors when they're updated and saved.
 
 **No Configuration Required**:
-CBL {major}.{minor}.{base}{empty} enables version vectors by default - the feature requires no API configuration.
+CBL 4.0 enables version vectors by default - the feature requires no API configuration.
 
 [#synchronization-compatibility-40]
 === Synchronization Compatibility
 
 **Sync Gateway Requirements**:
-CBL {major}.{minor}.{base}{empty} requires Sync Gateway 4.x or later for synchronization.
+CBL 4.0 requires Sync Gateway 4.x or later for synchronization.
 Attempting to sync with Sync Gateway versions prior to 4.x results in replication errors with appropriate error messages indicating the incompatibility.
 
-**Peer-to-Peer Compatibility**: CBL {major}.{minor}.{base}{empty} can only perform peer-to-peer synchronization with other CBL 4.x instances using either `URLEndpointListener` or `MessageEndpointListener`.
+**Peer-to-Peer Compatibility**: CBL 4.0 can only perform peer-to-peer synchronization with other CBL 4.x instances using either `URLEndpointListener` or `MessageEndpointListener`.
 Sync attempts with CBL 3.x peers fail with appropriate error messages.
 
 [#replication-compatibility]
@@ -67,7 +87,7 @@ Sync attempts with CBL 3.x or earlier peers fails with appropriate error message
 [#api-changes]
 === API Changes
 
-This section introduces the changes made to the Couchbase Lite for Java API for release {major}.{minor}.{base}{empty}.
+This section introduces the changes made to the Couchbase Lite for Java API for release 4.0.0.
 
 [#removed]
 ==== Removed
@@ -76,7 +96,7 @@ This section introduces the changes made to the Couchbase Lite for Java API for 
 ===== ResetCheckpoint
 
 The method https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/AbstractReplicator.html#resetCheckpoint--[Replicator.resetCheckpoint()] method has been removed. +
-Instead, use https://docs.couchbase.com/mobile/{major}.{minor}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/AbstractReplicator.html#start-boolean-[Replicator.resetCheckpoint(boolean reset)].
+Instead, use https://docs.couchbase.com/mobile/4.0.0/couchbase-lite-java/com/couchbase/lite/AbstractReplicator.html#start-boolean-[Replicator.resetCheckpoint(boolean reset)].
 
 .Before
 [source, Java,subs="attributes+, macros+"]
@@ -118,7 +138,7 @@ Database.log.getFile().setDomains(LogLevel.DEBUG)
 [#database-compact]
 ===== Database.compact
 The https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/Database.html#compact--[Database.compact()] method has been removed. +
-It's replaced by the new https://docs.couchbase.com/mobile/{major}.{minor}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/Database.html#performMaintenance-com.couchbase.lite.MaintenanceType-[Database.performMaintenance(MaintenanceType)] method, and the maintenance operations represented in the enum https://docs.couchbase.com/mobile/{major}.{minor}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/MaintenanceType.html[MaintenanceType]
+It's replaced by the new https://docs.couchbase.com/mobile/4.0.0/couchbase-lite-java/com/couchbase/lite/Database.html#performMaintenance-com.couchbase.lite.MaintenanceType-[Database.performMaintenance(MaintenanceType)] method, and the maintenance operations represented in the enum https://docs.couchbase.com/mobile/4.0.0/couchbase-lite-java/com/couchbase/lite/MaintenanceType.html[MaintenanceType]
 
 .Before
 [source, Java,subs="attributes+, macros+"]
@@ -139,7 +159,7 @@ testdb.performMaintenance(MaintenanceType.COMPACT)
 ===== MATCH
 The class, https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/FullTextExpression.html[FullTextExpression]
 has been deprecated. +
-Use https://docs.couchbase.com/mobile/{major}.{minor}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/FullTextFunction.html[FullTextFunction] instead.
+Use https://docs.couchbase.com/mobile/4.0.0/couchbase-lite-java/com/couchbase/lite/FullTextFunction.html[FullTextFunction] instead.
 
 .Before
 [source, Java,subs="attributes+, macros+"]
@@ -224,9 +244,9 @@ ReplicatorConfiguration config =
 The enum https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/AbstractReplicator.ActivityLevel.html[AbstractReplicator.ActivityLevel] and the classes https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/AbstractReplicator.Progress.html[AbstractReplicator.Progress] and https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/AbstractReplicator.Status.html[AbstractReplicator.Status] have all been moved to be top level definitions. +
 They are replaced by these definitions:
 
-* https://docs.couchbase.com/mobile/{major}.{minor}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/ReplicatorActivityLevel.html[ReplicatorActivityLevel]
-* https://docs.couchbase.com/mobile/{major}.{minor}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/ReplicatorProgress.html[ReplicatorProgress]
-* https://docs.couchbase.com/mobile/{major}.{minor}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/ReplicatorStatus.html[ReplicatorStatus]
+* https://docs.couchbase.com/mobile/4.0.0/couchbase-lite-java/com/couchbase/lite/ReplicatorActivityLevel.html[ReplicatorActivityLevel]
+* https://docs.couchbase.com/mobile/4.0.0/couchbase-lite-java/com/couchbase/lite/ReplicatorProgress.html[ReplicatorProgress]
+* https://docs.couchbase.com/mobile/4.0.0/couchbase-lite-java/com/couchbase/lite/ReplicatorStatus.html[ReplicatorStatus]
 
 .Before
 [source, Java,subs="attributes+, macros+"]
@@ -309,6 +329,8 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 * xref:java:blob.adoc[Blobs]
 * xref:java:replication.adoc[Remote Sync Gateway]
 * xref:java:conflict.adoc[Handling Data Conflicts]
+// TODO: Uncomment when DOC-14098 pages are merged
+// * xref:java:p2psync-multipeer-transports.adoc[Configure Transports]
 
 .
 

--- a/modules/objc/pages/upgrade.adoc
+++ b/modules/objc/pages/upgrade.adoc
@@ -3,39 +3,58 @@
 :page-role:
 :description:
 
-
-:source-language: objc
-
 :source-language: objc
 
 
-// The admonition does not apply to C as it references upgrading from versions 2.x.
-// CBL-C started at version 3.0
 [IMPORTANT]
 --
 On upgrading from a 2.x release, all Couchbase Lite databases automatically re-index on initial database open. +
 This can result in a delay before the database is usable.
 --
 
-[#4-0-0-upgrade]
+[#4-1-0-upgrade]
 == {major}.{minor}.{maintenance-ios}{empty} Upgrade
+
+Couchbase Lite {major}.{minor} is a non-breaking upgrade from 4.0.
+Update your Couchbase Lite dependency to {major}.{minor} -- no API or configuration changes are required.
+Existing `CBLMultipeerReplicatorConfiguration` setups continue to work without modification.
+The default transport remains Wi-Fi only.
+
+=== Enabling Bluetooth Transport (Optional)
+
+To enable Bluetooth Low Energy transport alongside Wi-Fi, set the `transports` property on your `CBLMultipeerReplicatorConfiguration`:
+
+[source, objc]
+----
+CBLMultipeerReplicatorConfiguration *config = [[CBLMultipeerReplicatorConfiguration alloc]
+    initWithPeerGroupID: @"myGroup"
+    identity: identity
+    authenticator: authenticator
+    collections: collections];
+config.transports = kCBLMultipeerTransportWifi | kCBLMultipeerTransportBluetooth;
+----
+
+Bluetooth transport requires iOS 15.0 or later.
+
+[#4-0-0-upgrade]
+== 4.0.0 Upgrade
 
 Couchbase Lite 4.0 introduces significant architectural changes, most notably the migration from revision trees to version vectors for document versioning.
 This upgrade requires careful planning and understanding of the compatibility requirements.
 
 The action takes place automatically and can lead to some delay in the database becoming available for use in your application.
 
-In addition, if you're syncing with a {major}.{minor}.{maintenance-ios}{empty} Sync Gateway, you should be aware of the significant configuration enhancements introduced and their effect.
+In addition, if you're syncing with a 4.0 Sync Gateway, you should be aware of the significant configuration enhancements introduced and their effect.
 See xref:sync-gateway::upgrading.adoc[Upgrading Sync Gateway] for more details.
 This is a one-way conversion.
 
 // All API and other listed changes included in the other platforms do not apply to CBL-C for the following reasons
 // The changes apply to pre 3.x versions (CBL-C started at 3.0)
 // Or they relate to Querybuilder functionality - CBL-C doesn't have Querybuilder.
-=== Major Changes in {major}.{minor}.{maintenance-ios}{empty}
+=== Major Changes in 4.0.0
 
 **Version Vector Architecture**:
-CBL {major}.{minor}.{maintenance-ios}{empty} replaces the revision tree system with version vectors, providing improved performance, scalability, and conflict resolution.
+CBL 4.0 replaces the revision tree system with version vectors, providing improved performance, scalability, and conflict resolution.
 Documents now use version-based revision IDs in the format `<timestamp>@<source-id>` instead of the previous `<generation>-<document-hash>` format.
 
 **Enhanced Conflict Resolution**: The default conflict resolution strategy changes from `most active wins` to `last write wins` based on hybrid logical timestamps, providing more intuitive and predictable conflict resolution behavior.
@@ -47,20 +66,20 @@ a new `timestamp` property is available on Document objects, providing direct ac
 === Database Compatibility
 
 **Automatic Upgrade from 3.x**:
-CBL {major}.{minor}.{maintenance-ios}{empty} databases are compatible with CBL 3.1 and 3.2 databases.
-When opening a 3.1 or 3.2 database with CBL {major}.{minor}.{maintenance-ios}{empty}, documents are automatically upgraded to use version vectors when they're updated and saved.
+CBL 4.0 databases are compatible with CBL 3.1 and 3.2 databases.
+When opening a 3.1 or 3.2 database with CBL 4.0, documents are automatically upgraded to use version vectors when they're updated and saved.
 
 **No Configuration Required**:
-CBL {major}.{minor}.{maintenance-ios}{empty} enables version vectors by default - the feature requires no API configuration.
+CBL 4.0 enables version vectors by default - the feature requires no API configuration.
 
 [#synchronization-compatibility-40]
 === Synchronization Compatibility
 
 **Sync Gateway Requirements**:
-CBL {major}.{minor}.{maintenance-ios}{empty} requires Sync Gateway 4.x or later for synchronization.
+CBL 4.0 requires Sync Gateway 4.x or later for synchronization.
 Attempting to sync with Sync Gateway versions prior to 4.x results in replication errors with appropriate error messages indicating the incompatibility.
 
-**Peer-to-Peer Compatibility**: CBL {major}.{minor}.{maintenance-ios}{empty} can only perform peer-to-peer synchronization with other CBL 4.x instances using either `CBLURLEndpointListener` or `CBLMessageEndpointListener`.
+**Peer-to-Peer Compatibility**: CBL 4.0 can only perform peer-to-peer synchronization with other CBL 4.x instances using either `CBLURLEndpointListener` or `CBLMessageEndpointListener`.
 Sync attempts with CBL 3.x peers fail with appropriate error messages.
 
 [#api-changes]
@@ -276,6 +295,8 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 * xref:objc:blob.adoc[Blobs]
 * xref:objc:replication.adoc[Remote Sync Gateway]
 * xref:objc:conflict.adoc[Handling Data Conflicts]
+// TODO: Uncomment when DOC-14098 pages are merged
+// * xref:objc:p2psync-multipeer-transports.adoc[Configure Transports]
 
 .
 

--- a/modules/swift/pages/upgrade.adoc
+++ b/modules/swift/pages/upgrade.adoc
@@ -12,22 +12,46 @@ On upgrading from a 2.x release, all Couchbase Lite databases automatically re-i
 This can result in a delay before the database is usable.
 --
 
-[#4-0-0-upgrade]
+[#4-1-0-upgrade]
 == {major}.{minor}.{maintenance-ios}{empty} Upgrade
+
+Couchbase Lite {major}.{minor} is a non-breaking upgrade from 4.0.
+Update your Couchbase Lite dependency to {major}.{minor} -- no API or configuration changes are required.
+Existing `MultipeerReplicatorConfiguration` setups continue to work without modification.
+The default transport remains Wi-Fi only.
+
+=== Enabling Bluetooth Transport (Optional)
+
+To enable Bluetooth Low Energy transport alongside Wi-Fi, set the `transports` property on your `MultipeerReplicatorConfiguration`:
+
+[source, swift]
+----
+var config = MultipeerReplicatorConfiguration(
+    peerGroupID: "myGroup",
+    identity: identity,
+    authenticator: authenticator,
+    collections: collections)
+config.transports = [.wifi, .bluetooth]
+----
+
+Bluetooth transport requires iOS 15.0 or later.
+
+[#4-0-0-upgrade]
+== 4.0.0 Upgrade
 
 Couchbase Lite 4.0 introduces significant architectural changes, most notably the migration from revision trees to version vectors for document versioning.
 This upgrade requires understanding of the compatibility requirements.
 
 The action takes place automatically and can lead to some delay in the database becoming available for use in your application.
 
-In addition, if you're syncing with a {major}.{minor}.{maintenance-ios}{empty} Sync Gateway, you should be aware of the significant configuration enhancements introduced and their effects.
+In addition, if you're syncing with a 4.0 Sync Gateway, you should be aware of the significant configuration enhancements introduced and their effects.
 See xref:sync-gateway::upgrading.adoc[Upgrading Sync Gateway] for more details.
 This is a one-way conversion.
 
-=== Major Changes in {major}.{minor}.{maintenance-ios}{empty}
+=== Major Changes in 4.0.0
 
 **Version Vector Architecture**:
-CBL {major}.{minor}.{maintenance-ios}{empty} replaces the revision tree system with version vectors, providing improved performance, scalability, and conflict resolution.
+CBL 4.0 replaces the revision tree system with version vectors, providing improved performance, scalability, and conflict resolution.
 Documents now use version-based revision IDs in the format `<timestamp>@<source-id>` instead of the previous `<generation>-<document-hash>` format.
 
 **Enhanced Conflict Resolution**: The default conflict resolution strategy changes from `most active wins` to `last write wins` based on hybrid logical timestamps, providing more intuitive and predictable conflict resolution behavior.
@@ -39,20 +63,20 @@ a new `timestamp` property is available on Document objects, providing direct ac
 === Database Compatibility
 
 **Automatic Upgrade from 3.x**:
-CBL {major}.{minor}.{maintenance-ios}{empty} databases are compatible with CBL 3.1 and 3.2 databases.
-When opening a 3.1 or 3.2 database with CBL {major}.{minor}.{maintenance-ios}{empty}, documents are automatically upgraded to use version vectors when they're updated and saved.
+CBL 4.0 databases are compatible with CBL 3.1 and 3.2 databases.
+When opening a 3.1 or 3.2 database with CBL 4.0, documents are automatically upgraded to use version vectors when they're updated and saved.
 
 **No Configuration Required**:
-CBL {major}.{minor}.{maintenance-ios}{empty} enables version vectors by default - the feature requires no API configuration.
+CBL 4.0 enables version vectors by default - the feature requires no API configuration.
 
 [#synchronization-compatibility-40]
 === Synchronization Compatibility
 
 **Sync Gateway Requirements**:
-CBL {major}.{minor}.{maintenance-ios}{empty} requires Sync Gateway 4.x or later for synchronization.
+CBL 4.0 requires Sync Gateway 4.x or later for synchronization.
 Attempting to sync with Sync Gateway versions prior to 4.x results in replication errors with appropriate error messages indicating the incompatibility.
 
-**Peer-to-Peer Compatibility**: CBL {major}.{minor}.{maintenance-ios}{empty} can only perform peer-to-peer synchronization with other CBL 4.x instances using either `URLEndpointListener` or `MessageEndpointListener`.
+**Peer-to-Peer Compatibility**: CBL 4.0 can only perform peer-to-peer synchronization with other CBL 4.x instances using either `URLEndpointListener` or `MessageEndpointListener`.
 Sync attempts with CBL 3.x peers fail with appropriate error messages.
 
 [#api-changes]
@@ -264,7 +288,7 @@ For example, when a new minor version such as CBL 3.1.0 becomes available, the r
 === Downgrading Between Patch Releases
 
 *Full Downgrade Support* - Couchbase Lite supports downgrades between patch releases.
-Users can downgrade between different patch versions within the same minor release.
+Users can safely downgrade between different patch versions within the same minor release.
 
 For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3.1.3 without issues.
 
@@ -294,6 +318,8 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 * xref:swift:blob.adoc[Blobs]
 * xref:swift:replication.adoc[Remote Sync Gateway]
 * xref:swift:conflict.adoc[Handling Data Conflicts]
+// TODO: Uncomment when DOC-14098 pages are merged
+// * xref:swift:p2psync-multipeer-transports.adoc[Configure Transports]
 
 .
 


### PR DESCRIPTION
Docs Issue: [DOC-14095](https://jira.issues.couchbase.com/browse/DOC-14095)

PR to update the upgrade pages for the CBL platforms

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-14095-upgrade-instructions

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-14095]: https://couchbasecloud.atlassian.net/browse/DOC-14095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ