### PR TITLE
DOC-14209-added release notes for 3.2.5 and update version number

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -25,7 +25,7 @@ asciidoc:
     maintenance-c: 4
     maintenance-android: 4
     maintenance-java: 4
-    maintenance-net: 4
+    maintenance-net: 5
     base: 4
 
     # Used for Vector Search Extension.

--- a/modules/csharp/pages/gs-install.adoc
+++ b/modules/csharp/pages/gs-install.adoc
@@ -19,19 +19,19 @@ _Abstract -- Using Nuget to install Couchbase Lite on csharp_ +
 
 .Quick Steps
 ****
-For experienced developers, this is all you need to add _Couchbase Lite for C#.Net {major}.{minor}.{base}{empty}_ to your application projects.
+For experienced developers, this is all you need to add _Couchbase Lite for C#.Net {major}.{minor}.{maintenance-net}{empty}_ to your application projects.
 
 . Create or open an existing Visual Studio project
 
 . Install either of the following packages from Nuget.
 +
-* Community Edition -- `Couchbase.Lite` package for {major}.{minor}.{base}{empty}
+* Community Edition -- `Couchbase.Lite` package for {major}.{minor}.{maintenance-net}{empty}
 
-* Enterprise Edition -- `Couchbase.Lite.Enterprise` package for {major}.{minor}.{base}{empty}
+* Enterprise Edition -- `Couchbase.Lite.Enterprise` package for {major}.{minor}.{maintenance-net}{empty}
 
 ** Vector Search Extension -- `Couchbase.Lite.VectorSearch` package for {vs-major}.{vs-minor}.{vs-maintenance-net}{empty}
 
-. Within your app, include a call to the relevant `Activate()` function inside of the class that is included in the support assembly.
+. Within your app, include a call to the relevant `Activate()` function inside of the class that's included in the support assembly.
 
 [IMPORTANT]
 --

--- a/modules/csharp/pages/releasenotes.adoc
+++ b/modules/csharp/pages/releasenotes.adoc
@@ -8,6 +8,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: C#.Net
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-csharp-release-note.3.2.5.adoc[]
+
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.2.4.adoc[]
 
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.2.3.adoc[]

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.2.5.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.2.5.adoc
@@ -1,0 +1,23 @@
+[#maint-3-2-5]
+== 3.2.5 -- April 2026
+
+Version 3.2.5 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://jira.issues.couchbase.com/browse/CBL-7625[CBL-7625 -- Upgrade MbedTLS to 3.6.4]
+
+=== Issues and Resolutions
+
+* https://jira.issues.couchbase.com/browse/CBL-7213[CBL-7213 -- Assertion Failure in URLEndpointListener Due to Collection Mismatch with Connected Replicator]
+* https://jira.issues.couchbase.com/browse/CBL-8010[CBL-8010 -- Fix potential crash in logging callback handling]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.2.0, see xref:ROOT:cbl-whatsnew.adoc[New in 3.2]


### PR DESCRIPTION
Docs Issue: [DOC-14209](https://jira.issues.couchbase.com/browse/DOC-14209?atlOrigin=eyJpIjoiYzkyM2VjNzc3MTNiNDQ4NDkyZWY4MTAxNzliOWRmZTIiLCJwIjoiaiJ9)

PR to add CBL .NET 3.2.5 release notes 

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-14209-cbl-net-3-2-5/couchbase-lite/current/csharp/releasenotes.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-14209]: https://couchbasecloud.atlassian.net/browse/DOC-14209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ