### PR TITLE
DOC-14363-release notes 3.2.6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,19 +9,19 @@ pipeline {
                 stage("Validate C#") {
                     agent { label 's61113u16 (litecore)' }
                     steps {
-                        sh 'jenkins/dotnet_build.sh 3.2.4 1.0.0'
+                        sh 'jenkins/dotnet_build.sh 3.2.6 1.0.0'
                     }
                 }
                 stage("Validate C") {
                     agent { label 's61113u16 (litecore)' }
                     steps {
-                        sh 'jenkins/c_build.sh 3.2.4'
+                        sh 'jenkins/c_build.sh 3.2.6'
                     }
                 }
                 stage("Validate iOS") {
                     agent { label 'mobile-builder-ios-pull-request' }
                     steps {
-                        sh 'jenkins/ios.sh 3.2.4 1.0.0'
+                        sh 'jenkins/ios.sh 3.2.6 1.0.0'
                     }
                 }
             }

--- a/modules/ROOT/pages/cbl-whatsnew.adoc
+++ b/modules/ROOT/pages/cbl-whatsnew.adoc
@@ -11,6 +11,22 @@ NOTE: Couchbase Lite 3.0 introduces some breaking changes. +
 If you're upgrading from 2.x, refer to the appropriate upgrade page -- see: <<lbl-upgrade>>. +
 You should be able to upgrade from 3.0.x to 3.1.x without manual intervention.
 
+== Release 3.2.6 (May 2026)
+
+Couchbase Lite Release 3.2.6 introduces fixes and enhancements for:
+
+xref:android:releasenotes.adoc#maint-latest[Android]
+|
+xref:c:releasenotes.adoc#maint-latest[C]
+|
+xref:csharp:releasenotes.adoc#maint-latest[.NET]
+|
+xref:java:releasenotes.adoc#maint-latest[Java]
+|
+xref:objc:releasenotes.adoc#maint-latest[Objective-C]
+|
+xref:swift:releasenotes.adoc#maint-latest[Swift]
+
 == Release 3.2.5 (April 2026)
 
 Couchbase Lite Release 3.2.5 introduces fixes and enhancements for:

--- a/modules/android/pages/releasenotes.adoc
+++ b/modules/android/pages/releasenotes.adoc
@@ -8,6 +8,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: Android
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-android-release-note.3.2.6.adoc[]
+
 include::partial$release-notes/couchbase-mobile-android-release-note.3.2.4.adoc[]
 
 include::partial$release-notes/couchbase-mobile-android-release-note.3.2.3.adoc[]

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.2.6.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.2.6.adoc
@@ -11,7 +11,9 @@ Version 3.2.6 for {param-title} delivers the following features and enhancements
 
 === Issues and Resolutions
 
-None for this release.
+* https://jira.issues.couchbase.com/browse/CBL-7065[CBL-7065 -- Replicator authentication failure with non-ASCII passwords]
+* https://jira.issues.couchbase.com/browse/CBL-7386[CBL-7386 -- Potential pull replicator crash when pulling a large number of documents]
+* https://jira.issues.couchbase.com/browse/CBL-8291[CBL-8291 -- Push and pull filters letting documents through on unexpected errors]
 
 === Known Issues
 

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.2.6.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.2.6.adoc
@@ -1,0 +1,24 @@
+[#maint-3-2-6]
+== 3.2.6 -- May 2026
+
+Version 3.2.6 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://jira.issues.couchbase.com/browse/CBL-8071[CBL-8071 -- Improve replicator WebSocket close completion when the server fails to acknowledge close]
+* https://jira.issues.couchbase.com/browse/CBL-8102[CBL-8102 -- Upgrade SQLite to 3.53.0]
+* https://jira.issues.couchbase.com/browse/CBL-8181[CBL-8181 -- Upgrade mbedTLS to 3.6.6]
+
+=== Issues and Resolutions
+
+None for this release.
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.2.0, see xref:ROOT:cbl-whatsnew.adoc[New in 3.2]

--- a/modules/c/pages/releasenotes.adoc
+++ b/modules/c/pages/releasenotes.adoc
@@ -9,6 +9,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-abstract: This content describes the key features and changes implemented by release {version} of Couchbase Lite on {param-title}
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-c-release-note.3.2.6.adoc[]
+
 include::partial$release-notes/couchbase-mobile-c-release-note.3.2.4.adoc[]
 
 include::partial$release-notes/couchbase-mobile-c-release-note.3.2.3.adoc[]

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.2.6.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.2.6.adoc
@@ -1,0 +1,24 @@
+[#maint-3-2-6]
+== 3.2.6 -- May 2026
+
+Version 3.2.6 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://jira.issues.couchbase.com/browse/CBL-8071[CBL-8071 -- Improve replicator WebSocket close completion when the server fails to acknowledge close]
+* https://jira.issues.couchbase.com/browse/CBL-8102[CBL-8102 -- Upgrade SQLite to 3.53.0]
+* https://jira.issues.couchbase.com/browse/CBL-8181[CBL-8181 -- Upgrade mbedTLS to 3.6.6]
+
+=== Issues and Resolutions
+
+* https://jira.issues.couchbase.com/browse/CBL-7386[CBL-7386 -- Potential pull replicator crash when pulling a large number of documents]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.2.0, see xref:ROOT:cbl-whatsnew.adoc[New in 3.2]

--- a/modules/csharp/pages/releasenotes.adoc
+++ b/modules/csharp/pages/releasenotes.adoc
@@ -8,6 +8,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: C#.Net
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-csharp-release-note.3.2.6.adoc[]
+
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.2.5.adoc[]
 
 include::partial$release-notes/couchbase-mobile-csharp-release-note.3.2.4.adoc[]

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.2.6.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.2.6.adoc
@@ -1,0 +1,25 @@
+[#maint-3-2-6]
+== 3.2.6 -- May 2026
+
+Version 3.2.6 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://jira.issues.couchbase.com/browse/CBL-8071[CBL-8071 -- Improve replicator WebSocket close completion when the server fails to acknowledge close]
+* https://jira.issues.couchbase.com/browse/CBL-8102[CBL-8102 -- Upgrade SQLite to 3.53.0]
+* https://jira.issues.couchbase.com/browse/CBL-8181[CBL-8181 -- Upgrade mbedTLS to 3.6.6]
+
+=== Issues and Resolutions
+
+* https://jira.issues.couchbase.com/browse/CBL-7111[CBL-7111 -- Partial indexes not functioning in .NET Community Edition]
+* https://jira.issues.couchbase.com/browse/CBL-8116[CBL-8116 -- Push and pull filters letting documents through on unexpected errors]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.2.0, see xref:ROOT:cbl-whatsnew.adoc[New in 3.2]

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.2.6.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.2.6.adoc
@@ -12,6 +12,7 @@ Version 3.2.6 for {param-title} delivers the following features and enhancements
 === Issues and Resolutions
 
 * https://jira.issues.couchbase.com/browse/CBL-7111[CBL-7111 -- Partial indexes not functioning in .NET Community Edition]
+* https://jira.issues.couchbase.com/browse/CBL-7386[CBL-7386 -- Potential pull replicator crash when pulling a large number of documents]
 * https://jira.issues.couchbase.com/browse/CBL-8116[CBL-8116 -- Push and pull filters letting documents through on unexpected errors]
 
 === Known Issues

--- a/modules/java/pages/releasenotes.adoc
+++ b/modules/java/pages/releasenotes.adoc
@@ -8,6 +8,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: Java
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-java-release-note.3.2.6.adoc[]
+
 include::partial$release-notes/couchbase-mobile-java-release-note.3.2.4.adoc[]
 
 include::partial$release-notes/couchbase-mobile-java-release-note.3.2.3.adoc[]

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.2.6.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.2.6.adoc
@@ -1,0 +1,26 @@
+[#maint-3-2-6]
+== 3.2.6 -- May 2026
+
+Version 3.2.6 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://jira.issues.couchbase.com/browse/CBL-7550[CBL-7550 -- Add CouchbaseLite.shutdown() to release shared executor services]
+* https://jira.issues.couchbase.com/browse/CBL-8102[CBL-8102 -- Upgrade SQLite to 3.53.0]
+* https://jira.issues.couchbase.com/browse/CBL-8181[CBL-8181 -- Upgrade mbedTLS to 3.6.6]
+
+=== Issues and Resolutions
+
+* https://jira.issues.couchbase.com/browse/CBL-7065[CBL-7065 -- Replicator authentication failure with non-ASCII passwords]
+* https://jira.issues.couchbase.com/browse/CBL-7386[CBL-7386 -- Potential pull replicator crash when pulling a large number of documents]
+* https://jira.issues.couchbase.com/browse/CBL-8291[CBL-8291 -- Push and pull filters letting documents through on unexpected errors]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.2.0, see xref:ROOT:cbl-whatsnew.adoc[New in 3.2]

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.2.6.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.2.6.adoc
@@ -6,6 +6,7 @@ Version 3.2.6 for {param-title} delivers the following features and enhancements
 === Enhancements
 
 * https://jira.issues.couchbase.com/browse/CBL-7550[CBL-7550 -- Add CouchbaseLite.shutdown() to release shared executor services]
+* https://jira.issues.couchbase.com/browse/CBL-8071[CBL-8071 -- Improve replicator WebSocket close completion when the server fails to acknowledge close]
 * https://jira.issues.couchbase.com/browse/CBL-8102[CBL-8102 -- Upgrade SQLite to 3.53.0]
 * https://jira.issues.couchbase.com/browse/CBL-8181[CBL-8181 -- Upgrade mbedTLS to 3.6.6]
 

--- a/modules/objc/pages/releasenotes.adoc
+++ b/modules/objc/pages/releasenotes.adoc
@@ -8,6 +8,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: Objective-C
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-objc-release-note.3.2.6.adoc[]
+
 include::partial$release-notes/couchbase-mobile-objc-release-note.3.2.4.adoc[]
 
 include::partial$release-notes/couchbase-mobile-objc-release-note.3.2.3.adoc[]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.2.6.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.2.6.adoc
@@ -9,8 +9,6 @@ None for this release
 
 === Issues and Resolutions
 
-include::ROOT:partial$release-notes/couchbase-mobile-litecore-release-note.3.2.6.adoc[tags=fixes]
-
 * https://jira.issues.couchbase.com/browse/CBL-7014[CBL-7014 -- Invalid or Inconsistent Certificate Locality Key Name]
 
 * https://jira.issues.couchbase.com/browse/CBL-6981[CBL-6981 -- Crash When Accessing Weak Cache of Nested Dictionary/Array/Blob]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.2.6.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.2.6.adoc
@@ -1,0 +1,28 @@
+[#maint-3-2-6]
+== 3.2.6 -- May 2026
+
+Version 3.2.6 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release
+
+=== Issues and Resolutions
+
+include::ROOT:partial$release-notes/couchbase-mobile-litecore-release-note.3.2.6.adoc[tags=fixes]
+
+* https://jira.issues.couchbase.com/browse/CBL-7014[CBL-7014 -- Invalid or Inconsistent Certificate Locality Key Name]
+
+* https://jira.issues.couchbase.com/browse/CBL-6981[CBL-6981 -- Crash When Accessing Weak Cache of Nested Dictionary/Array/Blob]
+
+* https://jira.issues.couchbase.com/browse/CBL-6959[CBL-6959 -- UserAgent info in the log shows incorrect LiteCore version]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.2.0, see xref:ROOT:cbl-whatsnew.adoc[New in 3.2]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.2.6.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.2.6.adoc
@@ -5,15 +5,20 @@ Version 3.2.6 for {param-title} delivers the following features and enhancements
 
 === Enhancements
 
-None for this release
+* https://jira.issues.couchbase.com/browse/CBL-8071[CBL-8071 -- Improve replicator WebSocket close completion when the server fails to acknowledge close]
+
+* https://jira.issues.couchbase.com/browse/CBL-8102[CBL-8102 -- Upgrade SQLite to 3.53.0]
+
+* https://jira.issues.couchbase.com/browse/CBL-8181[CBL-8181 -- Upgrade mbedTLS to 3.6.6]
+
 
 === Issues and Resolutions
 
-* https://jira.issues.couchbase.com/browse/CBL-7014[CBL-7014 -- Invalid or Inconsistent Certificate Locality Key Name]
+* https://jira.issues.couchbase.com/browse/CBL-7386[CBL-7386 -- Potential pull replicator crash when pulling a large number of documents]
 
-* https://jira.issues.couchbase.com/browse/CBL-6981[CBL-6981 -- Crash When Accessing Weak Cache of Nested Dictionary/Array/Blob]
+* https://jira.issues.couchbase.com/browse/CBL-7469[CBL-7469 -- Replicator omitting TLS SNI when a network interface is set]
 
-* https://jira.issues.couchbase.com/browse/CBL-6959[CBL-6959 -- UserAgent info in the log shows incorrect LiteCore version]
+* https://jira.issues.couchbase.com/browse/CBL-8158[CBL-8158 -- Result.data(as:dataKey:) dropping optional properties when using dataKey]
 
 === Known Issues
 

--- a/modules/swift/pages/releasenotes.adoc
+++ b/modules/swift/pages/releasenotes.adoc
@@ -8,6 +8,8 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: Swift
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-swift-release-note.3.2.6.adoc[]
+
 include::partial$release-notes/couchbase-mobile-swift-release-note.3.2.4.adoc[]
 
 include::partial$release-notes/couchbase-mobile-swift-release-note.3.2.3.adoc[]

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.2.6.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.2.6.adoc
@@ -14,8 +14,6 @@ Version 3.2.6 for {param-title} delivers the following features and enhancements
 
 === Issues and Resolutions
 
-include::ROOT:partial$release-notes/couchbase-mobile-litecore-release-note.3.2.6.adoc[tags=fixes]
-
 * https://jira.issues.couchbase.com/browse/CBL-7386[CBL-7386 -- Potential pull replicator crash when pulling a large number of documents]
 
 * https://jira.issues.couchbase.com/browse/CBL-7469[CBL-7469 -- Replicator omitting TLS SNI when a network interface is set]

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.2.6.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.2.6.adoc
@@ -1,0 +1,33 @@
+[#maint-3-2-6]
+== 3.2.6 -- May 2026
+
+Version 3.2.6 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://jira.issues.couchbase.com/browse/CBL-8071[CBL-8071 -- Improve replicator WebSocket close completion when the server fails to acknowledge close]
+
+* https://jira.issues.couchbase.com/browse/CBL-8102[CBL-8102 -- Upgrade SQLite to 3.53.0]
+
+* https://jira.issues.couchbase.com/browse/CBL-8181[CBL-8181 -- Upgrade mbedTLS to 3.6.6]
+
+
+=== Issues and Resolutions
+
+include::ROOT:partial$release-notes/couchbase-mobile-litecore-release-note.3.2.6.adoc[tags=fixes]
+
+* https://jira.issues.couchbase.com/browse/CBL-7386[CBL-7386 -- Potential pull replicator crash when pulling a large number of documents]
+
+* https://jira.issues.couchbase.com/browse/CBL-7469[CBL-7469 -- Replicator omitting TLS SNI when a network interface is set]
+
+* https://jira.issues.couchbase.com/browse/CBL-8158[CBL-8158 -- Result.data(as:dataKey:) dropping optional properties when using dataKey]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite 3.2.0, see xref:ROOT:cbl-whatsnew.adoc[New in 3.2]


### PR DESCRIPTION
Docs Issue: [DOC-14363](https://jira.issues.couchbase.com/browse/DOC-14363?atlOrigin=eyJpIjoiYTZmNmJlZWE2YTQ2NDgwMTkzYzFlZWJkMTg5NmE0N2UiLCJwIjoiaiJ9)

PR to add release notes for release 3.2.6

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-14363-release-notes-3-2-6

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-14363]: https://couchbasecloud.atlassian.net/browse/DOC-14363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ