### PR TITLE
add release notes 3.4

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -21,15 +21,15 @@ asciidoc:
     # releasetag:
     major: 3
     minor: 4
-    minor-net: 2
-    minor-java: 2
-    minor-c: 2
+    minor-net: 4
+    minor-java: 4
+    minor-c: 4
     maintenance-ios: 0
     maintenance-swift: 0
-    maintenance-c: 4
+    maintenance-c: 0
     maintenance-android: 0
-    maintenance-java: 4
-    maintenance-net: 4
+    maintenance-java: 0
+    maintenance-net: 0
     base: 0
 
     # Used for Vector Search Extension.

--- a/modules/android/pages/releasenotes.adoc
+++ b/modules/android/pages/releasenotes.adoc
@@ -8,8 +8,4 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: Android
 
 [#maint-latest]
-include::partial$release-notes/couchbase-mobile-android-release-note.3.3.2.adoc[]
-
-include::partial$release-notes/couchbase-mobile-android-release-note.3.3.1.adoc[]
-
-include::partial$release-notes/couchbase-mobile-android-release-note.3.3.0.adoc[]
+include::partial$release-notes/couchbase-mobile-android-release-note.3.4.0.adoc[]

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.4.0.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.4.0.adoc
@@ -32,4 +32,4 @@ Version 3.4.0 for {param-title} delivers the following features and enhancements
 
 None for this release.
 
-NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[].

--- a/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.4.0.adoc
+++ b/modules/android/partials/release-notes/couchbase-mobile-android-release-note.3.4.0.adoc
@@ -1,0 +1,35 @@
+[#maint-3-4-0]
+== 3.4.0 -- June 2026
+
+Version 3.4.0 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://jira.issues.couchbase.com/browse/CBL-7686[CBL-7686 -- MultipeerReplicator now supports Bluetooth Low Energy with automatic transport switching]
+* https://jira.issues.couchbase.com/browse/CBL-7968[CBL-7968 -- Improve COUNT query performance on the default collection]
+* https://jira.issues.couchbase.com/browse/CBL-7970[CBL-7970 -- Improve checkpoint resolution for non-numeric (compound) Sync Gateway sequences]
+* https://jira.issues.couchbase.com/browse/CBL-7971[CBL-7971 -- API to access the Replicator's correlation ID]
+* https://jira.issues.couchbase.com/browse/CBL-8121[CBL-8121 -- Kotlin Serialization support for documents and query results]
+
+=== Fixed Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7610[CBL-7610 -- QueryBuilder Unicode collation used null instead of the default system locale]
+* https://jira.issues.couchbase.com/browse/CBL-7960[CBL-7960 -- Purging a deleted document does not trigger query change listener events]
+* https://jira.issues.couchbase.com/browse/CBL-7985[CBL-7985 -- MultipeerReplicator may crash when registering a replication task while stopping]
+* https://jira.issues.couchbase.com/browse/CBL-8111[CBL-8111 -- MultipeerReplicator.getNecessaryPermissions() throws an incorrect compatibility error on Android 13 and newer]
+* https://jira.issues.couchbase.com/browse/CBL-8359[CBL-8359 -- WebSocket does not echo the close frame when the close is initiated by the remote]
+* https://jira.issues.couchbase.com/browse/CBL-8363[CBL-8363 -- Crash due to buffer overrun in Encoder::snip while saving a Version Vector document]
+* https://jira.issues.couchbase.com/browse/CBL-8380[CBL-8380 -- A peer connection that closes before the TLS handshake completes may hang the MultipeerReplicator]
+* https://jira.issues.couchbase.com/browse/CBL-8475[CBL-8475 -- Use-after-free crash (EXC_BAD_ACCESS) when a replicator is torn down]
+* https://jira.issues.couchbase.com/browse/CBL-8515[CBL-8515 -- A stalled inbound P2P TLS handshake can wedge the MultipeerReplicator]
+
+=== Known Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-8577[CBL-8577 -- MultipeerReplicator peer-info methods may block when using Bluetooth]
+
+
+=== Deprecations
+
+None for this release.
+
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]

--- a/modules/c/nav-c.adoc
+++ b/modules/c/nav-c.adoc
@@ -46,6 +46,8 @@ include::partial$_set_page_context_for_c.adoc[]
   * xref:c:upgrade.adoc[]
 
   * https://docs.couchbase.com/mobile/{major}.{minor-c}.{maintenance-c}/couchbase-lite-c/C/html/modules.html[API Reference]
+  * https://docs.couchbase.com/mobile/{major}.{minor-c}.{maintenance-c}/couchbase-lite-c/C++/html/annotated.html[C{plus}{plus} API Reference]
+
 
   * Product Notes
     ** xref:c:releasenotes.adoc[]

--- a/modules/c/pages/releasenotes.adoc
+++ b/modules/c/pages/releasenotes.adoc
@@ -9,4 +9,4 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-abstract: This content describes the key features and changes implemented by release {version} of Couchbase Lite on {param-title}
 
 [#maint-latest]
-include::partial$release-notes/couchbase-mobile-c-release-note.3.3.0.adoc[]
+include::partial$release-notes/couchbase-mobile-c-release-note.3.4.0.adoc[]

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.4.0.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.4.0.adoc
@@ -1,0 +1,36 @@
+[#maint-3-4-0]
+== 3.4.0 -- June 2026
+
+Version 3.4.0 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://jira.issues.couchbase.com/browse/CBL-7926[CBL-7926 -- Include the C++ API headers in the iOS XCFramework]
+* https://jira.issues.couchbase.com/browse/CBL-7968[CBL-7968 -- Improve COUNT query performance on the default collection]
+* https://jira.issues.couchbase.com/browse/CBL-7970[CBL-7970 -- Improve checkpoint resolution for non-numeric (compound) Sync Gateway sequences]
+* https://jira.issues.couchbase.com/browse/CBL-7971[CBL-7971 -- API to access the Replicator's correlation ID]
+* https://jira.issues.couchbase.com/browse/CBL-7972[CBL-7972 -- The C++ API is now officially supported]
+* https://jira.issues.couchbase.com/browse/CBL-7973[CBL-7973 -- Add support for Windows on ARM64]
+
+=== Fixed Issues
+
+
+* https://jira.issues.couchbase.com/browse/CBL-7766[CBL-7766 -- SQL++ fails to parse the IN operator]
+* https://jira.issues.couchbase.com/browse/CBL-7960[CBL-7960 -- Purging a deleted document does not trigger query change listener events]
+* https://jira.issues.couchbase.com/browse/CBL-7985[CBL-7985 -- MultipeerReplicator may crash when registering a replication task while stopping]
+* https://jira.issues.couchbase.com/browse/CBL-8363[CBL-8363 -- Crash due to buffer overrun in Encoder::snip while saving a Version Vector document]
+* https://jira.issues.couchbase.com/browse/CBL-8380[CBL-8380 -- A peer connection that closes before the TLS handshake completes may hang the MultipeerReplicator]
+* https://jira.issues.couchbase.com/browse/CBL-8475[CBL-8475 -- Use-after-free crash (EXC_BAD_ACCESS) when a replicator is torn down]
+* https://jira.issues.couchbase.com/browse/CBL-8515[CBL-8515 -- A stalled inbound P2P TLS handshake can wedge the MultipeerReplicator]
+* https://jira.issues.couchbase.com/browse/CBL-8561[CBL-8561 -- Replicator may time out when replicating a large number of collections]
+
+=== Known Issues
+
+
+None for this release.
+
+=== Deprecations
+
+None for this release.
+
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]

--- a/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.4.0.adoc
+++ b/modules/c/partials/release-notes/couchbase-mobile-c-release-note.3.4.0.adoc
@@ -33,4 +33,4 @@ None for this release.
 
 None for this release.
 
-NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[].

--- a/modules/csharp/pages/releasenotes.adoc
+++ b/modules/csharp/pages/releasenotes.adoc
@@ -8,4 +8,4 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: C#.Net
 
 [#maint-latest]
-include::partial$release-notes/couchbase-mobile-csharp-release-note.3.3.0.adoc[]
+include::partial$release-notes/couchbase-mobile-csharp-release-note.3.4.0.adoc[]

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.4.0.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.4.0.adoc
@@ -32,4 +32,4 @@ None for this release.
 None for this release.
 
 
-NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[].

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.4.0.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.3.4.0.adoc
@@ -1,0 +1,35 @@
+[#maint-3-4-0]
+== 3.4.0 -- June 2026
+
+Version 3.4.0 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://jira.issues.couchbase.com/browse/CBL-7968[CBL-7968 -- Improve COUNT query performance on the default collection]
+* https://jira.issues.couchbase.com/browse/CBL-7970[CBL-7970 -- Improve checkpoint resolution for non-numeric (compound) Sync Gateway sequences]
+* https://jira.issues.couchbase.com/browse/CBL-7971[CBL-7971 -- API to access the Replicator's correlation ID]
+
+=== Fixed Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7766[CBL-7766 -- SQL++ fails to parse the IN operator]
+* https://jira.issues.couchbase.com/browse/CBL-7873[CBL-7873 -- Replicator ignores proxy settings from a PAC file on iOS and Mac Catalyst]
+* https://jira.issues.couchbase.com/browse/CBL-7960[CBL-7960 -- Purging a deleted document does not trigger query change listener events]
+* https://jira.issues.couchbase.com/browse/CBL-7985[CBL-7985 -- MultipeerReplicator may crash when registering a replication task while stopping]
+* https://jira.issues.couchbase.com/browse/CBL-8282[CBL-8282 -- WebSocket wrapper could throw an uncaught ObjectDisposedException during connection shutdown]
+* https://jira.issues.couchbase.com/browse/CBL-8363[CBL-8363 -- Crash due to buffer overrun in Encoder::snip while saving a Version Vector document]
+* https://jira.issues.couchbase.com/browse/CBL-8380[CBL-8380 -- A peer connection that closes before the TLS handshake completes may hang the MultipeerReplicator]
+* https://jira.issues.couchbase.com/browse/CBL-8382[CBL-8382 -- Stopping a replicator with pending conflict tasks could throw an uncaught exception]
+* https://jira.issues.couchbase.com/browse/CBL-8475[CBL-8475 -- Use-after-free crash (EXC_BAD_ACCESS) when a replicator is torn down]
+* https://jira.issues.couchbase.com/browse/CBL-8515[CBL-8515 -- A stalled inbound P2P TLS handshake can wedge the MultipeerReplicator]
+* https://jira.issues.couchbase.com/browse/CBL-8561[CBL-8561 -- Replicator may time out when replicating a large number of collections]
+
+=== Known Issues
+
+None for this release.
+
+=== Deprecations
+
+None for this release.
+
+
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]

--- a/modules/java/pages/releasenotes.adoc
+++ b/modules/java/pages/releasenotes.adoc
@@ -8,5 +8,5 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: Java
 
 [#maint-latest]
-include::partial$release-notes/couchbase-mobile-java-release-note.3.3.0.adoc[]
+include::partial$release-notes/couchbase-mobile-java-release-note.3.4.0.adoc[]
 

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.4.0.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.4.0.adoc
@@ -1,0 +1,35 @@
+[#maint-3-4-0]
+== 3.4.0 -- June 2026
+
+Version 3.4.0 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+
+* https://jira.issues.couchbase.com/browse/CBL-7968[CBL-7968 -- Improve COUNT query performance on the default collection]
+* https://jira.issues.couchbase.com/browse/CBL-7970[CBL-7970 -- Improve checkpoint resolution for non-numeric (compound) Sync Gateway sequences]
+* https://jira.issues.couchbase.com/browse/CBL-7971[CBL-7971 -- API to access the Replicator's correlation ID]
+
+=== Fixed Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7610[CBL-7610 -- QueryBuilder Unicode collation used null instead of the default system locale]
+* https://jira.issues.couchbase.com/browse/CBL-7766[CBL-7766 -- SQL++ fails to parse the IN operator]
+* https://jira.issues.couchbase.com/browse/CBL-7960[CBL-7960 -- Purging a deleted document does not trigger query change listener events]
+* https://jira.issues.couchbase.com/browse/CBL-7985[CBL-7985 -- MultipeerReplicator may crash when registering a replication task while stopping]
+* https://jira.issues.couchbase.com/browse/CBL-8359[CBL-8359 -- WebSocket does not echo the close frame when the close is initiated by the remote]
+* https://jira.issues.couchbase.com/browse/CBL-8363[CBL-8363 -- Crash due to buffer overrun in Encoder::snip while saving a Version Vector document]
+* https://jira.issues.couchbase.com/browse/CBL-8380[CBL-8380 -- A peer connection that closes before the TLS handshake completes may hang the MultipeerReplicator]
+* https://jira.issues.couchbase.com/browse/CBL-8475[CBL-8475 -- Use-after-free crash (EXC_BAD_ACCESS) when a replicator is torn down]
+* https://jira.issues.couchbase.com/browse/CBL-8515[CBL-8515 -- A stalled inbound P2P TLS handshake can wedge the MultipeerReplicator]
+* https://jira.issues.couchbase.com/browse/CBL-8561[CBL-8561 -- Replicator may time out when replicating a large number of collections]
+
+=== Known Issues
+
+None for this release.
+
+=== Deprecations
+
+None for this release.
+
+
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]

--- a/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.4.0.adoc
+++ b/modules/java/partials/release-notes/couchbase-mobile-java-release-note.3.4.0.adoc
@@ -32,4 +32,4 @@ None for this release.
 None for this release.
 
 
-NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[].

--- a/modules/objc/pages/releasenotes.adoc
+++ b/modules/objc/pages/releasenotes.adoc
@@ -8,9 +8,4 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: Objective-C
 
 [#maint-latest]
-include::partial$release-notes/couchbase-mobile-objc-release-note.3.3.2.adoc[]
-
-include::partial$release-notes/couchbase-mobile-objc-release-note.3.3.1.adoc[]
-
-include::partial$release-notes/couchbase-mobile-objc-release-note.3.3.0.adoc[]
-
+include::partial$release-notes/couchbase-mobile-objc-release-note.3.4.0.adoc[]

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.4.0.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.4.0.adoc
@@ -31,4 +31,4 @@ None for this release
 
 None for this release
 
-NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[].

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.4.0.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.4.0.adoc
@@ -29,6 +29,6 @@ None for this release.
 
 === Deprecations
 
-None for this release
+None for this release.
 
 NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[].

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.4.0.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.4.0.adoc
@@ -25,7 +25,7 @@ Version 3.4.0 for {param-title} delivers the following features and enhancements
 
 === Known Issues
 
-None for this release
+None for this release.
 
 === Deprecations
 

--- a/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.4.0.adoc
+++ b/modules/objc/partials/release-notes/couchbase-mobile-objc-release-note.3.4.0.adoc
@@ -1,0 +1,34 @@
+[#maint-3-4-0]
+== 3.4.0 -- June 2026
+
+Version 3.4.0 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://jira.issues.couchbase.com/browse/CBL-7968[CBL-7968 -- Improve COUNT query performance on the default collection]
+* https://jira.issues.couchbase.com/browse/CBL-7970[CBL-7970 -- Improve checkpoint resolution for non-numeric (compound) Sync Gateway sequences]
+* https://jira.issues.couchbase.com/browse/CBL-7971[CBL-7971 -- API to access the Replicator's correlation ID]
+
+=== Fixed Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7766[CBL-7766 -- SQL++ fails to parse the IN operator]
+* https://jira.issues.couchbase.com/browse/CBL-7873[CBL-7873 -- Replicator ignores proxy settings from a PAC file on iOS and Mac Catalyst]
+* https://jira.issues.couchbase.com/browse/CBL-7960[CBL-7960 -- Purging a deleted document does not trigger query change listener events]
+* https://jira.issues.couchbase.com/browse/CBL-7985[CBL-7985 -- MultipeerReplicator may crash when registering a replication task while stopping]
+* https://jira.issues.couchbase.com/browse/CBL-8282[CBL-8282 -- WebSocket wrapper could throw an uncaught ObjectDisposedException during connection shutdown]
+* https://jira.issues.couchbase.com/browse/CBL-8363[CBL-8363 -- Crash due to buffer overrun in Encoder::snip while saving a Version Vector document]
+* https://jira.issues.couchbase.com/browse/CBL-8380[CBL-8380 -- A peer connection that closes before the TLS handshake completes may hang the MultipeerReplicator]
+* https://jira.issues.couchbase.com/browse/CBL-8382[CBL-8382 -- Stopping a replicator with pending conflict tasks could throw an uncaught exception]
+* https://jira.issues.couchbase.com/browse/CBL-8475[CBL-8475 -- Use-after-free crash (EXC_BAD_ACCESS) when a replicator is torn down]
+* https://jira.issues.couchbase.com/browse/CBL-8515[CBL-8515 -- A stalled inbound P2P TLS handshake can wedge the MultipeerReplicator]
+* https://jira.issues.couchbase.com/browse/CBL-8561[CBL-8561 -- Replicator may time out when replicating a large number of collections]
+
+=== Known Issues
+
+None for this release
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]

--- a/modules/swift/pages/releasenotes.adoc
+++ b/modules/swift/pages/releasenotes.adoc
@@ -8,9 +8,4 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: Swift
 
 [#maint-latest]
-include::partial$release-notes/couchbase-mobile-swift-release-note.3.3.2.adoc[]
-
-include::partial$release-notes/couchbase-mobile-swift-release-note.3.3.1.adoc[]
-
-include::partial$release-notes/couchbase-mobile-swift-release-note.3.3.0.adoc[]
-
+include::partial$release-notes/couchbase-mobile-swift-release-note.3.4.0.adoc[]

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.4.0.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.4.0.adoc
@@ -33,4 +33,4 @@ Version 3.4.0 for {param-title} delivers the following features and enhancements
 
 None for this release
 
-NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[].

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.4.0.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.4.0.adoc
@@ -1,0 +1,36 @@
+[#maint-3-4-0]
+== 3.4.0 -- June 2026
+
+Version 3.4.0 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+* https://jira.issues.couchbase.com/browse/CBL-7685[CBL-7685 -- MultipeerReplicator now supports Bluetooth Low Energy with automatic transport switching]
+* https://jira.issues.couchbase.com/browse/CBL-7968[CBL-7968 -- Improve COUNT query performance on the default collection]
+* https://jira.issues.couchbase.com/browse/CBL-7970[CBL-7970 -- Improve checkpoint resolution for non-numeric (compound) Sync Gateway sequences]
+* https://jira.issues.couchbase.com/browse/CBL-7971[CBL-7971 -- API to access the Replicator's correlation ID]
+
+=== Fixed Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-7250[CBL-7250 -- Combine change publisher may miss the first result when subscribed on a different dispatch queue]
+* https://jira.issues.couchbase.com/browse/CBL-7960[CBL-7960 -- Purging a deleted document does not trigger query change listener events]
+* https://jira.issues.couchbase.com/browse/CBL-7985[CBL-7985 -- MultipeerReplicator may crash when registering a replication task while stopping]
+* https://jira.issues.couchbase.com/browse/CBL-8188[CBL-8188 -- Potential deadlock when closing a database with active services running]
+* https://jira.issues.couchbase.com/browse/CBL-8236[CBL-8236 -- Replicator may crash with a SIGABRT when its WebSocket closes during teardown]
+* https://jira.issues.couchbase.com/browse/CBL-8333[CBL-8333 -- Memory leak when encoding a Codable model into a document]
+* https://jira.issues.couchbase.com/browse/CBL-8355[CBL-8355 -- MultipeerReplicator may deadlock, causing an iOS watchdog kill (0x8BADF00D) when the app backgrounds]
+* https://jira.issues.couchbase.com/browse/CBL-8363[CBL-8363 -- Crash due to buffer overrun in Encoder::snip while saving a Version Vector document]
+* https://jira.issues.couchbase.com/browse/CBL-8380[CBL-8380 -- A peer connection that closes before the TLS handshake completes may hang the MultipeerReplicator]
+* https://jira.issues.couchbase.com/browse/CBL-8395[CBL-8395 -- Default conflict resolution does not compare revision IDs when two revisions have the same generation]
+* https://jira.issues.couchbase.com/browse/CBL-8475[CBL-8475 -- Use-after-free crash (EXC_BAD_ACCESS) when a replicator is torn down]
+* https://jira.issues.couchbase.com/browse/CBL-8515[CBL-8515 -- A stalled inbound P2P TLS handshake can wedge the MultipeerReplicator]
+
+=== Known Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-8575[CBL-8575 -- MultipeerReplicator peer-info methods may block when using Bluetooth]
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[]

--- a/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.4.0.adoc
+++ b/modules/swift/partials/release-notes/couchbase-mobile-swift-release-note.3.4.0.adoc
@@ -31,6 +31,6 @@ Version 3.4.0 for {param-title} delivers the following features and enhancements
 
 === Deprecations
 
-None for this release
+None for this release.
 
 NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[].


### PR DESCRIPTION
Release notes for 3.4 CBL platforms, add C++ API reference 

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-update-release-3-4

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.