### PR TITLE
DOC-14249-update version number for c

### DIFF
--- a/modules/c/pages/gs-downloads.adoc
+++ b/modules/c/pages/gs-downloads.adoc
@@ -23,7 +23,7 @@ xref:c:gs-build.adoc[Build and Run]
 .Downloads are available for the following versions:
 ****
 <<release-{major}-{minor}-{maintenance-c}>>   |
-<<vs-release-1-0-0>>   |
+<<vs-release-2-0-0>>   |
 // |
 ****
 
@@ -34,8 +34,8 @@ include::partial$downloadslist.adoc[]
 :param-version!:
 :param-version-hyphenated!:
 
-:vs-param-version: 1.0.0
-:vs-param-version-hyphenated: 1-0-0
+:vs-param-version: 2.0.0
+:vs-param-version-hyphenated: 2-0-0
 include::partial$downloadslist.adoc[]
 :vs-param-version!:
 :vs-param-version-hyphenated!:


### PR DESCRIPTION
Docs Issue: [https://jira.issues.couchbase.com/browse/DOC-14249?atlOrigin=eyJpIjoiZDFkZmYxYjc1NzFlNDFiMWIwM2MxMzI1NWUzN2JiYzAiLCJwIjoiaiJ9](https://jira.issues.couchbase.com/browse/DOC-14249?atlOrigin=eyJpIjoiZDFkZmYxYjc1NzFlNDFiMWIwM2MxMzI1NWUzN2JiYzAiLCJwIjoiaiJ9)

PR to update the version number vector search C download page

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-14249-updat-cbl-version

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.