### PR TITLE
Callout-list fixes

### DIFF
--- a/modules/c/pages/p2psync-websocket-using-active.adoc
+++ b/modules/c/pages/p2psync-websocket-using-active.adoc
@@ -335,7 +335,7 @@ include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags=replication-retry-config,i
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="replication-retry-config", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="replication-retry-config", indent=0]
 ----
 <.> Here we use heartbeat to set the required interval (in seconds) between the heartbeat pulses.
 <.> Here we use maxAttempts to set the required number of retry attempts.
@@ -511,7 +511,7 @@ include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags=p2p-act-rep-start-full,ind
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="p2p-act-rep-start-full;!p2p-act-rep-add-change-listener", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="p2p-act-rep-start-full;!p2p-act-rep-add-change-listener", indent=0]
 ----
 <.> Initialize the replicator with the configuration
 <.> Start the replicator
@@ -679,7 +679,7 @@ This is a snapshot and may have changed by the time the response is received and
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="replication-pendingdocuments", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="replication-pendingdocuments", indent=0]
 ----
 <.> Returns a list of the document IDs for all documents waiting to be pushed.
 This is a snapshot and may have changed by the time the response is received and processed.
@@ -816,7 +816,7 @@ Local Wins::
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tag=local-win-conflict-resolver,indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tag=local-win-conflict-resolver,indent=0]
 ----
 --
 
@@ -825,7 +825,7 @@ Remote Wins::
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tag=remote-win-conflict-resolver,indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tag=remote-win-conflict-resolver,indent=0]
 ----
 --
 
@@ -834,7 +834,7 @@ Merge::
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tag=merge-conflict-resolver,indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tag=merge-conflict-resolver,indent=0]
 ----
 --
 

--- a/modules/c/pages/p2psync-websocket-using-passive.adoc
+++ b/modules/c/pages/p2psync-websocket-using-passive.adoc
@@ -93,6 +93,12 @@ C::
 ----
 include::c:example$code_snippets/main.cpp[tags="listener-initialize", indent=0]
 ----
+
+. Here we show the default TLS authentication, which is an anonymous self-signed certificate.
+The server must always authenticate itself to the client. @/config.tlsIdentity/
+
+. Here we show how basic authentication is configured to authenticate the client-supplied credentials from the http authentication header against valid credentials -- see <<lbl-authenticating-the-client>> for more options.
+Note that client authentication is optional. @/config.authenticator/
 --
 
 {cpp}::
@@ -100,18 +106,12 @@ include::c:example$code_snippets/main.cpp[tags="listener-initialize", indent=0]
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-initialize", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-initialize", indent=0]
 ----
 --
 =====
 
 ====
-
-. Here we show the default TLS authentication, which is an anonymous self-signed certificate.
-The server must always authenticate itself to the client. @/config.tlsIdentity/
-
-. Here we show how basic authentication is configured to authenticate the client-supplied credentials from the http authentication header against valid credentials -- see <<lbl-authenticating-the-client>> for more options.
-Note that client authentication is optional. @/config.authenticator/
 
 
 [#api-references]
@@ -155,7 +155,7 @@ include::c:example$code_snippets/main.cpp[tags="listener-config-db", indent=0]
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-config-db", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-config-db", indent=0]
 ----
 --
 =====
@@ -193,7 +193,7 @@ include::c:example$code_snippets/main.cpp[tags="listener-config-port", indent=0]
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-config-port", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-config-port", indent=0]
 ----
 --
 =====
@@ -230,7 +230,7 @@ include::c:example$code_snippets/main.cpp[tags="listener-config-netw-iface", ind
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-config-netw-iface", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-config-netw-iface", indent=0]
 ----
 --
 =====
@@ -270,7 +270,7 @@ include::c:example$code_snippets/main.cpp[tags="listener-config-delta-sync", ind
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-config-delta-sync", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-config-delta-sync", indent=0]
 ----
 --
 =====
@@ -461,6 +461,11 @@ C::
 ----
 include::c:example$code_snippets/main.cpp[tags="listener-config-tls-enable;listener-config-tls-id-anon", indent=0]
 ----
+
+. Ensure TLS is used.
+This is the default setting. @/config.disableTLS/
+. Authenticate using an anonymous self-signed certificate.
+This is the default setting. @/config.tlsIdentity/
 --
 
 {cpp}::
@@ -468,18 +473,12 @@ include::c:example$code_snippets/main.cpp[tags="listener-config-tls-enable;liste
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-config-tls-enable;listener-config-tls-id-anon", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-config-tls-enable;listener-config-tls-id-anon", indent=0]
 ----
 --
 =====
 
 ====
-
-
-. Ensure TLS is used.
-This is the default setting. @/config.disableTLS/
-. Authenticate using an anonymous self-signed certificate.
-This is the default setting. @/config.tlsIdentity/
 
 .Use External Key Callbacks
 [#ex-external-key-callbacks]
@@ -580,7 +579,7 @@ include::c:example$code_snippets/main.cpp[tags="listener-config-client-auth-pwd"
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-config-client-auth-pwd", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-config-client-auth-pwd", indent=0]
 ----
 --
 =====
@@ -624,6 +623,12 @@ C::
 ----
 include::c:example$code_snippets/main.cpp[tags="listener-config-client-auth-root", indent=0]
 ----
+
+. Get the identity data to authenticate against.
+This can be, for example, from a resource file provided with the app, or an identity previously saved in secure storage. @/CBLCert_CreateWithData/
+. Configure the authenticator to authenticate the client supplied certificate(s) using these root certs.
+A valid client will provide one or more certificates that match a certificate in this list. @/CBLListenerAuth_CreateCertificateWithRootCerts/
+. Add the authenticator to the Listener configuration. @/config.authenticator/
 --
 
 {cpp}::
@@ -631,18 +636,12 @@ include::c:example$code_snippets/main.cpp[tags="listener-config-client-auth-root
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-config-client-auth-root", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-config-client-auth-root", indent=0]
 ----
 --
 =====
 
 ====
-
-. Get the identity data to authenticate against.
-This can be, for example, from a resource file provided with the app, or an identity previously saved in secure storage. @/CBLCert_CreateWithData/
-. Configure the authenticator to authenticate the client supplied certificate(s) using these root certs.
-A valid client will provide one or more certificates that match a certificate in this list. @/CBLListenerAuth_CreateCertificateWithRootCerts/
-. Add the authenticator to the Listener configuration. @/config.authenticator/
 
 
 .Application Logic
@@ -660,17 +659,6 @@ C::
 ----
 include::c:example$code_snippets/main.cpp[tags="listener-config-client-auth-lambda", indent=0]
 ----
---
-
-{cpp}::
-+
---
-[source, cpp]
-----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-config-client-auth-lambda", indent=0]
-----
---
-=====
 
 ////
 <.>  Get the identity data to authenticate against.
@@ -680,6 +668,17 @@ This can be, for example, from a resource file provided with the app, or an iden
 This code assumes complete responsibility for authenticating the client supplied certificate(s).
 It must return a boolean value; with `true` denoting the client supplied certificate authentic. @/authenticateClientCert/
 . Add the authenticator to the Listener configuration. @/config.authenticator/
+--
+
+{cpp}::
++
+--
+[source, cpp]
+----
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-config-client-auth-lambda", indent=0]
+----
+--
+=====
 
 ====
 
@@ -710,7 +709,7 @@ include::c:example$code_snippets/main.cpp[tags="p2psync-act-tlsid-delete", inden
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="p2psync-act-tlsid-delete", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="p2psync-act-tlsid-delete", indent=0]
 ----
 --
 =====
@@ -779,7 +778,7 @@ include::c:example$code_snippets/main.cpp[tags="listener-start", indent=0]
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-start", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-start", indent=0]
 ----
 --
 =====
@@ -816,7 +815,7 @@ include::c:example$code_snippets/main.cpp[tags="listener-status-check", indent=0
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-status-check", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-status-check", indent=0]
 ----
 --
 =====
@@ -851,7 +850,7 @@ include::c:example$code_snippets/main.cpp[tags="listener-stop", indent=0]
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-stop", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-stop", indent=0]
 ----
 --
 =====

--- a/modules/c/pages/p2psync-websocket.adoc
+++ b/modules/c/pages/p2psync-websocket.adoc
@@ -148,6 +148,11 @@ C::
 ----
 include::c:example$code_snippets/main.cpp[tags="listener-simple", indent=0]
 ----
+
+. Initialize the Listener configuration @/CBLURLEndpointListenerConfiguration config/
+. Configure the client authenticator to require basic authentication @/config.authenticator/
+. Initialize the Listener @/CBLURLEndpointListener_Create/
+. Start the Listener @/CBLURLEndpointListener_Start/
 --
 
 {cpp}::
@@ -155,17 +160,12 @@ include::c:example$code_snippets/main.cpp[tags="listener-simple", indent=0]
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="listener-simple", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="listener-simple", indent=0]
 ----
 --
 =====
 
 ====
-
-. Initialize the Listener configuration @/CBLURLEndpointListenerConfiguration config/
-. Configure the client authenticator to require basic authentication @/config.authenticator/
-. Initialize the Listener @/CBLURLEndpointListener_Create/
-. Start the Listener @/CBLURLEndpointListener_Start/
 
 
 .Simple Replicator
@@ -180,6 +180,14 @@ C::
 ----
 include::c:example$code_snippets/main.cpp[tags="replicator-simple", indent=0]
 ----
+
+. Get the Listener's' endpoint.
+Here we use a known URL, but it could be a URL established dynamically in a discovery phase. @/replConfig.endpoint/
+. Initialize the replicator configuration with the database to be synchronized and the Listener it is to synchronize with. @/replConfig.collections/
+. Configure the replicator to expect a self-signed certificate from the Listener. @/replConfig.acceptOnlySelfSignedServerCertificate/
+. Configure the replicator to present basic authentication credentials if the Listener prompts for them -- client authentication is optional. @/replConfig.authenticator/
+. Initialize the replicator @/CBLReplicator_Create/
+. Start the replicator @/CBLReplicator_Start/
 --
 
 C++::
@@ -192,14 +200,6 @@ include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags=replicator-simple,indent=0
 --
 =====
 ====
-
-. Get the Listener's' endpoint.
-Here we use a known URL, but it could be a URL established dynamically in a discovery phase. @/replConfig.endpoint/
-. Initialize the replicator configuration with the database to be synchronized and the Listener it is to synchronize with. @/replConfig.collections/
-. Configure the replicator to expect a self-signed certificate from the Listener. @/replConfig.acceptOnlySelfSignedServerCertificate/
-. Configure the replicator to present basic authentication credentials if the Listener prompts for them -- client authentication is optional. @/replConfig.authenticator/
-. Initialize the replicator @/CBLReplicator_Create/
-. Start the replicator @/CBLReplicator_Start/
 
 
 [#api-highlights]


### PR DESCRIPTION
Noticed we had some build errors with "Phrase not found", that were related to our use of @RayOffiah's plugin for external callouts.

Using Claude, it identified that this was introduced by the refactor to tabs. I've verified that the errors seem to go away, and some callouts now display.

Here's Claude's summary (includes a few suggestions for ongoing fixes):

> Callout-list relocation (fixes "Phrase not found") — moved 6 @/.../ callout lists from after the [tabs] block back to inside the C tab (immediately after the C include::, before that tab closes), so asciidoctor-external-callout binds to the correct C listing instead of the trailing C++ one:
> - p2psync-websocket.adoc: listener-simple and replicator-simple blocks
> - p2psync-websocket-using-passive.adoc: listener-initialize, listener-config-tls-enable;...tls-id-anon, listener-config-client-auth-root, listener-config-client-auth-lambda blocks
> 
> (p2psync-websocket-using-active.adoc needed no relocation — its one @/.../ list sits on a plain literal code block, not a tabbed one.)
> 
> Wrong include path: fixed code_snippets/cbl_cpp.cpp → code_snippets_cpp/cbl_cpp.cpp everywhere across
> all three pages (19 occurrences total: 1 in websocket.adoc, 6 in active, 13 in passive).
> 
> Heads up, unresolved: fixing the path doesn't make the Passive Peer page's C++ tabs actually work — code_snippets_cpp/cbl_cpp.cpp has zero listener-* tags. The C++ (cbl:: API) example code for the Listener/server side hasn't been written yet, so every {cpp}/C++ tab in p2psync-websocket-using-passive.adoc (and the listener-simple C++ tab in p2psync-websocket.adoc) will still fail to resolve — just with an Antora "tag not found" error instead of "file not found." That's a content gap for whoever owns the C++ snippets, not a doc-syntax fix. Worth a ticket if there isn't one already (the client-auth-root block even had a comment referencing a prior cleanup ticket for the same file, so there's precedent for tracking it that way).
> 
> Also noticed while sweeping: conflict.adoc, query-resultsets.adoc, query-live.adoc, and query-n1ql-mobile.adoc have the same wrong code_snippets/cbl_cpp.cpp path — outside the three pages you asked about, so I left those alone, but flagging in case they're on your list too.