### PR TITLE
update logging apis

### DIFF
--- a/modules/c/examples/code_snippets/main.cpp
+++ b/modules/c/examples/code_snippets/main.cpp
@@ -38,7 +38,7 @@ static void old_file_logging() {
     // NOTE: No error handling, for brevity (see getting started)
     // NOTE: Use a platform-appropriate method to find a temporary directory
  
-    CBLLogFileConfiguration config = {}; // Don't bother zeroing, since we set all properties
+    CBLLogFileConfiguration config = {}; // Skip zeroing, since all fields are explicitly set
     config.level = kCBLLogInfo;
     config.directory = FLSTR("/tmp/logs");
     config.maxRotateCount = 12;

--- a/modules/c/examples/code_snippets/main.cpp
+++ b/modules/c/examples/code_snippets/main.cpp
@@ -27,6 +27,29 @@ static void stop_replicator(CBLReplicator* replicator) {
     CBLReplicator_Release(replicator);
 }
 
+static void old_console_logging() {
+    // tag::console-logging[]
+    CBLLog_SetConsoleLevel(kCBLLogVerbose);
+    // end::console-logging[]
+}
+
+static void old_file_logging() {
+    // tag::file-logging[]
+    // NOTE: No error handling, for brevity (see getting started)
+    // NOTE: You will need to use a platform appropriate method for finding
+    // a temporary directory
+    CBLLogFileConfiguration config = {}; // Don't bother zeroing, since we set all properties
+    config.level = kCBLLogInfo;
+    config.directory = FLSTR("/tmp/logs");
+    config.maxRotateCount = 12;
+    config.maxSize = 1048576;
+    config.usePlaintext = false;
+
+    CBLError err = {};
+    CBLLog_SetFileConfig(config, &err);
+    // end::file-logging[]
+}
+
 //  BEGIN lower-level function declarations
 
 //  DOCS NOTE --
@@ -1719,6 +1742,12 @@ static void custom_log_sink_callback(CBLLogDomain domain, CBLLogLevel level, FLS
     // handle the message, for example piping it to a third party framework.
 }
 // end::new-custom-logging[]
+
+static void old_set_custom_logging() {
+    // tag::set-custom-logging[]
+    CBLLog_SetCallback(custom_log_callback);
+    // end::set-custom-logging[]
+}
 
 static void enable_custom_log_sink() {
     // tag::set-new-custom-logging[]

--- a/modules/c/examples/code_snippets/main.cpp
+++ b/modules/c/examples/code_snippets/main.cpp
@@ -37,7 +37,7 @@ static void old_file_logging() {
     // tag::file-logging[]
     // NOTE: No error handling, for brevity (see getting started)
     // NOTE: Use a platform-appropriate method to find a temporary directory
-    // a temporary directory
+ 
     CBLLogFileConfiguration config = {}; // Don't bother zeroing, since we set all properties
     config.level = kCBLLogInfo;
     config.directory = FLSTR("/tmp/logs");

--- a/modules/c/examples/code_snippets/main.cpp
+++ b/modules/c/examples/code_snippets/main.cpp
@@ -36,7 +36,7 @@ static void old_console_logging() {
 static void old_file_logging() {
     // tag::file-logging[]
     // NOTE: No error handling, for brevity (see getting started)
-    // NOTE: You will need to use a platform appropriate method for finding
+    // NOTE: Use a platform-appropriate method to find a temporary directory
     // a temporary directory
     CBLLogFileConfiguration config = {}; // Don't bother zeroing, since we set all properties
     config.level = kCBLLogInfo;

--- a/modules/c/pages/new-logging-api.adoc
+++ b/modules/c/pages/new-logging-api.adoc
@@ -79,31 +79,13 @@ For greater flexibility you can implement a custom logging class.
 The changes necessary convert the installation of a console logger from the old to the new API are minimal.
 Create an instance of `ConsoleLogSink` initialized with the desired log level and domains and install it.
 
-
 .Old API
 ====
-[tabs]
-=====
-C::
-+
---
 [source.no-callouts, c, indent=0]
 ----
 include::c:example$code_snippets/main.cpp[tags=console-logging]
 ----
---
-
-{cpp}::
-+
---
-[source.no-callouts, cpp, indent=0]
-----
-include::c:example$code_snippets/cbl_cpp.cpp[tags=console-logging]
-----
---
-=====
 ====
-
 
 .New API
 [{tabs}]
@@ -139,26 +121,10 @@ NOTE: `setRotateCount` from the old API is slightly different from `setMaxKeptFi
 
 .Old API
 ====
-[tabs]
-=====
-C::
-+
---
 [source.no-callouts, c, indent=0]
 ----
 include::c:example$code_snippets/main.cpp[tags=file-logging]
 ----
---
-
-{cpp}::
-+
---
-[source.no-callouts, cpp, indent=0]
-----
-include::c:example$code_snippets/cbl_cpp.cpp[tags=file-logging]
-----
---
-=====
 ====
 
 .New API
@@ -205,29 +171,12 @@ IMPORTANT: With the new API, customer code can no longer log, directly, to any o
 The Console and File log sinks cannot be subclassed and do not publish methods that allow writing logs.
 If you need to log to the console for example, you'll have to create your own way of doing so.
 
-
 .Old API
 ====
-[tabs]
-=====
-C::
-+
---
 [source.no-callouts, c, indent=0]
 ----
 include::c:example$code_snippets/main.cpp[tags=custom-logging;set-custom-logging]
 ----
---
-
-{cpp}::
-+
---
-[source.no-callouts, cpp, indent=0]
-----
-include::c:example$code_snippets/cbl_cpp.cpp[tags=custom-logging;set-custom-logging]
-----
---
-=====
 ====
 
 .New API
@@ -250,15 +199,4 @@ C++::
 include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags=new-custom-logging;set-new-custom-logging]
 ----
 --
-====
-
-{cpp}::
-+
---
-[source.no-callouts, cpp, indent=0]
-----
-include::c:example$code_snippets/cbl_cpp.cpp[tags=new-custom-logging;set-new-custom-logging]
-----
---
-=====
 ====


### PR DESCRIPTION
Docs Issue: [DOC-14478](https://jira.issues.couchbase.com/browse/DOC-14478?atlOrigin=eyJpIjoiMDFkM2EyODIyODJjNGNlNTk5MzVkNjVkN2I3ZjRkNzAiLCJwIjoiaiJ9)


PR to update the new logging API page 

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-14478-broken-snippets-logging/couchbase-lite/current/c/new-logging-api.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-14478]: https://couchbasecloud.atlassian.net/browse/DOC-14478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ