### PR TITLE
update upgrade and compat pages

### DIFF
--- a/modules/android/pages/compatibility.adoc
+++ b/modules/android/pages/compatibility.adoc
@@ -118,6 +118,11 @@ with delta sync enabled
 
 |===
 
+[#vector-search-compatibility]
+== Vector Search Extension Compatibility
+
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
+
 [#operating-system-sdk-support]
 == Operating System SDK Support
 

--- a/modules/android/pages/upgrade.adoc
+++ b/modules/android/pages/upgrade.adoc
@@ -15,6 +15,11 @@ On upgrading from a 2.x release, all Couchbase Lite databases will be automatica
 This can result in a delay before the database is usable.
 --
 
+=== Vector Search Extension
+
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
+If your application uses Vector Search, update the Vector Search Extension to 2.0.0 when upgrading to Couchbase Lite 3.4.0.
+
 [#3-4-0-upgrade]
 == {major}.{minor}.{base}{empty} Upgrade
 
@@ -22,6 +27,12 @@ Couchbase Lite {major}.{minor} is a non-breaking upgrade from 3.3.
 Update your Couchbase Lite dependency to {major}.{minor} -- no API or configuration changes are required.
 Existing `MultipeerReplicatorConfiguration` setups continue to work without modification.
 The default transport remains Wi-Fi only.
+
+[WARNING]
+--
+When upgrading from Couchbase Lite 3.4.0 to the 4.x release line, upgrade directly to 4.1.0 or later.
+Couchbase Lite 4.x versions below 4.1.0 do not include all APIs added in 3.4.0 (Multipeer Replicator with Bluetooth and Auto Switching, Replication Correlation ID, Kotlin Serialization, and on C, the C++ API).
+--
 
 === Enabling Bluetooth Transport (Optional)
 
@@ -85,13 +96,10 @@ NOTE: Bluetooth transport requires Android API 29 or later.
 [#api-changes]
 === API Changes
 
-
 This content introduces the changes made to the Couchbase{nbsp}Lite for Android API for release {major}.{minor}.{base}{empty}.
-
 
 [#removed]
 ==== Removed
-
 
 [#resetcheckpoint]
 ===== ResetCheckpoint
@@ -126,7 +134,6 @@ Instead:
 [source, java, subs="attributes+, macros+"]
 ----
 Database.setLogLevel(LogDomain.ALL, LogLevel.VERBOSE)
-
 ----
 
 .After
@@ -146,7 +153,6 @@ It is replaced by the new https://docs.couchbase.com/mobile/{major}.{minor}.{bas
 [source, java, subs="attributes+, macros+"]
 ----
 try testdb.compact()
-
 ----
 
 .After
@@ -155,155 +161,16 @@ try testdb.compact()
 testdb.performMaintenance(MaintenanceType.COMPACT)
 ----
 
-
-[#deprecated-in-the-api]
-==== Deprecated in the API
-
-
-[#match]
-===== MATCH
-The class, https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-android/com/couchbase/lite/FullTextExpression.html[FullTextExpression]
-has been deprecated. +
-Use https://docs.couchbase.com/mobile/{major}.{minor}.{base}{empty}/couchbase-lite-android/com/couchbase/lite/FullTextFunction.html[FullTextFunction] instead.
-
-.Before
-[source, java, subs="attributes+, macros+"]
-----
-FullTextExpression index = FullTextExpression.index("indexName")
-Query q = QueryBuilder.select([SelectResult.expression(Meta.id)])
-  .from(DataSource.database(testdb))
-  .where(index.match(queryString))
-
-----
-
-.After
-[source, java, subs="attributes+, macros+"]
-----
-Query q = QueryBuilder.select([SelectResult.expression(Meta.id)])
-  .from(DataSource.database(testdb))
-  .where(FullTextFunction.match("indexName", queryString))
-
-----
-
-[#isnullormissingnotnullormissing]
-===== isNullOrMissing/notNullOrMissing
-
-The functions https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-android/com/couchbase/lite/Expression.html#isNullOrMissing--[Expression.isNullOrMissing] and https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-android/com/couchbase/lite/Expression.html#notNullOrMissing--[Expression.notNullOrMissing] have been deprecated. +
-Use `isNotValued()` and-or `isValued()` instead.
-
-.Before
-[source, java, subs="attributes+, macros+"]
-----
-Query q =
-  QueryBuilder
-    .select([SelectResult.expression(Meta.id)])
-    .from(DataSource.database(testdb))
-    .where(
-      Expression.property("missingProp").isNullOrMissing())
-
-Query q =
-  QueryBuilder
-    .select([SelectResult.expression(Meta.id)])
-    .from(DataSource.database(testdb))
-    .where(Expression.property("notMissingProp").notNullOrMissing())
-
-----
-.After
-[source, java, subs="attributes+, macros+"]
-----
-Query q = QueryBuilder.select([SelectResult.expression(Meta.id)])
-  .from(DataSource.database(testdb))
-  .where(Expression.property("missingProp").isNotValued())
-
-Query q = QueryBuilder.select([SelectResult.expression(Meta.id)])
-  .from(DataSource.database(testdb))
-  .where(Expression.property("notMissingProp").isValued())
-
-----
-
-[#abstractreplicatorconfiguration]
-===== AbstractReplicatorConfiguration
-
-The enum https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-android/com/couchbase/lite/ReplicatorConfiguration.html#setReplicatorType-com.couchbase.lite.AbstractReplicatorConfiguration.ReplicatorType-[AbstractReplicatorConfiguration.ReplicatorType]
-and the methods
-https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-android/com/couchbase/lite/ReplicatorConfiguration.html#setReplicatorType--[
-ReplicatorConfiguration.setReplicatorType]
-and
-https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-android/com/couchbase/lite/ReplicatorConfiguration.html#getReplicatorType--[
-ReplicatorConfiguration.getReplicatorType]
-have all been deprecated. +
-Instead, use the methods `ReplicatorConfiguration.setType` and `ReplicatorConfiguration.getType`, and the top level enum `ReplicatorType`.
-
-.Before
-[source, java, subs="attributes+, macros+"]
-----
-ReplicatorConfiguration config =
-  new ReplicatorConfiguration().setReplicatorType(ReplicatorConfiguration.ReplicatorType.PUSH_AND_PULL);
-----
-.After
-[source, java, subs="attributes+, macros+"]
-----
-ReplicatorConfiguration config =
-  new ReplicatorConfiguration().setType(ReplicatorType.PUSH_AND_PULL);
-----
-
-
-[#moved-in-the-api]
-==== Moved in the API
-
-
-The enum https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-android/com/couchbase/lite/AbstractReplicator.ActivityLevel.html[AbstractReplicator.ActivityLevel] and the classes https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-android/com/couchbase/lite/AbstractReplicator.Progress.html[AbstractReplicator.Progress] and https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-android/com/couchbase/lite/AbstractReplicator.Status.html[AbstractReplicator.Status] have all been moved to be top level definitions. +
-They are replaced by these definitions:
-
-* https://docs.couchbase.com/mobile/{major}.{minor}.{base}{empty}/couchbase-lite-android/com/couchbase/lite/ReplicatorActivityLevel.html[ReplicatorActivityLevel]
-* https://docs.couchbase.com/mobile/{major}.{minor}.{base}{empty}/couchbase-lite-android/com/couchbase/lite/ReplicatorProgress.html[ReplicatorProgress]
-* https://docs.couchbase.com/mobile/{major}.{minor}.{base}{empty}/couchbase-lite-android/com/couchbase/lite/ReplicatorStatus.html[ReplicatorStatus]
-
-
-.Before
-[source, java, subs="attributes+, macros+"]
-----
-ListenerToken token =
-  replicator.addChangeListener(
-    testSerialExecutor,
-    change -> {
-      final AbstractReplicator.Status status = change.getStatus()
-      if (status.getActivityLevel() == AbstractReplicator.ActivityLevel.BUSY)
-      { AbstractReplicator.Progress progress =
-          status.getProgress(); Logger.log("Progress: " + progress.completed + "/" progress.total);
-      }
-    });
-
-----
-.After
-[source, java, subs="attributes+, macros+"]
-----
-ListenerToken token =
-  replicator.addChangeListener(
-    testSerialExecutor,
-    change -> {
-      final ReplicatorStatus status = change.getStatus()
-      if (status.getActivityLevel() == ReplicatorActivityLevel.BUSY)
-      { ReplicatorProgress progress =
-          status.getProgress(); Logger.log("Progress: " + progress.completed + "/" progress.total);
-      }
-    });
-
-----
-
-
 [#lbl-db-upgrades]
 == 1.x Databases Upgrades to 2.x
 
-Databases created using Couchbase Lite 1.2 or later can still be used with Couchbase Lite 2.x; but will be automatically updated to the  current 2.x version.
+Databases created using Couchbase Lite 1.2 or later can still be used with Couchbase Lite 2.x; but will be automatically updated to the current 2.x version.
 This feature is only available for the default storage type (i.e., not a ForestDB database).
 
 [#encrypted-databases]
 === Encrypted Databases
 The automatic migration feature does not support encrypted databases.
 So if the 1.x database is encrypted you will first need to disable encryption using the Couchbase Lite 1.x API (see the https://docs-archive.couchbase.com/couchbase-lite/1.4/Kotlin.html#database-encryption[1.x Database Guide]).
-
-Thus, to upgrade an encrypted 1.x database, you should do the following:
 
 .Upgrading Encrypted Databases
 ****
@@ -315,94 +182,6 @@ Since it is not possible to package Couchbase Lite 1.x and Couchbase Lite 2.x in
 
 If you are using Sync Gateway to synchronize the database content, it may be preferable to run a pull replication from a new 2.x database with encryption enabled and delete the 1.x local database.
 
-
-[#handling-of-existing-conflicts]
-=== Handling of Existing Conflicts
-
-If there are existing conflicts in the 1.x database, the automatic upgrade process copies the default winning revision to the new database and does NOT copy any conflicting revisions.
-
-This functionality is related to the way conflicts are now being handled in Couchbase Lite -- see xref:android:conflict.adoc[Handling Data Conflicts].
-
-Optionally, existing conflicts in the 1.x database can be resolved with the https://docs-archive.couchbase.com/couchbase-lite/1.4/Kotlin.html#resolving-conflicts[1.x API] prior to the database being upgraded.
-
-[#handling-of-existing-attachments]
-=== Handling of Existing Attachments
-
-Attachments persisted in a 1.x database are copied to the new database.
-NOTE: The relevant Couchbase Lite API is now called the `Blob` API not the `Attachments` API.
-
-The functionally is identical but the internal schema for attachments has changed.
-
-Blobs are stored anywhere in the document, just like other value types.
-Whereas in 1.x they were stored under the `_attachments` field.
-
-The automatic upgrade functionality *does not* update the internal schema for attachments, so they remain accessible under the `_attachments` field.
-See xref:android:upgrade.adoc#ex-get-att[] for how to retrieve an attachment that was created in a 1.x database with a 2.x API.
-
-.Retrieve 1.x Attachment
-[#ex-get-att]
-
-
-[#ex-get-att]
-====
-
-[tabs]
-=====
-
-
-Kotlin::
-+
---
-
-[source, Kotlin]
-----
-include::android:example$codesnippet_collection.kt[tags="1x-attachment", indent=0]
-----
-
---
-
-Java::
-+
---
-[source, Java]
-----
-include::android:example$codesnippet_collection.java[tags="1x-attachment", indent=0]
-----
---
-
-=====
-
-
-====
-
-
-[#replication-compatibility]
-=== Replication Compatibility
-
-The current replication protocol is not backwards compatible with the 1.x replication protocol.
-Therefore, to use replication with Couchbase Lite 2.x, the target Sync Gateway instance must also be upgraded to 2.x.
-
-Sync Gateway 2.x will continue to accept clients that connect through the 1.x protocol.
-
-It will automatically use the 1.x replication protocol when a Couchbase Lite 1.x client connects through \http://localhost:4984/db and the 2.0 replication protocol when a Couchbase Lite 2.0 client connects through ws://localhost:4984/db.
-
-This allows for a smoother transition to get all your user base onto a version of your application built with Couchbase Lite 2.x.
-
-
-[#android-studio]
-== Android Studio
-
-
-The API changed in Couchbase Lite 2.0 and you will need to port any application that is using Couchbase Lite 1.x API to the latest Couchbase Lite API.
-To update an Android project built with Couchbase Lite 1.x:
-
-* Remove the existing Couchbase Lite dependency from the Android Studio project.
-* Install the Couchbase Lite framework in your project -- see the https://docs-archive.couchbase.com/couchbase-lite/1.4/java.html#getting-started[Getting Started].
-At this point, there will be many compiler warnings.
-Refer to the examples on this page to learn about the new API.
-* Build & run your application.
-
-
 [#downgrading-couchbase-lite]
 == Downgrading Couchbase Lite
 
@@ -412,24 +191,17 @@ Refer to the examples on this page to learn about the new API.
 *No Downgrade Support* - Downgrades between major versions of Couchbase Lite (CBL) are not supported.
 Once you upgrade to a new major version, downgrading to a previous major version may lead to incompatibility issues.
 
-For example, Upgrading from CBL 2.x.x to CBL 3.x.x does not guarantee the ability to revert to CBL 2.x.x.
-
 [#downgrading-between-minor-releases]
 === Downgrading Between Minor Releases
 
 *Conditional Downgrade Support* - Downgrade support for minor releases is considered on a case-by-case basis.
 The release notes for each minor version will clarify whether downgrades are supported.
 
-For example, if a new minor version such as CBL 3.1.0 is released the release notes will specify whether downgrading to CBL 3.0.x is supported.
-
 [#downgrading-between-patch-releases]
 === Downgrading Between Patch Releases
 
 *Full Downgrade Support* - Downgrades between patch releases are supported.
 Users can safely downgrade between different patch versions within the same minor release.
-
-For example, if you're' running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3.1.3 without issues.
-
 
 [#related-content]
 == Related Content
@@ -444,7 +216,6 @@ For example, if you're' running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 
 * xref:android:gs-install.adoc[Install]
 * xref:android:gs-build.adoc[Build and Run]
 
-
 .
 
 [.column]
@@ -458,7 +229,6 @@ For example, if you're' running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 
 
 .
 
-
 [.column]
 === {empty}
 .Dive Deeper . . .
@@ -467,7 +237,6 @@ https://blog.couchbase.com/[Blog] |
 https://docs.couchbase.com/tutorials/[Tutorials]
 
 .
-
 
 ++++
 </div>

--- a/modules/c/pages/compatibility.adoc
+++ b/modules/c/pages/compatibility.adoc
@@ -1,4 +1,3 @@
-
 = Compatibility
 :page-aliases: clang:compatibility.adoc
 :page-role:
@@ -21,15 +20,14 @@ Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:c:releasenotes.ad
 [#couchbase-litesync-gateway-matrix]
 == Couchbase Lite/Sync Gateway Matrix
 
-
 The table below summarizes the compatible versions of Couchbase Lite with Sync Gateway.
 
 .Sync Gateway and Couchbase Lite Compatibility Matrix
-[cols="3,^1,^1,^1,^1,^1,^1,^1,^1"]
+[cols="3,^1,^1,^1,^1,^1,^1,^1,^1,^1"]
 |===
 
 .2+^.>| Sync Gateway Versions ↓
-8+| Couchbase Lite →
+9+| Couchbase Lite →
 
 ^| 1.4 *footnote:eos-cbl[This Couchbase Lite version is End of Support]]*
 ^| 2.0
@@ -39,6 +37,7 @@ The table below summarizes the compatible versions of Couchbase Lite with Sync G
 ^| 3.1.0
 ^| 3.2.0
 ^| 3.3.0
+^| 3.4.0
 
 | 1.4 *footnote:eos-sgw[This Sync Gateway version is End of Support]* and 1.5 *footnote:eol-sgw[This Sync Gateway version is End of Life]*
 | image:ROOT:yes.png[]
@@ -49,8 +48,10 @@ The table below summarizes the compatible versions of Couchbase Lite with Sync G
 | image:ROOT:no.png[]
 | image:ROOT:no.png[]
 | image:ROOT:no.png[]
+| image:ROOT:no.png[]
 
 | 2.0 and 2.1
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -70,6 +71,7 @@ with delta sync disabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 2.5 to 2.8 +
 with delta sync enabled
@@ -81,9 +83,11 @@ with delta sync enabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 3.0.0
 | image:ROOT:no.png[]
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -101,9 +105,11 @@ with delta sync enabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 3.2.0
 | image:ROOT:no.png[]
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -121,8 +127,25 @@ with delta sync enabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+
+| 4.0.0
+| image:ROOT:no.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 |===
+
+[#vector-search-compatibility]
+== Vector Search Extension Compatibility
+
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
 
 [#operating-system-sdk-support]
 == Operating System SDK Support
@@ -130,9 +153,8 @@ with delta sync enabled
 The table below summarizes the Operating System SDK versions supported by Couchbase Lite.
 
 .OS -- SDK Support
-[cols="1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1"]
+[cols="1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1"]
 |===
-
 
 ^.>h|
 ^.>h| 2.0
@@ -145,6 +167,7 @@ The table below summarizes the Operating System SDK versions supported by Couchb
 ^.>h| 3.1
 ^.>h| 3.2
 ^.>h| 3.3
+^.>h| 3.4
 
 h| Android
 | https://docs-archive.couchbase.com/home/index.html[archive link]
@@ -157,6 +180,7 @@ h| Android
 | xref:3.1@couchbase-lite:android:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:android:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:android:supported-os.adoc[link]
+| xref:android:supported-os.adoc[link]
 
 h| C
 | -
@@ -169,8 +193,9 @@ h| C
 | xref:3.1@couchbase-lite:c:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:c:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:c:supported-os.adoc[link]
+| xref:c:supported-os.adoc[link]
 
-h|  iOS
+h| iOS
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
@@ -181,21 +206,22 @@ h|  iOS
 | xref:3.1@couchbase-lite:swift:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:swift:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:swift:supported-os.adoc[link]
+| xref:swift:supported-os.adoc[link]
 
-
-h|  Java
+h| Java
+| -
 | -
 | -
 | -
 | -
 | https://docs-archive.couchbase.com/home/index.html[archive link]
-| xref:2.8@couchbase-lite:java:supported-os.adoc[link]
 | xref:3.0@couchbase-lite:java:supported-os.adoc[link]
 | xref:3.1@couchbase-lite:java:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:java:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:java:supported-os.adoc[link]
+| xref:java:supported-os.adoc[link]
 
-h|  Javascript
+h| Javascript
 | -
 | -
 | -
@@ -206,8 +232,9 @@ h|  Javascript
 | xref:3.1@couchbase-lite:ROOT:javascript.adoc[link]
 | xref:3.2@couchbase-lite:ROOT:javascript.adoc[link]
 | xref:3.3@couchbase-lite:ROOT:javascript.adoc[link]
+| xref:ROOT:javascript.adoc[link]
 
-h|  .NET
+h| .NET
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
@@ -218,6 +245,7 @@ h|  .NET
 | xref:3.1@couchbase-lite:csharp:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:csharp:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:csharp:supported-os.adoc[link]
+| xref:csharp:supported-os.adoc[link]
 
 |===
 
@@ -236,7 +264,6 @@ h|  .NET
 * xref:c:supported-os.adoc[Supported Platforms]
 * xref:cbl-whatsnew.adoc[What's New]
 
-
 .
 
 [.column]
@@ -250,7 +277,6 @@ h|  .NET
 
 .
 
-
 [.column]
 ====== {empty}
 .Tutorials
@@ -260,9 +286,6 @@ https://docs.couchbase.com/tutorials/[Tutorials]
 
 .
 
-
 ++++
 </div>
 ++++
-
-

--- a/modules/c/pages/upgrade.adoc
+++ b/modules/c/pages/upgrade.adoc
@@ -1,4 +1,3 @@
-
 = Upgrade
 :page-aliases:
 :page-role:
@@ -10,22 +9,22 @@
 :url-api-references-classes: https://docs.couchbase.com/mobile/{major}.{minor-c}.{maintenance-c}{empty}/couchbase-lite-c/C/html/group__
 
 
-// The admonition does not apply to C as it references upgrading from versions 2.x.
-// CBL-C started at version 3.0
-
-[#3-2-3-upgrade]
+[#3-4-0-upgrade]
 == {major}.{minor-c}.{maintenance-c}{empty} Upgrade
 
-The action will take place automatically and can lead to some delay in the database becoming available for use in your application.
+Couchbase Lite {major}.{minor} is a non-breaking upgrade from 3.3.
+Update your Couchbase Lite dependency to {major}.{minor} -- no API or configuration changes are required.
 
-In addition, if you are syncing with a {major}.{minor}.{base}{empty} Sync Gateway, you should be aware of the significant configuration enhancements introduced and their impact.
-See xref:sync-gateway::upgrading.adoc[Upgrading Sync Gateway] for more details.
-This is a one-way conversion.
+[WARNING]
+--
+When upgrading from Couchbase Lite 3.4.0 to the 4.x release line, upgrade directly to 4.1.0 or later.
+Couchbase Lite 4.x versions below 4.1.0 do not include all APIs added in 3.4.0 (Multipeer Replicator with Bluetooth and Auto Switching, Replication Correlation ID, and on Android, Kotlin Serialization; and on C, the C++ API).
+--
 
-// All API and other listed changes included in the other platforms do not apply to CBL-C for the following reasons
-// The changes apply to pre 3.x versions (CBL-C started at 3.0)
-// Or they relate to Querybuilder functionality - CBL-C doesn't have Querybuilder.
+=== Vector Search Extension
 
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
+If your application uses Vector Search, update the Vector Search Extension to 2.0.0 when upgrading to Couchbase Lite 3.4.0.
 
 [#downgrading-couchbase-lite]
 == Downgrading Couchbase Lite
@@ -36,27 +35,17 @@ This is a one-way conversion.
 *No Downgrade Support* - Downgrades between major versions of Couchbase Lite (CBL) are not supported.
 Once you upgrade to a new major version, downgrading to a previous major version may lead to incompatibility issues.
 
-For example, Upgrading from CBL 2.x.x to CBL 3.x.x does not guarantee the ability to revert to CBL 2.x.x.
-
 [#downgrading-between-minor-releases]
 === Downgrading Between Minor Releases
 
 *Conditional Downgrade Support* - Downgrade support for minor releases is considered on a case-by-case basis.
 The release notes for each minor version will clarify whether downgrades are supported.
 
-For example, if a new minor version such as CBL 3.1.0 is released the release notes will specify whether downgrading to CBL 3.0.x is supported.
-
 [#downgrading-between-patch-releases]
 === Downgrading Between Patch Releases
 
 *Full Downgrade Support* - Downgrades between patch releases are supported.
 Users can safely downgrade between different patch versions within the same minor release.
-
-For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3.1.3 without issues.
-
-
-// Include standard footer
-
 
 [#related-content]
 == Related Content
@@ -71,7 +60,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 * xref:c:gs-install.adoc[Install]
 * xref:c:gs-build.adoc[Build and Run]
 
-
 .
 
 [.column]
@@ -85,7 +73,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 
 .
 
-
 [.column]
 === {empty}
 .Dive Deeper . . .
@@ -95,8 +82,6 @@ https://docs.couchbase.com/tutorials/[Tutorials]
 
 .
 
-
 ++++
 </div>
 ++++
-

--- a/modules/csharp/pages/compatibility.adoc
+++ b/modules/csharp/pages/compatibility.adoc
@@ -1,4 +1,3 @@
-
 = Compatibility
 :page-aliases: product/csharp-compatibility.adoc
 :page-role:
@@ -18,15 +17,14 @@ Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:csharp:releasenot
 [#couchbase-litesync-gateway-matrix]
 == Couchbase Lite/Sync Gateway Matrix
 
-
 The table below summarizes the compatible versions of Couchbase Lite with Sync Gateway.
 
 .Sync Gateway and Couchbase Lite Compatibility Matrix
-[cols="3,^1,^1,^1,^1,^1,^1,^1,^1"]
+[cols="3,^1,^1,^1,^1,^1,^1,^1,^1,^1"]
 |===
 
 .2+^.>| Sync Gateway Versions ↓
-8+| Couchbase Lite →
+9+| Couchbase Lite →
 
 ^| 1.4 *footnote:eos-cbl[This Couchbase Lite version is End of Support]]*
 ^| 2.0
@@ -36,6 +34,7 @@ The table below summarizes the compatible versions of Couchbase Lite with Sync G
 ^| 3.1.0
 ^| 3.2.0
 ^| 3.3.0
+^| 3.4.0
 
 | 1.4 *footnote:eos-sgw[This Sync Gateway version is End of Support]* and 1.5 *footnote:eol-sgw[This Sync Gateway version is End of Life]*
 | image:ROOT:yes.png[]
@@ -46,8 +45,10 @@ The table below summarizes the compatible versions of Couchbase Lite with Sync G
 | image:ROOT:no.png[]
 | image:ROOT:no.png[]
 | image:ROOT:no.png[]
+| image:ROOT:no.png[]
 
 | 2.0 and 2.1
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -67,6 +68,7 @@ with delta sync disabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 2.5 to 2.8 +
 with delta sync enabled
@@ -78,9 +80,11 @@ with delta sync enabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 3.0.0
 | image:ROOT:no.png[]
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -98,6 +102,7 @@ with delta sync enabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 3.2.0
 | image:ROOT:no.png[]
@@ -108,8 +113,36 @@ with delta sync enabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+
+| 3.3.0
+| image:ROOT:no.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+
+| 4.0.0
+| image:ROOT:no.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 |===
+
+[#vector-search-compatibility]
+== Vector Search Extension Compatibility
+
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
 
 [#operating-system-sdk-support]
 == Operating System SDK Support
@@ -117,9 +150,8 @@ with delta sync enabled
 The table below summarizes the Operating System SDK versions supported by Couchbase Lite.
 
 .OS -- SDK Support
-[cols="1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1"]
+[cols="1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1"]
 |===
-
 
 ^.>h|
 ^.>h| 2.0
@@ -132,6 +164,7 @@ The table below summarizes the Operating System SDK versions supported by Couchb
 ^.>h| 3.1
 ^.>h| 3.2
 ^.>h| 3.3
+^.>h| 3.4
 
 h| Android
 | https://docs-archive.couchbase.com/home/index.html[archive link]
@@ -144,6 +177,7 @@ h| Android
 | xref:3.1@couchbase-lite:android:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:android:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:android:supported-os.adoc[link]
+| xref:android:supported-os.adoc[link]
 
 h| C
 | -
@@ -156,8 +190,9 @@ h| C
 | xref:3.1@couchbase-lite:c:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:c:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:c:supported-os.adoc[link]
+| xref:c:supported-os.adoc[link]
 
-h|  iOS
+h| iOS
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
@@ -168,9 +203,9 @@ h|  iOS
 | xref:3.1@couchbase-lite:swift:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:swift:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:swift:supported-os.adoc[link]
+| xref:swift:supported-os.adoc[link]
 
-
-h|  Java
+h| Java
 | -
 | -
 | -
@@ -181,8 +216,9 @@ h|  Java
 | xref:3.1@couchbase-lite:java:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:java:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:java:supported-os.adoc[link]
+| xref:java:supported-os.adoc[link]
 
-h|  Javascript
+h| Javascript
 | -
 | -
 | -
@@ -193,8 +229,9 @@ h|  Javascript
 | xref:3.1@couchbase-lite:ROOT:javascript.adoc[link]
 | xref:3.2@couchbase-lite:ROOT:javascript.adoc[link]
 | xref:3.3@couchbase-lite:ROOT:javascript.adoc[link]
+| xref:ROOT:javascript.adoc[link]
 
-h|  .NET
+h| .NET
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
@@ -205,6 +242,7 @@ h|  .NET
 | xref:3.1@couchbase-lite:csharp:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:csharp:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:csharp:supported-os.adoc[link]
+| xref:csharp:supported-os.adoc[link]
 
 |===
 
@@ -223,7 +261,6 @@ h|  .NET
 * xref:csharp:supported-os.adoc[Supported Platforms]
 * xref:cbl-whatsnew.adoc[What's New]
 
-
 .
 
 [.column]
@@ -237,7 +274,6 @@ h|  .NET
 
 .
 
-
 [.column]
 ====== {empty}
 .Tutorials
@@ -247,9 +283,6 @@ https://docs.couchbase.com/tutorials/[Tutorials]
 
 .
 
-
 ++++
 </div>
 ++++
-
-

--- a/modules/csharp/pages/upgrade.adoc
+++ b/modules/csharp/pages/upgrade.adoc
@@ -1,4 +1,3 @@
-
 = Upgrade
 :page-aliases: advance/csharp-dep-upgrade.adoc, dep-upgrade.adoc
 :page-role:
@@ -7,56 +6,36 @@
 :source-language: C#
 
 
-// The admonition does not apply to C as it references upgrading from versions 2.x.
-// CBL-C started at version 3.0
 [IMPORTANT]
 --
 On upgrading from a 2.x release, all Couchbase Lite databases will be automatically re-indexed on initial database open. +
 This can result in a delay before the database is usable.
 --
 
-[#3-3-0-upgrade]
+=== Vector Search Extension
+
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
+If your application uses Vector Search, update the Vector Search Extension to 2.0.0 when upgrading to Couchbase Lite 3.4.0.
+
+[#3-4-0-upgrade]
 == {major}.{minor-net}.{maintenance-net}{empty} Upgrade
 
-The action takes place automatically and can lead to some delay in the database becoming available for use in your application.
+Couchbase Lite {major}.{minor} is a non-breaking upgrade from 3.3.
+Update your Couchbase Lite dependency to {major}.{minor} -- no API or configuration changes are required.
 
-In addition, if you're syncing with a {major}.{minor}.{maintenance} Sync Gateway, you should be aware of the significant configuration enhancements introduced and their impact.
-See xref:sync-gateway::upgrading.adoc[Upgrading Sync Gateway] for more details.
-This is a one-way conversion.
+[WARNING]
+--
+When upgrading from Couchbase Lite 3.4.0 to the 4.x release line, upgrade directly to 4.1.0 or later.
+Couchbase Lite 4.x versions below 4.1.0 do not include all APIs added in 3.4.0 (Multipeer Replicator with Bluetooth and Auto Switching, Replication Correlation ID, and on Android, Kotlin Serialization; and on C, the C++ API).
+--
 
-// All API and other listed changes included in the other platforms do not apply to CBL-C for the following reasons
-// The changes apply to pre 3.x versions (CBL-C started at 3.0)
-// Or they relate to Querybuilder functionality - CBL-C doesn't have Querybuilder.
 [#api-changes]
 === API Changes
 
-
 This content introduces the changes made to the Couchbase{nbsp}Lite for C#.Net API for release {major}.{minor-net}.{maintenance-net}.
-
-// Starting from 3.2 Couchbase{nbsp}Lite for C#.Net requires _Visual Studio 2019+_ and uses .Net Core 3.1 (updating from .Net Core 2.0).
-
-[#breaking-change]
-==== Breaking Change
-
-The function https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-net/api/Couchbase.Lite.Query.Function.html#Couchbase_Lite_Query_Function_Atan2_Couchbase_Lite_Query_IExpression_Couchbase_Lite_Query_IExpression_[ATAN2(x, y)],
-which returns the principal value of the arc tangent of y/x, now becomes
-https://docs.couchbase.com/mobile/{major}.{minor-net}.{maintenance-net}/couchbase-lite-net/api/Couchbase.Lite.Query.Function.html#Couchbase_Lite_Query_Function_Atan2_Couchbase_Lite_Query_IExpression_Couchbase_Lite_Query_IExpression_[ATAN2(y, x)];
-that's, the arguments are reversed in line with common notation.
-
 
 [#removed]
 ==== Removed
-
-[#activate]
-===== Activate
-
-We have removed the method `Activate()` from *all* platform support libraries *except* `Support.Android` (Xamarin Android)
-
-
-[#enabletextlogging]
-===== EnableTextLogging()
-We have removed the obsolete method `EnableTextLogging()` from all the platform support libraries.
-
 
 [#resetcheckpoint]
 ===== ResetCheckpoint
@@ -66,188 +45,23 @@ https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-net/api/Couchbase.Lite.Sy
 has been removed.
 Use the `reset:` argument when starting the replicator instead.
 
-[#before]
-===== Before
-[source, java,subs="attributes+, macros+"]
+.Before
+[source, C#,subs="attributes+, macros+"]
 ----
 replicator.ResetCheckpoint();
 replicator.Start();
 ----
 
-[#after]
-===== After
-[source, java,subs="attributes+, macros+"]
+.After
+[source, C#,subs="attributes+, macros+"]
 ----
-replicator.Start(true) // <.>
-
+replicator.Start(true)
 ----
-<.> Set the `reset:` argument `true` to initiate a replicator checkpoint reset
-
-[#setloglevel]
-===== SetLogLevel()
-We have removed the method
-https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-net/api/Couchbase.Lite.Database.html#Couchbase_Lite_Database_SetLogLevel_Couchbase_Lite_Logging_LogDomain_Couchbase_Lite_Logging_LogLevel_[Database.setLogLevel()] +
-Use
-https://docs.couchbase.com/mobile/{major}.{minor-net}.{maintenance-net}/couchbase-lite-net/api/Couchbase.Lite.Logging.Log.html#Couchbase_Lite_Logging_Log_Console[
-Database.log.console]
-instead:
-
-[#before-2]
-===== Before
-[source, java,subs="attributes+, macros+"]
-----
-Database.SetLogLevel(LogDomain.Replicator, LogLevel.Verbose);
-Database.SetLogLevel(LogDomain.Query, LogLevel.Verbose);
-----
-
-[#after-2]
-===== After
-[source, java,subs="attributes+, macros+"]
-----
-Database.Log.Console.Domains = LogDomain.All;
-Database.Log.Console.LogLevel = LogLevel.Verbose;
-
-----
-
-
-[#database-compact]
-==== Database.Compact
-We have removed the method
-https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-net/api/Couchbase.Lite.Database.html#Couchbase_Lite_Database_Compact[Database.compact()]. +
-Use the method
-https://docs.couchbase.com/mobile/{major}.{minor-net}.{maintenance-net}/couchbase-lite-net/api/Couchbase.Lite.Database.html#Couchbase_Lite_Database_PerformMaintenance_Couchbase_Lite_MaintenanceType_[Database.PerformMaintenance()] and the enum
-https://docs.couchbase.com/mobile/{major}.{minor-net}.{maintenance-net}/couchbase-lite-net/api/Couchbase.Lite.MaintenanceType.html[MaintenanceType]
-instead
-
-[#before-3]
-===== Before
-[source, java,subs="attributes+, macros+"]
-----
-var db = new Database("thisdb");
-db.Compact()
-----
-
-[#after-3]
-===== After
-[source, java,subs="attributes+, macros+"]
-----
-var db = new Database("thisdb");
-
-db.PerformMaintenance(MaintenanceType.Compact)
-
-----
-
-
-[#deprecated-api]
-==== Deprecated API
-
-
-[#match]
-===== Match
-We will remove
-https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-net/api/Couchbase.Lite.Query.IFullTextExpression.html#Couchbase_Lite_Query_IFullTextExpression_Match_System_String_[Match]
-at the next major release. +
-You should plan to switch to using the alternative
-https://docs.couchbase.com/mobile/{major}.{minor-net}.{maintenance-net}/couchbase-lite-net/api/Couchbase.Lite.Query.FullTextFunction.html#Couchbase_Lite_Query_FullTextFunction_Match_System_String_System_String_[FullTextFunction.match(indexName:)]
-at the earliest opportunity.
-
-[#before-4]
-===== Before
-[source, java,subs="attributes+, macros+"]
-----
-var whereClause =
-        FullTextExpression.Index("nameFTSIndex").Match("'querystring'");
-using (var query = QueryBuilder.Select(SelectResult.Expression(Meta.ID))
-    .From(DataSource.Database(db))
-    .Where(whereClause)) {
-    foreach (var result in query.Execute()) {
-        Console.WriteLine($"Document id {result.GetString(0)}");
-    }
-}
-----
-
-[#after-4]
-===== After
-[source, java,subs="attributes+, macros+"]
-----
-var whereClause =
-      FullTextFunction.Match("nameFTSIndex"),"'querystring'"); // <.>
-using (var query =
-    QueryBuilder.Select(SelectResult.Expression(Meta.ID))
-      .From(DataSource.Database(db))
-      .Where(whereClause)) {
-      foreach (var result in query.Execute()) {
-        Console.WriteLine($"Document id {result.GetString(0)}");
-      }
-  }
-----
-<.> Here we use https://docs.couchbase.com/mobile/{major}.{minor-net}.{maintenance-net}/couchbase-lite-net/api/Couchbase.Lite.Query.FullTextFunction.htmlFullTextFunction.match(indexName:)[FullTextFunction.match(indexName:)]
-to build the query
-
-[#isnullormissing]
-===== IsNullOrMissing
-We will remove
-https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-net/api/Couchbase.Lite.Query.IExpression.html#Couchbase_Lite_Query_IExpression_IsNullOrMissing[isNullOrMissing] +
-You should plan to switch to using the alternative
-https://docs.couchbase.com/mobile/{major}.{minor-net}.{maintenance-net}/couchbase-lite-net/api/Couchbase.Lite.Query.IExpression.html#Couchbase_Lite_Query_IExpression_IsNotValued[IsNotValued()]
-
-at the earliest opportunity.
-
-[#before-5]
-===== Before
-[source, java,subs="attributes+, macros+"]
-----
-var query = QueryBuilder.Select(SelectResult.All())
-    .From(DataSource.Database(db))
-    .Where(Expression.Property("missingprop").IsNullOrMissing())
-----
-
-[#after-5]
-===== After
-[source, java,subs="attributes+, macros+"]
-----
-var query = QueryBuilder.Select(SelectResult.All())
-    .From(DataSource.Database(db))
-    .Where(Expression.Property("missingprop").IsNotValued())
-----
-
-
-[#notnullormissing]
-===== NotNullOrMissing
-We will remove
-https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-net/api/Couchbase.Lite.Query.IExpression.html#Couchbase_Lite_Query_IExpression_NotNullOrMissing[notNullOrMissing]. +
-You should plan to switch to using the alternative
-https://docs.couchbase.com/mobile/{major}.{minor-net}.{maintenance-net}/couchbase-lite-net/api/Couchbase.Lite.Query.IExpression.html#Couchbase_Lite_Query_IExpression_IsValued[isValued()]
-at the earliest opportunity.
-
-
-| isNotValued()
-
-
-[#before-6]
-===== Before
-[source, java,subs="attributes+, macros+"]
-----
-var query = QueryBuilder.Select(SelectResult.All())
-    .From(DataSource.Database(db))
-    .Where(Expression.Property("notmissingprop").NotNullOrMissing())
-----
-
-[#after-6]
-===== After
-[source, java,subs="attributes+, macros+"]
-----
-var query = QueryBuilder.Select(SelectResult.All())
-    .From(DataSource.Database(db))
-    .Where(Expression.Property("notmissingprop").IsValued())
-
-----
-
 
 [#lbl-db-upgrades]
 == 1.x Databases Upgrades to 2.x
 
-Databases created using Couchbase Lite 1.2 or later can still be used with Couchbase Lite 2.x; but will be automatically updated to the  current 2.x version.
+Databases created using Couchbase Lite 1.2 or later can still be used with Couchbase Lite 2.x; but will be automatically updated to the current 2.x version.
 This feature is only available for the default storage type (i.e., not a ForestDB database).
 
 [#encrypted-databases]
@@ -255,84 +69,13 @@ This feature is only available for the default storage type (i.e., not a ForestD
 The automatic migration feature does not support encrypted databases.
 So if the 1.x database is encrypted you will first need to disable encryption using the Couchbase Lite 1.x API (see the https://docs-archive.couchbase.com/couchbase-lite/1.4/C#.html#database-encryption[1.x Database Guide]).
 
-To upgrade an encrypted 1.x database, you should do the following:
-
 .Upgrading Encrypted Databases
 ****
 . Disable encryption using the Couchbase Lite 1.x framework (see https://docs-archive.couchbase.com/couchbase-lite/1.4/csharp.html#database-encryption[1.x encryption guide])
 . Open the database file with encryption enabled using the Couchbase Lite 2.x framework.
 ****
 
-Since it's not possible to package Couchbase Lite 1.x and Couchbase Lite 2.x in the same application this upgrade path would require two successive upgrades.
-
-If you're using Sync Gateway to synchronize the database content, it may be preferable to run a pull replication from a new 2.x database with encryption enabled and delete the 1.x local database.
-
-
-[#handling-of-existing-conflicts]
-=== Handling of Existing Conflicts
-
-If there are existing conflicts in the 1.x database, the automatic upgrade process copies the default winning revision to the new database and does NOT copy any conflicting revisions.
-
-This functionality is related to the way conflicts are now being handled in Couchbase Lite -- see xref:csharp:conflict.adoc[Handling Data Conflicts].
-
-Optionally, existing conflicts in the 1.x database can be resolved with the https://docs-archive.couchbase.com/couchbase-lite/1.4/C#.html#resolving-conflicts[1.x API] prior to the database being upgraded.
-
-[#handling-of-existing-attachments]
-=== Handling of Existing Attachments
-
-Attachments persisted in a 1.x database are copied to the new database.
-NOTE: The relevant Couchbase Lite API is now called the `Blob` API not the `Attachments` API.
-
-The functionally is identical but the internal schema for attachments has changed.
-
-Blobs are stored anywhere in the document, just like other value types.
-Whereas in 1.x they were stored under the `_attachments` field.
-
-The automatic upgrade functionality *does not* update the internal schema for attachments, so they remain accessible under the `_attachments` field.
-See xref:csharp:upgrade.adoc#ex-get-att[] for how to retrieve an attachment that was created in a 1.x database with a 2.x API.
-
-.Retrieve 1.x Attachment
-[#ex-get-att]
-
-
-[#ex-get-att]
-====
-
-
-[source, C#]
-----
-include::csharp:example$code_snippets/Program.cs[tags="1x-attachment", indent=0]
-----
-
-
-====
-
-
-[#replication-compatibility]
-=== Replication Compatibility
-
-The current replication protocol is not backwards compatible with the 1.x replication protocol.
-Therefore, to use replication with Couchbase Lite 2.x, the target Sync Gateway instance must also be upgraded to 2.x.
-
-Sync Gateway 2.x continues to accept clients that connect through the 1.x protocol.
-
-It automatically uses the 1.x replication protocol when a Couchbase Lite 1.x client connects through \http://localhost:4984/db and the 2.0 replication protocol when a Couchbase Lite 2.0 client connects through ws://localhost:4984/db.
-
-This allows for a smoother transition to get all your user base onto a version of your application built with Couchbase Lite 2.x.
-
-
-[#visual-studio]
-== Visual Studio
-
-The public facing API has completely changed in Couchbase Lite 2.0 and will require a re-write to upgrade an application that is using Couchbase Lite 1.x.
-To update an Xcode project built with Couchbase Lite 1.x:
-
-* Remove the existing Couchbase Lite nuget package from the Visual Studio project.
-* Remove all the Couchbase Lite 1.x dependencies -- see the  https://docs-archive.couchbase.com/couchbase-lite/1.4/csharp.html#getting-started[1.x installation guide].
-* Install the Couchbase Lite 2.0 framework in your project  -- see xref:csharp:gs-install.adoc[Install].
-At this point, there will be many compiler warnings.
-Refer to the examples on this page to learn about the new API.
-* Build & run your application.
+Since it is not possible to package Couchbase Lite 1.x and Couchbase Lite 2.x in the same application this upgrade path would require two successive upgrades.
 
 [#downgrading-couchbase-lite]
 == Downgrading Couchbase Lite
@@ -341,9 +84,6 @@ Refer to the examples on this page to learn about the new API.
 === Downgrading Between Major Releases
 
 *No Downgrade Support* - Downgrades between major versions of Couchbase Lite (CBL) are not supported.
-Once you upgrade to a new major version, downgrading to a previous major version may lead to incompatibility issues.
-
-For example, Upgrading from CBL 2.x.x to CBL 3.x.x does not guarantee the ability to revert to CBL 2.x.x.
 
 [#downgrading-between-minor-releases]
 === Downgrading Between Minor Releases
@@ -351,19 +91,11 @@ For example, Upgrading from CBL 2.x.x to CBL 3.x.x does not guarantee the abilit
 *Conditional Downgrade Support* - Downgrade support for minor releases is considered on a case-by-case basis.
 The release notes for each minor version will clarify whether downgrades are supported.
 
-For example, if a new minor version such as CBL 3.1.0 is released the release notes will specify whether downgrading to CBL 3.0.x is supported.
-
 [#downgrading-between-patch-releases]
 === Downgrading Between Patch Releases
 
 *Full Downgrade Support* - Downgrades between patch releases are supported.
 Users can safely downgrade between different patch versions within the same minor release.
-
-For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3.1.3 without issues.
-
-
-// Include standard footer
-
 
 [#related-content]
 == Related Content
@@ -378,7 +110,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 * xref:csharp:gs-install.adoc[Install]
 * xref:csharp:gs-build.adoc[Build and Run]
 
-
 .
 
 [.column]
@@ -392,7 +123,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 
 .
 
-
 [.column]
 === {empty}
 .Dive Deeper . . .
@@ -402,8 +132,6 @@ https://docs.couchbase.com/tutorials/[Tutorials]
 
 .
 
-
 ++++
 </div>
 ++++
-

--- a/modules/java/pages/compatibility.adoc
+++ b/modules/java/pages/compatibility.adoc
@@ -1,4 +1,3 @@
-
 = Compatibility
 :page-aliases: product/java-compatibility.adoc
 :page-role:
@@ -18,15 +17,14 @@ Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:java:releasenotes
 [#couchbase-litesync-gateway-matrix]
 == Couchbase Lite/Sync Gateway Matrix
 
-
 The table below summarizes the compatible versions of Couchbase Lite with Sync Gateway.
 
 .Sync Gateway and Couchbase Lite Compatibility Matrix
-[cols="3,^1,^1,^1,^1,^1,^1,^1,^1"]
+[cols="3,^1,^1,^1,^1,^1,^1,^1,^1,^1"]
 |===
 
 .2+^.>| Sync Gateway Versions ↓
-8+| Couchbase Lite →
+9+| Couchbase Lite →
 
 ^| 1.4 *footnote:eos-cbl[This Couchbase Lite version is End of Support]]*
 ^| 2.0
@@ -36,6 +34,7 @@ The table below summarizes the compatible versions of Couchbase Lite with Sync G
 ^| 3.1.0
 ^| 3.2.0
 ^| 3.3.0
+^| 3.4.0
 
 | 1.4 *footnote:eos-sgw[This Sync Gateway version is End of Support]* and 1.5 *footnote:eol-sgw[This Sync Gateway version is End of Life]*
 | image:ROOT:yes.png[]
@@ -46,8 +45,10 @@ The table below summarizes the compatible versions of Couchbase Lite with Sync G
 | image:ROOT:no.png[]
 | image:ROOT:no.png[]
 | image:ROOT:no.png[]
+| image:ROOT:no.png[]
 
 | 2.0 and 2.1
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -67,6 +68,7 @@ with delta sync disabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 2.5 to 2.8 +
 with delta sync enabled
@@ -78,9 +80,11 @@ with delta sync enabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 3.0.0
 | image:ROOT:no.png[]
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -98,9 +102,11 @@ with delta sync enabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 3.2.0
 | image:ROOT:no.png[]
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -118,8 +124,25 @@ with delta sync enabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+
+| 4.0.0
+| image:ROOT:no.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 |===
+
+[#vector-search-compatibility]
+== Vector Search Extension Compatibility
+
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
 
 [#operating-system-sdk-support]
 == Operating System SDK Support
@@ -127,9 +150,8 @@ with delta sync enabled
 The table below summarizes the Operating System SDK versions supported by Couchbase Lite.
 
 .OS -- SDK Support
-[cols="1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1"]
+[cols="1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1"]
 |===
-
 
 ^.>h|
 ^.>h| 2.0
@@ -142,6 +164,7 @@ The table below summarizes the Operating System SDK versions supported by Couchb
 ^.>h| 3.1
 ^.>h| 3.2
 ^.>h| 3.3
+^.>h| 3.4
 
 h| Android
 | https://docs-archive.couchbase.com/home/index.html[archive link]
@@ -154,6 +177,7 @@ h| Android
 | xref:3.1@couchbase-lite:android:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:android:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:android:supported-os.adoc[link]
+| xref:android:supported-os.adoc[link]
 
 h| C
 | -
@@ -166,8 +190,9 @@ h| C
 | xref:3.1@couchbase-lite:c:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:c:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:c:supported-os.adoc[link]
+| xref:c:supported-os.adoc[link]
 
-h|  iOS
+h| iOS
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
@@ -178,9 +203,9 @@ h|  iOS
 | xref:3.1@couchbase-lite:swift:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:swift:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:swift:supported-os.adoc[link]
+| xref:swift:supported-os.adoc[link]
 
-
-h|  Java
+h| Java
 | -
 | -
 | -
@@ -191,8 +216,9 @@ h|  Java
 | xref:3.1@couchbase-lite:java:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:java:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:java:supported-os.adoc[link]
+| xref:java:supported-os.adoc[link]
 
-h|  Javascript
+h| Javascript
 | -
 | -
 | -
@@ -203,8 +229,9 @@ h|  Javascript
 | xref:3.1@couchbase-lite:ROOT:javascript.adoc[link]
 | xref:3.2@couchbase-lite:ROOT:javascript.adoc[link]
 | xref:3.3@couchbase-lite:ROOT:javascript.adoc[link]
+| xref:ROOT:javascript.adoc[link]
 
-h|  .NET
+h| .NET
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
 | https://docs-archive.couchbase.com/home/index.html[archive link]
@@ -215,6 +242,7 @@ h|  .NET
 | xref:3.1@couchbase-lite:csharp:supported-os.adoc[link]
 | xref:3.2@couchbase-lite:csharp:supported-os.adoc[link]
 | xref:3.3@couchbase-lite:csharp:supported-os.adoc[link]
+| xref:csharp:supported-os.adoc[link]
 
 |===
 
@@ -233,7 +261,6 @@ h|  .NET
 * xref:java:supported-os.adoc[Supported Platforms]
 * xref:cbl-whatsnew.adoc[What's New]
 
-
 .
 
 [.column]
@@ -247,7 +274,6 @@ h|  .NET
 
 .
 
-
 [.column]
 ====== {empty}
 .Tutorials
@@ -257,9 +283,6 @@ https://docs.couchbase.com/tutorials/[Tutorials]
 
 .
 
-
 ++++
 </div>
 ++++
-
-

--- a/modules/java/pages/upgrade.adoc
+++ b/modules/java/pages/upgrade.adoc
@@ -1,4 +1,3 @@
-
 = Upgrade
 :page-aliases: advance/java-dep-upgrade.adoc, dep-upgrade.adoc
 :page-role:
@@ -8,29 +7,31 @@
 :source-language: Java
 
 
-// The admonition does not apply to C as it references upgrading from versions 2.x.
-// CBL-C started at version 3.0
 [IMPORTANT]
 --
 On upgrading from a 2.x release, all Couchbase Lite databases will be automatically re-indexed on initial database open. +
 This can result in a delay before the database is usable.
 --
 
-[#3-2-3-upgrade]
+=== Vector Search Extension
+
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
+If your application uses Vector Search, update the Vector Search Extension to 2.0.0 when upgrading to Couchbase Lite 3.4.0.
+
+[#3-4-0-upgrade]
 == {major}.{minor-java}.{maintenance-java}{empty} Upgrade
 
-The action takes place automatically and can lead to some delay in the database becoming available for use in your application.
+Couchbase Lite {major}.{minor} is a non-breaking upgrade from 3.3.
+Update your Couchbase Lite dependency to {major}.{minor} -- no API or configuration changes are required.
 
-In addition, if you're syncing with a {major}.{minor}.{base}{empty} Sync Gateway, you should be aware of the significant configuration enhancements introduced and their impact.
-See xref:sync-gateway::upgrading.adoc[Upgrading Sync Gateway] for more details.
-This is a one-way conversion.
+[WARNING]
+--
+When upgrading from Couchbase Lite 3.4.0 to the 4.x release line, upgrade directly to 4.1.0 or later.
+Couchbase Lite 4.x versions below 4.1.0 do not include all APIs added in 3.4.0 (Multipeer Replicator with Bluetooth and Auto Switching, Replication Correlation ID, and on Android, Kotlin Serialization; and on C, the C++ API).
+--
 
-// All API and other listed changes included in the other platforms do not apply to CBL-C for the following reasons
-// The changes apply to pre 3.x versions (CBL-C started at 3.0)
-// Or they relate to Querybuilder functionality - CBL-C doesn't have Querybuilder.
 [#api-changes]
 === API Changes
-
 
 This content introduces the changes made to the Couchbase{nbsp}Lite for Java API for release {major}.{minor-java}.{maintenance-java}{empty}.
 
@@ -56,198 +57,16 @@ replicator.start()
 replicator.start(true)
 ----
 
-[#database-setloglevel]
-===== Database.setLogLevel
-
-The method https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/Database.html#setLogLevel-com.couchbase.lite.LogDomain-com.couchbase.lite.LogLevel-[Database.setLogLevel()]
-has been removed. +
-Instead:
-
-. Set the logging levels for loggers, individually
-. Set the domains to be logged by the console logger, explicitly.
-
-.Before
-[source, Java,subs="attributes+, macros+"]
-----
-Database.setLogLevel(LogDomain.ALL, LogLevel.VERBOSE)
-
-----
-
-.After
-[source, Java,subs="attributes+, macros+"]
-----
-Database.log.getConsole().setDomains(LogDomain.ALL_DOMAINS)
-Database.log.getConsole().setLevel(LogLevel.VERBOSE)
-Database.log.getFile().setDomains(LogLevel.DEBUG)
-----
-
-[#database-compact]
-===== Database.compact
-The https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/Database.html#compact--[Database.compact()] method has been removed. +
-It is replaced by the new https://docs.couchbase.com/mobile/{major}.{minor-java}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/Database.html#performMaintenance-com.couchbase.lite.MaintenanceType-[Database.performMaintenance(MaintenanceType)] method, and the maintenance operations represented in the enum https://docs.couchbase.com/mobile/{major}.{minor-java}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/MaintenanceType.html[MaintenanceType]
-
-.Before
-[source, Java,subs="attributes+, macros+"]
-----
-try testdb.compact()
-
-----
-
-.After
-[source, Java,subs="attributes+, macros+"]
-----
-testdb.performMaintenance(MaintenanceType.COMPACT)
-----
-
-
-[#deprecated-in-the-api]
-==== Deprecated in the API
-
-[#match]
-===== MATCH
-The class, https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/FullTextExpression.html[FullTextExpression]
-has been deprecated. +
-Use https://docs.couchbase.com/mobile/{major}.{minor-java}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/FullTextFunction.html[FullTextFunction] instead.
-
-.Before
-[source, Java,subs="attributes+, macros+"]
-----
-FullTextExpression index = FullTextExpression.index("indexName")
-Query q = QueryBuilder.select([SelectResult.expression(Meta.id)])
-  .from(DataSource.database(testdb))
-  .where(index.match(queryString))
-
-----
-
-.After
-[source, Java,subs="attributes+, macros+"]
-----
-Query q = QueryBuilder.select([SelectResult.expression(Meta.id)])
-  .from(DataSource.database(testdb))
-  .where(FullTextFunction.match("indexName", queryString))
-
-----
-
-[#isnullormissingnotnullormissing]
-===== isNullOrMissing/notNullOrMissing
-
-The functions https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/Expression.html#isNullOrMissing--[Expression.isNullOrMissing] and https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/Expression.html#notNullOrMissing--[Expression.notNullOrMissing] have been deprecated. +
-Use `isNotValued()` and-or `isValued()` instead.
-
-
-.Before
-[source, Java,subs="attributes+, macros+"]
-----
-Query q =
-  QueryBuilder
-    .select([SelectResult.expression(Meta.id)])
-    .from(DataSource.database(testdb))
-    .where(
-      Expression.property("missingProp").isNullOrMissing())
-
-Query q =
-  QueryBuilder
-    .select([SelectResult.expression(Meta.id)])
-    .from(DataSource.database(testdb))
-    .where(Expression.property("notMissingProp").notNullOrMissing())
-
-----
-.After
-[source, Java,subs="attributes+, macros+"]
-----
-Query q = QueryBuilder.select([SelectResult.expression(Meta.id)])
-  .from(DataSource.database(testdb))
-  .where(Expression.property("missingProp").isNotValued())
-
-Query q = QueryBuilder.select([SelectResult.expression(Meta.id)])
-  .from(DataSource.database(testdb))
-  .where(Expression.property("notMissingProp").isValued())
-
-----
-
-
-[#abstractreplicatorconfiguration]
-===== AbstractReplicatorConfiguration
-
-The enum https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/ReplicatorConfiguration.html#setReplicatorType-com.couchbase.lite.AbstractReplicatorConfiguration.ReplicatorType-[AbstractReplicatorConfiguration.ReplicatorType]
-and the methods
-https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/ReplicatorConfiguration.html#setReplicatorType--[
-ReplicatorConfiguration.setReplicatorType]
-and
-https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/ReplicatorConfiguration.html#getReplicatorType--[
-ReplicatorConfiguration.getReplicatorType]
-have all been deprecated. +
-Instead, use the methods `ReplicatorConfiguration.setType` and `ReplicatorConfiguration.getType`, and the top level enum `ReplicatorType`.
-
-.Before
-[source, Java,subs="attributes+, macros+"]
-----
-ReplicatorConfiguration config =
-  new ReplicatorConfiguration().setReplicatorType(ReplicatorConfiguration.ReplicatorType.PUSH_AND_PULL);
-----
-.After
-[source, Java,subs="attributes+, macros+"]
-----
-ReplicatorConfiguration config =
-  new ReplicatorConfiguration().setType(ReplicatorType.PUSH_AND_PULL);
-----
-
-
-[#moved-in-the-api]
-==== Moved in the API
-
-The enum https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/AbstractReplicator.ActivityLevel.html[AbstractReplicator.ActivityLevel] and the classes https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/AbstractReplicator.Progress.html[AbstractReplicator.Progress] and https://docs.couchbase.com/mobile/2.8.0/couchbase-lite-java/com/couchbase/lite/AbstractReplicator.Status.html[AbstractReplicator.Status] have all been moved to be top level definitions. +
-They are replaced by these definitions:
-
-* https://docs.couchbase.com/mobile/{major}.{minor-java}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/ReplicatorActivityLevel.html[ReplicatorActivityLevel]
-* https://docs.couchbase.com/mobile/{major}.{minor-java}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/ReplicatorProgress.html[ReplicatorProgress]
-* https://docs.couchbase.com/mobile/{major}.{minor-java}.{base}{empty}/couchbase-lite-java/com/couchbase/lite/ReplicatorStatus.html[ReplicatorStatus]
-
-
-.Before
-[source, Java,subs="attributes+, macros+"]
-----
-ListenerToken token =
-  replicator.addChangeListener(
-    testSerialExecutor,
-    change -> {
-      final AbstractReplicator.Status status = change.getStatus()
-      if (status.getActivityLevel() == AbstractReplicator.ActivityLevel.BUSY)
-      { AbstractReplicator.Progress progress =
-          status.getProgress(); Logger.log("Progress: " + progress.completed + "/" progress.total);
-      }
-    });
-
-----
-.After
-[source, Java,subs="attributes+, macros+"]
-----
-ListenerToken token =
-  replicator.addChangeListener(
-    testSerialExecutor,
-    change -> {
-      final ReplicatorStatus status = change.getStatus()
-      if (status.getActivityLevel() == ReplicatorActivityLevel.BUSY)
-      { ReplicatorProgress progress =
-          status.getProgress(); Logger.log("Progress: " + progress.completed + "/" progress.total);
-      }
-    });
-
-----
-
-
 [#lbl-db-upgrades]
 == 1.x Databases Upgrades to 2.x
 
-Databases created using Couchbase Lite 1.2 or later can still be used with Couchbase Lite 2.x; but will be automatically updated to the  current 2.x version.
+Databases created using Couchbase Lite 1.2 or later can still be used with Couchbase Lite 2.x; but will be automatically updated to the current 2.x version.
 This feature is only available for the default storage type (i.e., not a ForestDB database).
 
 [#encrypted-databases]
 === Encrypted Databases
 The automatic migration feature does not support encrypted databases.
 So if the 1.x database is encrypted you will first need to disable encryption using the Couchbase Lite 1.x API (see the https://docs-archive.couchbase.com/couchbase-lite/1.4/Java.html#database-encryption[1.x Database Guide]).
-
-Thus, to upgrade an encrypted 1.x database, you should do the following:
 
 .Upgrading Encrypted Databases
 ****
@@ -257,62 +76,6 @@ Thus, to upgrade an encrypted 1.x database, you should do the following:
 
 Since it is not possible to package Couchbase Lite 1.x and Couchbase Lite 2.x in the same application this upgrade path would require two successive upgrades.
 
-If you are using Sync Gateway to synchronize the database content, it may be preferable to run a pull replication from a new 2.x database with encryption enabled and delete the 1.x local database.
-
-
-[#handling-of-existing-conflicts]
-=== Handling of Existing Conflicts
-
-If there are existing conflicts in the 1.x database, the automatic upgrade process copies the default winning revision to the new database and does NOT copy any conflicting revisions.
-
-This functionality is related to the way conflicts are now being handled in Couchbase Lite -- see xref:java:conflict.adoc[Handling Data Conflicts].
-
-Optionally, existing conflicts in the 1.x database can be resolved with the https://docs-archive.couchbase.com/couchbase-lite/1.4/Java.html#resolving-conflicts[1.x API] prior to the database being upgraded.
-
-[#handling-of-existing-attachments]
-=== Handling of Existing Attachments
-
-Attachments persisted in a 1.x database are copied to the new database.
-NOTE: The relevant Couchbase Lite API is now called the `Blob` API not the `Attachments` API.
-
-The functionally is identical but the internal schema for attachments has changed.
-
-Blobs are stored anywhere in the document, just like other value types.
-Whereas in 1.x they were stored under the `_attachments` field.
-
-The automatic upgrade functionality *does not* update the internal schema for attachments, so they remain accessible under the `_attachments` field.
-See xref:java:upgrade.adoc#ex-get-att[] for how to retrieve an attachment that was created in a 1.x database with a 2.x API.
-
-.Retrieve 1.x Attachment
-[#ex-get-att]
-
-
-[#ex-get-att]
-====
-
-
-[source, Java]
-----
-include::java:example$codesnippet_collection.java[tags="1x-attachment", indent=0]
-----
-
-
-====
-
-
-[#replication-compatibility]
-=== Replication Compatibility
-
-The current replication protocol is not backwards compatible with the 1.x replication protocol.
-Therefore, to use replication with Couchbase Lite 2.x, the target Sync Gateway instance must also be upgraded to 2.x.
-
-Sync Gateway 2.x will continue to accept clients that connect through the 1.x protocol.
-
-It will automatically use the 1.x replication protocol when a Couchbase Lite 1.x client connects through \http://localhost:4984/db and the 2.0 replication protocol when a Couchbase Lite 2.0 client connects through ws://localhost:4984/db.
-
-This allows for a smoother transition to get all your user base onto a version of your application built with Couchbase Lite 2.x.
-
-
 [#downgrading-couchbase-lite]
 == Downgrading Couchbase Lite
 
@@ -320,9 +83,6 @@ This allows for a smoother transition to get all your user base onto a version o
 === Downgrading Between Major Releases
 
 *No Downgrade Support* - Downgrades between major versions of Couchbase Lite (CBL) are not supported.
-Once you upgrade to a new major version, downgrading to a previous major version may lead to incompatibility issues.
-
-For example, Upgrading from CBL 2.x.x to CBL 3.x.x does not guarantee the ability to revert to CBL 2.x.x.
 
 [#downgrading-between-minor-releases]
 === Downgrading Between Minor Releases
@@ -330,19 +90,11 @@ For example, Upgrading from CBL 2.x.x to CBL 3.x.x does not guarantee the abilit
 *Conditional Downgrade Support* - Downgrade support for minor releases is considered on a case-by-case basis.
 The release notes for each minor version will clarify whether downgrades are supported.
 
-For example, if a new minor version such as CBL 3.1.0 is released the release notes will specify whether downgrading to CBL 3.0.x is supported.
-
 [#downgrading-between-patch-releases]
 === Downgrading Between Patch Releases
 
 *Full Downgrade Support* - Downgrades between patch releases are supported.
 Users can safely downgrade between different patch versions within the same minor release.
-
-For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3.1.3 without issues.
-
-
-// Include standard footer
-
 
 [#related-content]
 == Related Content
@@ -357,7 +109,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 * xref:java:gs-install.adoc[Install]
 * xref:java:gs-build.adoc[Build and Run]
 
-
 .
 
 [.column]
@@ -371,7 +122,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 
 .
 
-
 [.column]
 === {empty}
 .Dive Deeper . . .
@@ -381,8 +131,6 @@ https://docs.couchbase.com/tutorials/[Tutorials]
 
 .
 
-
 ++++
 </div>
 ++++
-

--- a/modules/objc/pages/compatibility.adoc
+++ b/modules/objc/pages/compatibility.adoc
@@ -108,9 +108,10 @@ with delta sync enabled
 
 |===
 
-// NOTE: Verify CBL 3.4 / Sync Gateway compatibility rows with engineering
-// before publishing. Confirm whether SGW 4.0.0 is compatible with CBL 3.4,
-// and whether any additional SGW versions gain or lose compatibility.
+[#vector-search-compatibility]
+== Vector Search Extension Compatibility
+
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
 
 [#operating-system-sdk-support]
 == Operating System SDK Support

--- a/modules/objc/pages/upgrade.adoc
+++ b/modules/objc/pages/upgrade.adoc
@@ -1,4 +1,3 @@
-
 = Upgrade Couchbase Lite
 :page-aliases: advance/objc-dep-upgrade.adoc, dep-upgrade.adoc
 :page-role:
@@ -7,29 +6,30 @@
 
 :source-language: objc
 
-:source-language: objc
 
-
-// The admonition does not apply to C as it references upgrading from versions 2.x.
-// CBL-C started at version 3.0
 [IMPORTANT]
 --
 On upgrading from a 2.x release, all Couchbase Lite databases will be automatically re-indexed on initial database open. +
 This can result in a delay before the database is usable.
 --
 
-[#3-2-3-upgrade]
+=== Vector Search Extension
+
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
+If your application uses Vector Search, update the Vector Search Extension to 2.0.0 when upgrading to Couchbase Lite 3.4.0.
+
+[#3-4-0-upgrade]
 == {major}.{minor}.{base}{empty} Upgrade
 
-The action will take place automatically and can lead to some delay in the database becoming available for use in your application.
+Couchbase Lite {major}.{minor} is a non-breaking upgrade from 3.3.
+Update your Couchbase Lite dependency to {major}.{minor} -- no API or configuration changes are required.
 
-In addition, if you are syncing with a {major}.{minor}.{base}{empty} Sync Gateway, you should be aware of the significant configuration enhancements introduced and their impact.
-See xref:sync-gateway::upgrading.adoc[Upgrading Sync Gateway] for more details.
-This is a one-way conversion.
+[WARNING]
+--
+When upgrading from Couchbase Lite 3.4.0 to the 4.x release line, upgrade directly to 4.1.0 or later.
+Couchbase Lite 4.x versions below 4.1.0 do not include all APIs added in 3.4.0 (Multipeer Replicator with Bluetooth and Auto Switching, Replication Correlation ID, and on Android, Kotlin Serialization; and on C, the C++ API).
+--
 
-// All API and other listed changes included in the other platforms do not apply to CBL-C for the following reasons
-// The changes apply to pre 3.x versions (CBL-C started at 3.0)
-// Or they relate to Querybuilder functionality - CBL-C doesn't have Querybuilder.
 [#api-changes]
 === API Changes
 
@@ -85,101 +85,16 @@ CBLDatabase.log.console.domains = kCBLLogDomainAll;
 [testdb performMaintenance:kCBLMaintenanceTypeCompact error:&error];
 ----
 
-
-[#deprecated-api]
-==== Deprecated API
-
-[#match]
-===== Match
-.Alternative
-`[CBLQueryFullTextFunction matchWithIndexName: query:]`
-
-.Before
-----
-CBLQueryFullTextExpression* index = [CBLQueryFullTextExpression indexWithName: @"indexName"];
-q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: [CBLQueryMeta id]]]
-                        from: [CBLQueryDataSource database: self.database]
-                        where: [index match: @"'queryString'"]];
-----
-
-.After
-----
-    q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: [CBLQueryMeta id]]]
-                           from: [CBLQueryDataSource database: self.database]
-                          where: [CBLQueryFullTextFunction matchWithIndexName: @"indexName"
-                                                                        query: @"'queryString'"]];
-----
-
-
-[#isnullormissing-and-notnullormissing]
-===== isNullOrMissing and notNullOrMissing
-
-.Alternatives
-----
-[exp isValued];
-[exp isNotValued];
-----
-
-.Before
-----
-    q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: [CBLQueryMeta id]]]
-                           from: [CBLQueryDataSource database: self.database]
-                          where: [[CBLQueryExpression property: @"missingProp"] isNullOrMissing]];
-
-    q2 = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: [CBLQueryMeta id]]]
-                            from: [CBLQueryDataSource database: self.database]
-                           where: [[CBLQueryExpression property: @"notMissingProp"] notNullOrMissing]];
-----
-
-.After
-----
-    q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: [CBLQueryMeta id]]]
-                           from: [CBLQueryDataSource database: self.database]
-                          where: [[CBLQueryExpression property: @"missingProp"] isNotValued]];
-
-    q2 = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: [CBLQueryMeta id]]]
-                            from: [CBLQueryDataSource database: self.database]
-                           where: [[CBLQueryExpression property: @"notMissingProp"] isValued]];
-----
-
-[#updated-api]
-==== Updated API
-
-
-[#atan2]
-===== ATAN2
-
-CAUTION: Breaking change
-
-`ATAN2(x, y)` now becomes `ATAN2(y, x)`
-
-.Before
-[source, objc]
-----
-q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: [CBLQueryFunction atan2: p y: [CBLQueryExpression integer: 90]]]]
-                            from: [CBLQueryDataSource database: self.database]];
-----
-
-.After
-[source, objc]
-----
-q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: [CBLQueryFunction atan2: [CBLQueryExpression integer: 90] x: p]]]
-                           from: [CBLQueryDataSource database: self.database]];
-----
-
-
 [#lbl-db-upgrades]
 == 1.x Databases Upgrades to 2.x
 
-Databases created using Couchbase Lite 1.2 or later can still be used with Couchbase Lite 2.x; but will be automatically updated to the  current 2.x version.
+Databases created using Couchbase Lite 1.2 or later can still be used with Couchbase Lite 2.x; but will be automatically updated to the current 2.x version.
 This feature is only available for the default storage type (i.e., not a ForestDB database).
 
 [#encrypted-databases]
 === Encrypted Databases
 The automatic migration feature does not support encrypted databases.
 So if the 1.x database is encrypted you will first need to disable encryption using the Couchbase Lite 1.x API (see the https://docs-archive.couchbase.com/couchbase-lite/1.4/objc.html#database-encryption[1.x Database Guide]).
-
-Thus, to upgrade an encrypted 1.x database, you should do the following:
 
 .Upgrading Encrypted Databases
 ****
@@ -191,74 +106,6 @@ Since it is not possible to package Couchbase Lite 1.x and Couchbase Lite 2.x in
 
 If you are using Sync Gateway to synchronize the database content, it may be preferable to run a pull replication from a new 2.x database with encryption enabled and delete the 1.x local database.
 
-
-[#handling-of-existing-conflicts]
-=== Handling of Existing Conflicts
-
-If there are existing conflicts in the 1.x database, the automatic upgrade process copies the default winning revision to the new database and does NOT copy any conflicting revisions.
-
-This functionality is related to the way conflicts are now being handled in Couchbase Lite -- see xref:objc:conflict.adoc[Handling Data Conflicts].
-
-Optionally, existing conflicts in the 1.x database can be resolved with the https://docs-archive.couchbase.com/couchbase-lite/1.4/objc.html#resolving-conflicts[1.x API] prior to the database being upgraded.
-
-[#handling-of-existing-attachments]
-=== Handling of Existing Attachments
-
-Attachments persisted in a 1.x database are copied to the new database.
-NOTE: The relevant Couchbase Lite API is now called the `Blob` API not the `Attachments` API.
-
-The functionally is identical but the internal schema for attachments has changed.
-
-Blobs are stored anywhere in the document, just like other value types.
-Whereas in 1.x they were stored under the `_attachments` field.
-
-The automatic upgrade functionality *does not* update the internal schema for attachments, so they remain accessible under the `_attachments` field.
-See xref:objc:upgrade.adoc#ex-get-att[] for how to retrieve an attachment that was created in a 1.x database with a 2.x API.
-
-.Retrieve 1.x Attachment
-[#ex-get-att]
-
-
-[#ex-get-att]
-====
-
-
-[source, objc]
-----
-include::objc:example$code_snippets/SampleCodeTest.m[tags="1x-attachment", indent=0]
-----
-
-
-====
-
-
-[#replication-compatibility]
-=== Replication Compatibility
-
-The current replication protocol is not backwards compatible with the 1.x replication protocol.
-Therefore, to use replication with Couchbase Lite 2.x, the target Sync Gateway instance must also be upgraded to 2.x.
-
-Sync Gateway 2.x will continue to accept clients that connect through the 1.x protocol.
-
-It will automatically use the 1.x replication protocol when a Couchbase Lite 1.x client connects through \http://localhost:4984/db and the 2.0 replication protocol when a Couchbase Lite 2.0 client connects through ws://localhost:4984/db.
-
-This allows for a smoother transition to get all your user base onto a version of your application built with Couchbase Lite 2.x.
-
-
-[#xcode]
-== Xcode
-
-The API has changed in Couchbase Lite 2.0 and will require porting an application that is using Couchbase Lite 1.x API to the Couchbase Lite 2.0 API.
-To update an Xcode project built with Couchbase Lite 1.x:
-
-* Remove the existing *CouchbaseLite.framework* dependency from the Xcode project.
-* Remove all the Couchbase Lite 1.x dependencies (see the https://docs-archive.couchbase.com/couchbase-lite/1.4/objc.html#getting-started[1.x installation guide]).
-* Install the Couchbase Lite 2.0 framework in your project  -- see xref:objc:gs-install.adoc[Install].
-At this point, there will be many compiler warnings.
-Refer to the examples on this page to learn about the new API.
-* Build & run your application.
-
-
 [#downgrading-couchbase-lite]
 == Downgrading Couchbase Lite
 
@@ -268,27 +115,17 @@ Refer to the examples on this page to learn about the new API.
 *No Downgrade Support* - Downgrades between major versions of Couchbase Lite (CBL) are not supported.
 Once you upgrade to a new major version, downgrading to a previous major version may lead to incompatibility issues.
 
-For example, Upgrading from CBL 2.x.x to CBL 3.x.x does not guarantee the ability to revert to CBL 2.x.x.
-
 [#downgrading-between-minor-releases]
 === Downgrading Between Minor Releases
 
 *Conditional Downgrade Support* - Downgrade support for minor releases is considered on a case-by-case basis.
 The release notes for each minor version will clarify whether downgrades are supported.
 
-For example, if a new minor version such as CBL 3.1.0 is released the release notes will specify whether downgrading to CBL 3.0.x is supported.
-
 [#downgrading-between-patch-releases]
 === Downgrading Between Patch Releases
 
 *Full Downgrade Support* - Downgrades between patch releases are supported.
 Users can safely downgrade between different patch versions within the same minor release.
-
-For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3.1.3 without issues.
-
-
-// Include standard footer
-
 
 [#related-content]
 == Related Content
@@ -303,7 +140,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 * xref:objc:gs-install.adoc[Install]
 * xref:objc:gs-build.adoc[Build and Run]
 
-
 .
 
 [.column]
@@ -317,7 +153,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 
 .
 
-
 [.column]
 === {empty}
 .Dive Deeper . . .
@@ -327,8 +162,6 @@ https://docs.couchbase.com/tutorials/[Tutorials]
 
 .
 
-
 ++++
 </div>
 ++++
-

--- a/modules/swift/pages/compatibility.adoc
+++ b/modules/swift/pages/compatibility.adoc
@@ -108,9 +108,10 @@ with delta sync enabled
 
 |===
 
-// NOTE: Verify CBL 3.4 / Sync Gateway compatibility rows with engineering
-// before publishing. Confirm whether SGW 4.0.0 is compatible with CBL 3.4,
-// and whether any additional SGW versions gain or lose compatibility.
+[#vector-search-compatibility]
+== Vector Search Extension Compatibility
+
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
 
 [#operating-system-sdk-support]
 == Operating System SDK Support

--- a/modules/swift/pages/upgrade.adoc
+++ b/modules/swift/pages/upgrade.adoc
@@ -6,13 +6,16 @@
 :source-language: swift
 
 
-// The admonition does not apply to C as it references upgrading from versions 2.x.
-// CBL-C started at version 3.0
 [IMPORTANT]
 --
 On upgrading from a 2.x release, all Couchbase Lite databases will automatically be re-indexed on initial database open. +
 This can result in a delay before the database is usable.
 --
+
+=== Vector Search Extension
+
+Couchbase Lite 3.4.0 is compatible with Vector Search Extension 2.0.0 only.
+If your application uses Vector Search, update the Vector Search Extension to 2.0.0 when upgrading to Couchbase Lite 3.4.0.
 
 [#3-4-0-upgrade]
 == {major}.{minor}.{base}{empty} Upgrade
@@ -21,6 +24,12 @@ Couchbase Lite {major}.{minor} is a non-breaking upgrade from 3.3.
 Update your Couchbase Lite dependency to {major}.{minor} -- no API or configuration changes are required.
 Existing `MultipeerReplicatorConfiguration` setups continue to work without modification.
 The default transport remains Wi-Fi only.
+
+[WARNING]
+--
+When upgrading from Couchbase Lite 3.4.0 to the 4.x release line, upgrade directly to 4.1.0 or later.
+Couchbase Lite 4.x versions below 4.1.0 do not include all APIs added in 3.4.0 (Multipeer Replicator with Bluetooth and Auto Switching, Replication Correlation ID, and on Android, Kotlin Serialization; and on C, the C++ API).
+--
 
 === Enabling Bluetooth Transport (Optional)
 
@@ -108,126 +117,16 @@ try testdb.compact()
 try testdb.performMaintenance(type: .compact)
 ----
 
-
-[#deprecated-api]
-==== Deprecated API
-
-[#match]
-===== Match
-.Alternative
-`FullTextFunction.match(indexName:)`
-
-.Before
-----
-let index = FullTextExpression.index ("indexName")
-let q = QueryBuilder.select([SelectResult.
-expression(Meta.id)])
-            .from(DataSource.database(testdb)) +
-            .where(index.match("'queryString'"))
-----
-
-.After
-----
-let q = QueryBuilder.select([SelectResult.expression(Meta.id)])
-            .from(DataSource.database(testdb))
-            .where(FullTextFunction.match(indexName: "indexName", query: "'queryString'"))
-----
-
-
-[#isnullormissing-and-notnullormissing]
-===== isNullOrMissing and notNullOrMissing
-
-.Alternatives
-`isNotValued()` +
-`isValued()`
-
-.Before
-----
-|let q1 = QueryBuilder.select([SelectResult.expression(Meta.id)])
-            .from(DataSource.database(testdb))
-            .where(Expression.property("missingProp").isNullOrMissing())
-
-let q2 = QueryBuilder.select([SelectResult.expression(Meta.id)])
-            .from(DataSource.database(testdb))
-            .where(Expression.property("notMissingProp").notNullOrMissing())
-----
-
-.After
-----
-let q1 = QueryBuilder.select([SelectResult.expression(Meta.id)])
-            .from(DataSource.database(testdb))
-            .where(Expression.property("missingProp").isNotValued())
-
-let q2 = QueryBuilder.select([SelectResult.expression(Meta.id)])
-            .from(DataSource.database(testdb))
-            .where(Expression.property("notMissingProp").isValued())
-----
-
-[#updated-api]
-==== Updated API
-
-[#configuration]
-===== Configuration
-The following classes are changed to Swift struct.
-
-* DatabaseConfiguration
-* ReplicatorConfiguration
-* URLEndpointListenerConfiguration
-
-.Before
-----
-
-let config = DatabaseConfiguration()
-config.encryptionKey = EncryptionKey.password(password!)
-
-let config = ReplicatorConfiguration(database: db, target: target)
-config.continuous = true
-----
-
-.After
-----
-var config = DatabaseConfiguration()
-config.encryptionKey = EncryptionKey.password(password!)
-
-var config = ReplicatorConfiguration(database: db, target: target)
-config.continuous = true
-----
-
-[#atan2]
-===== ATAN2
-
-CAUTION: Breaking change
-
-`ATAN2(x, y)` now becomes `ATAN2(y, x)`
-
-.Before
-[source, swift]
-----
-let p = Expression.property("number")
-let q = QueryBuilder.select([SelectResult.expression(Function.atan2(x: Expression.int(90), y: p))])
-            .from(DataSource.database(testdb))
-----
-
-.After
-[source, swift]
-----
-let q = QueryBuilder.select([SelectResult.expression(Function.atan2(y: Expression.int(90), x: p))])
-            .from(DataSource.database(testdb))
-----
-
-
 [#lbl-db-upgrades]
 == 1.x Databases Upgrades to 2.x
 
-Databases created using Couchbase Lite 1.2 or later can still be used with Couchbase Lite 2.x; but will automatically be updated to the  current 2.x version.
+Databases created using Couchbase Lite 1.2 or later can still be used with Couchbase Lite 2.x; but will automatically be updated to the current 2.x version.
 This feature is only available for the default storage type (i.e., not a ForestDB database).
 
 [#encrypted-databases]
 === Encrypted Databases
 The automatic migration feature does not support encrypted databases.
 So if the 1.x database is encrypted you will first need to disable encryption using the Couchbase Lite 1.x API (see the https://docs-archive.couchbase.com/couchbase-lite/1.4/swift.html#database-encryption[1.x Database Guide]).
-
-Thus, to upgrade an encrypted 1.x database, you should do the following:
 
 .Upgrading Encrypted Databases
 ****
@@ -239,74 +138,6 @@ Since it is not possible to package Couchbase Lite 1.x and Couchbase Lite 2.x in
 
 If you are using Sync Gateway to synchronize the database content, it may be preferable to run a pull replication from a new 2.x database with encryption enabled and delete the 1.x local database.
 
-
-[#handling-of-existing-conflicts]
-=== Handling of Existing Conflicts
-
-If there are existing conflicts in the 1.x database, the automatic upgrade process copies the default winning revision to the new database and does NOT copy any conflicting revisions.
-
-This functionality is related to the way conflicts are now being handled in Couchbase Lite -- see xref:swift:conflict.adoc[Handling Data Conflicts].
-
-Optionally, existing conflicts in the 1.x database can be resolved with the https://docs-archive.couchbase.com/couchbase-lite/1.4/swift.html#resolving-conflicts[1.x API] prior to the database being upgraded.
-
-[#handling-of-existing-attachments]
-=== Handling of Existing Attachments
-
-Attachments persisted in a 1.x database are copied to the new database.
-NOTE: The relevant Couchbase Lite API is now called the `Blob` API not the `Attachments` API.
-
-The functionally is identical but the internal schema for attachments has changed.
-
-Blobs are stored anywhere in the document, just like other value types.
-Whereas in 1.x they were stored under the `_attachments` field.
-
-The automatic upgrade functionality *does not* update the internal schema for attachments, so they remain accessible under the `_attachments` field.
-See xref:swift:upgrade.adoc#ex-get-att[] for how to retrieve an attachment that was created in a 1.x database with a 2.x API.
-
-.Retrieve 1.x Attachment
-[#ex-get-att]
-
-
-[#ex-get-att]
-====
-
-
-[source, swift]
-----
-include::swift:example$code_snippets/SampleCodeTest.swift[tags="1x-attachment", indent=0]
-----
-
-
-====
-
-
-[#replication-compatibility]
-=== Replication Compatibility
-
-The current replication protocol is not backwards compatible with the 1.x replication protocol.
-Therefore, to use replication with Couchbase Lite 2.x, the target Sync Gateway instance must also be upgraded to 2.x.
-
-Sync Gateway 2.x continues to accept clients that connect through the 1.x protocol.
-
-It automatically uses the 1.x replication protocol when a Couchbase Lite 1.x client connects through \http://localhost:4984/db and the 2.0 replication protocol when a Couchbase Lite 2.0 client connects through ws://localhost:4984/db.
-
-This allows for a smoother transition to get all your user base onto a version of your application built with Couchbase Lite 2.x.
-
-
-[#xcode]
-== Xcode
-
-The API has changed in Couchbase Lite 2.0 and requires porting an application that's using Couchbase Lite 1.x API to the Couchbase Lite 2.0 API.
-To update an Xcode project built with Couchbase Lite 1.x:
-
-* Remove the existing *CouchbaseLite.framework* dependency from the Xcode project.
-* Remove all the Couchbase Lite 1.x dependencies (see the https://docs-archive.couchbase.com/couchbase-lite/1.4/swift.html#getting-started[1.x installation guide]).
-* Install the Couchbase Lite 2.0 framework in your project  -- see xref:swift:gs-install.adoc[Install].
-At this point, there will be many compiler warnings.
-Refer to the examples on this page to learn about the new API.
-* Build & run your application.
-
-
 [#downgrading-couchbase-lite]
 == Downgrading Couchbase Lite
 
@@ -316,27 +147,17 @@ Refer to the examples on this page to learn about the new API.
 *No Downgrade Support* - Downgrades between major versions of Couchbase Lite (CBL) are not supported.
 Once you upgrade to a new major version, downgrading to a previous major version may lead to incompatibility issues.
 
-For example, Upgrading from CBL 2.x.x to CBL 3.x.x does not guarantee the ability to revert to CBL 2.x.x.
-
 [#downgrading-between-minor-releases]
 === Downgrading Between Minor Releases
 
 *Conditional Downgrade Support* - Downgrade support for minor releases is considered on a case-by-case basis.
 The release notes for each minor version clarifies whether downgrades are supported.
 
-For example, if a new minor version such as CBL 3.1.0 is released the release notes specify whether downgrading to CBL 3.0.x is supported.
-
 [#downgrading-between-patch-releases]
 === Downgrading Between Patch Releases
 
 *Full Downgrade Support* - Downgrades between patch releases are supported.
 Users can downgrade between different patch versions within the same minor release.
-
-For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3.1.3 without issues.
-
-
-// Include standard footer
-
 
 [#related-content]
 == Related Content
@@ -351,7 +172,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 * xref:swift:gs-install.adoc[Install]
 * xref:swift:gs-build.adoc[Build and Run]
 
-
 .
 
 [.column]
@@ -365,7 +185,6 @@ For example, if you're running CBL 3.1.6 you can downgrade to CBL 3.1.4 or CBL 3
 
 .
 
-
 [.column]
 === {empty}
 .Dive Deeper . . .
@@ -374,7 +193,6 @@ https://blog.couchbase.com/[Blog] |
 https://docs.couchbase.com/tutorials/[Tutorials]
 
 .
-
 
 ++++
 </div>


### PR DESCRIPTION
Update compatibility and upgrade pages to include 3.4 only works with 2.0 version vectors 

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-upgrade-3-4-vs-compat

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.