### PR TITLE
DOC-14529-net-4.1.1 maintenance release

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -14,7 +14,7 @@ nav:
 - modules/swift/nav-swift.adoc
 asciidoc:
   attributes:
-    prerelease: 
+    prerelease:
     previous-release:
     release: '4.1'
     # releasetag:
@@ -26,7 +26,7 @@ asciidoc:
     maintenance-c: 0
     maintenance-android: 0
     maintenance-java: 0
-    maintenance-net: 0
+    maintenance-net: 1
     maintenance-swift: 0
     base: 0
 

--- a/modules/csharp/pages/releasenotes.adoc
+++ b/modules/csharp/pages/releasenotes.adoc
@@ -8,4 +8,5 @@ ifdef::prerelease[:page-status: {prerelease}]
 :param-title: C#.Net
 
 [#maint-latest]
+include::partial$release-notes/couchbase-mobile-csharp-release-note.4.1.1.adoc[]
 include::partial$release-notes/couchbase-mobile-csharp-release-note.4.1.0.adoc[]

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.4.1.1.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.4.1.1.adoc
@@ -1,0 +1,23 @@
+[#maint-4-1-1]
+== 4.1.1 -- July 2026
+
+Version 4.1.1 for {param-title} delivers the following features and enhancements:
+
+=== Enhancements
+
+None for this release.
+
+=== Fixed Issues
+
+* https://jira.issues.couchbase.com/browse/CBL-8677[CBL-8677 -- WinUI missing console log writer registration]
+* https://jira.issues.couchbase.com/browse/CBL-8678[CBL-8678 -- WinUI missing console log writer registration]
+
+=== Known Issues
+
+None for this release.
+
+=== Deprecations
+
+None for this release
+
+NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[].

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.4.1.1.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.4.1.1.adoc
@@ -17,6 +17,6 @@ None for this release.
 
 === Deprecations
 
-None for this release
+None for this release.
 
 NOTE: For an overview of the latest features offered in Couchbase Lite {release}, see xref:ROOT:cbl-whatsnew.adoc[].

--- a/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.4.1.1.adoc
+++ b/modules/csharp/partials/release-notes/couchbase-mobile-csharp-release-note.4.1.1.adoc
@@ -10,7 +10,6 @@ None for this release.
 === Fixed Issues
 
 * https://jira.issues.couchbase.com/browse/CBL-8677[CBL-8677 -- WinUI missing console log writer registration]
-* https://jira.issues.couchbase.com/browse/CBL-8678[CBL-8678 -- WinUI missing console log writer registration]
 
 === Known Issues
 


### PR DESCRIPTION
Docs Issue: [DOC-14529](https://jira.issues.couchbase.com/browse/DOC-14529)

PR to add the 4.1.1 .NET maintenance release 

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-DOC-14529-net-4.1.1-release

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-14529]: https://couchbasecloud.atlassian.net/browse/DOC-14529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ